### PR TITLE
GH-25 only ask to save document if changes were user initiated. 

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -815,7 +815,7 @@ public class Page extends Dictionary {
      * @return reference to annotation that was added.
      */
     @SuppressWarnings("unchecked")
-    public Annotation addAnnotation(Annotation newAnnotation) {
+    public Annotation addAnnotation(Annotation newAnnotation, boolean isNew) {
 
         // make sure the page annotations have been initialized.
         if (annotations == null) {
@@ -839,20 +839,18 @@ public class Page extends Dictionary {
             // update annots dictionary with new annotations reference,
             annotations.add(newAnnotation.getPObjectReference());
             // add the page as state change
-            stateManager.addChange(
-                    new PObject(this, this.getPObjectReference()));
+            stateManager.addChange(new PObject(this, this.getPObjectReference()), isNew);
         } else if (isAnnotAReference && annotations != null) {
             // get annots array from page
             // update annots dictionary with new annotations reference,
             annotations.add(newAnnotation.getPObjectReference());
             // add the annotations reference dictionary as state has changed
             stateManager.addChange(
-                    new PObject(annotations, library.getObjectReference(
-                            entries, ANNOTS_KEY)));
+                    new PObject(annotations, library.getObjectReference(entries, ANNOTS_KEY)), isNew);
         }
         // we need to add the a new annots reference
         else {
-            List<Reference> annotsVector = new ArrayList(4);
+            List<Reference> annotsVector = new ArrayList<>(4);
             annotsVector.add(newAnnotation.getPObjectReference());
 
             // create a new Dictionary of annotations using an external reference
@@ -866,8 +864,8 @@ public class Page extends Dictionary {
 
             // add the page and the new dictionary to the state change
             stateManager.addChange(
-                    new PObject(this, this.getPObjectReference()));
-            stateManager.addChange(annotsPObject);
+                    new PObject(this, this.getPObjectReference()), isNew);
+            stateManager.addChange(annotsPObject, isNew);
 
             this.annotations = new ArrayList<>();
         }
@@ -883,7 +881,7 @@ public class Page extends Dictionary {
         library.addObject(newAnnotation, newAnnotation.getPObjectReference());
 
         // finally add the new annotations to the state manager
-        stateManager.addChange(new PObject(newAnnotation, newAnnotation.getPObjectReference()));
+        stateManager.addChange(new PObject(newAnnotation, newAnnotation.getPObjectReference()), isNew);
 
         // return to caller for further manipulations.
         return newAnnotation;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -812,6 +812,8 @@ public class Page extends Dictionary {
      * the method @link{#createAnnotation} for creating new annotations.
      *
      * @param newAnnotation annotation object to add
+     * @param isNew annotation is new and should be added to stateManager, otherwise change will be part of the document
+     *              but not yet added to the stateManager as the change was likely a missing content stream or popup.
      * @return reference to annotation that was added.
      */
     @SuppressWarnings("unchecked")

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/StateManager.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/StateManager.java
@@ -80,7 +80,18 @@ public class StateManager {
      * @param pObject object to add to cache.
      */
     public void addChange(PObject pObject) {
-        changes.put(pObject.getReference(), pObject);
+        addChange(pObject, true);
+    }
+
+    /**
+     * Add a new PObject containing changed data to the cache.
+     *
+     * @param pObject object to add to cache.
+     * @param isNew   new indicates a new object that should be saved when isChanged() is called.  If false the object
+     *                was added but because the object wasn't present for rendering and was created by the core library.
+     */
+    public void addChange(PObject pObject, boolean isNew) {
+        changes.put(pObject.getReference(), new Change(pObject, isNew));
         int objectNumber = pObject.getReference().getObjectNumber();
         // check the reference numbers
         synchronized (this) {
@@ -121,10 +132,25 @@ public class StateManager {
     }
 
     /**
-     * @return If there are any changes
+     * @return If there are any changes from objects that were manipulated by user interaction
      */
-    public boolean isChanged() {
-        return !changes.isEmpty();
+    public boolean isChange() {
+        Collection<Change> changeValues = changes.values();
+        Change[] changeArray = changeValues.toArray(new Change[0]);
+        for (Change change : changeArray) {
+            if (change.isNew) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return If there are any changes that end up in the state manager form user interactions or annotations
+     * needing to create missing content streams or popups.
+     */
+    public boolean isNoChange() {
+        return changes.isEmpty();
     }
 
     /**
@@ -139,22 +165,11 @@ public class StateManager {
     /**
      * @return An Iterator&lt;PObject&gt; for all the changes objects, sorted
      */
-    public Iterator<PObject> iteratorSortedByObjectNumber() {
-        Collection<PObject> coll = changes.values();
-/*
- * This code allows me to force an object to be treated as modified,
- * so I can debug how we write out that kind of object, before we
- * add a ui to actually edit it.
-Reference ref = new Reference(10,0);
-Object ob = trailer.getLibrary().getObject(ref);
-logger.severe("Object 10: " + ob + "  ob.class: " + ob.getClass().getName());
-java.util.HashSet<PObject> hs = new java.util.HashSet<PObject>(coll);
-hs.add(new PObject(ob, ref));
-coll = hs;
-*/
-        PObject[] arr = coll.toArray(new PObject[coll.size()]);
+    public Iterator<Change> iteratorSortedByObjectNumber() {
+        Collection<Change> coll = changes.values();
+        Change[] arr = coll.toArray(new Change[0]);
         Arrays.sort(arr, new PObjectComparatorByReferenceObjectNumber());
-        List<PObject> sortedList = Arrays.asList(arr);
+        List<Change> sortedList = Arrays.asList(arr);
         return sortedList.iterator();
     }
 
@@ -164,16 +179,16 @@ coll = hs;
 
 
     private static class PObjectComparatorByReferenceObjectNumber
-            implements Comparator<PObject> {
-        public int compare(PObject a, PObject b) {
+            implements Comparator<Change> {
+        public int compare(Change a, Change b) {
             if (a == null && b == null)
                 return 0;
             else if (a == null)
                 return -1;
             else if (b == null)
                 return 1;
-            Reference ar = a.getReference();
-            Reference br = b.getReference();
+            Reference ar = a.pObject.getReference();
+            Reference br = b.pObject.getReference();
             if (ar == null && br == null)
                 return 0;
             else if (ar == null)
@@ -187,6 +202,24 @@ coll = hs;
             else if (aron > bron)
                 return 1;
             return 0;
+        }
+    }
+
+    /**
+     * Wrapper class of a pObject and how it was created.  The newFlag differentiates if the object was created
+     * by a user action vs the core library creating an object that isn't in the source file but needed for rendering.
+     */
+    public class Change {
+        protected PObject pObject;
+        protected boolean isNew;
+
+        public Change(PObject pObject, boolean isNew) {
+            this.pObject = pObject;
+            this.isNew = isNew;
+        }
+
+        public PObject getPObject() {
+            return pObject;
         }
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/StateManager.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/StateManager.java
@@ -35,7 +35,7 @@ public class StateManager {
             Logger.getLogger(StateManager.class.getName());
 
     // a list is all we might need. 
-    private final HashMap<Reference, PObject> changes;
+    private final HashMap<Reference, Change> changes;
 
     // access to xref size and next revision number.
     private final PTrailer trailer;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AbstractWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AbstractWidgetAnnotation.java
@@ -110,7 +110,7 @@ public abstract class AbstractWidgetAnnotation<T extends FieldDictionary> extend
         // check to make sure the field value matches the content stream.
         InteractiveForm interactiveForm = library.getCatalog().getInteractiveForm();
         if (interactiveForm != null && interactiveForm.needAppearances()) {
-            resetAppearanceStream(new AffineTransform());
+            resetAppearanceStream(new AffineTransform(), false);
         }
         // todo check if we have content value but no appearance stream.
     }
@@ -118,7 +118,7 @@ public abstract class AbstractWidgetAnnotation<T extends FieldDictionary> extend
     public abstract void reset();
 
     @Override
-    public abstract void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace);
+    public abstract void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew);
 
     @Override
     protected void renderAppearanceStream(Graphics2D g) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AbstractWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AbstractWidgetAnnotation.java
@@ -110,7 +110,7 @@ public abstract class AbstractWidgetAnnotation<T extends FieldDictionary> extend
         // check to make sure the field value matches the content stream.
         InteractiveForm interactiveForm = library.getCatalog().getInteractiveForm();
         if (interactiveForm != null && interactiveForm.needAppearances()) {
-            resetAppearanceStream(new AffineTransform(), false);
+            resetAppearanceStream(new AffineTransform());
         }
         // todo check if we have content value but no appearance stream.
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
@@ -884,7 +884,7 @@ public abstract class Annotation extends Dictionary {
             if (rectangle != null) {
                 setBBox(rectangle.getBounds());
             }
-            resetAppearanceStream(new AffineTransform(), false);
+            resetAppearanceStream(new AffineTransform());
         }
     }
 
@@ -1979,7 +1979,16 @@ public abstract class Annotation extends Dictionary {
                 (float) tBbox.getWidth(), (float) tBbox.getHeight()));
     }
 
+    /**
+     * Reset the appearance stream given the specified location and page space transform.
+     * @param dx coord-x
+     * @param dy coord-y
+     * @param pageSpace page space transform
+     * @param isNew marks the reset as happening because of a
+     */
     public abstract void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew);
+
+//    public abstract void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace);
 
     public void resetAppearanceStream(AffineTransform pageSpace, boolean isNew) {
         resetAppearanceStream(0, 0, pageSpace, isNew);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
@@ -884,7 +884,7 @@ public abstract class Annotation extends Dictionary {
             if (rectangle != null) {
                 setBBox(rectangle.getBounds());
             }
-            resetAppearanceStream(new AffineTransform());
+            resetAppearanceStream(new AffineTransform(), false);
         }
     }
 
@@ -1853,7 +1853,8 @@ public abstract class Annotation extends Dictionary {
      * @param rawBytes raw bytes of string data making up the content stream.
      * @return new Form object with updated appearance stream.
      */
-    public Form updateAppearanceStream(Shapes shapes, Rectangle2D bbox, AffineTransform matrix, byte[] rawBytes) {
+    public Form updateAppearanceStream(Shapes shapes, Rectangle2D bbox, AffineTransform matrix, byte[] rawBytes,
+                                       boolean isNew) {
         // update the appearance stream
         // create/update the appearance stream of the xObject.
         StateManager stateManager = library.getStateManager();
@@ -1978,10 +1979,14 @@ public abstract class Annotation extends Dictionary {
                 (float) tBbox.getWidth(), (float) tBbox.getHeight()));
     }
 
-    public abstract void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace);
+    public abstract void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew);
+
+    public void resetAppearanceStream(AffineTransform pageSpace, boolean isNew) {
+        resetAppearanceStream(0, 0, pageSpace, isNew);
+    }
 
     public void resetAppearanceStream(AffineTransform pageSpace) {
-        resetAppearanceStream(0, 0, pageSpace);
+        resetAppearanceStream(0, 0, pageSpace, false);
     }
 
     public Shapes getShapes() {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/ButtonWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/ButtonWidgetAnnotation.java
@@ -53,11 +53,12 @@ public class ButtonWidgetAnnotation extends AbstractWidgetAnnotation<ButtonField
     /**
      * Button appearance streams are fixed, all that is done in this method is appearance selected state
      * is set and the change persisted to the StateManager.
-     * @param dx current location of the annotation
-     * @param dy current location of the annotation
+     *
+     * @param dx        current location of the annotation
+     * @param dy        current location of the annotation
      * @param pageSpace current page space.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew) {
         // update the appearanceState in the state manager so the change will persist.
         Appearance appearance = appearances.get(currentAppearance);
         if (appearance != null) {
@@ -80,7 +81,7 @@ public class ButtonWidgetAnnotation extends AbstractWidgetAnnotation<ButtonField
             //getFieldDictionary().getParent().getEntries().put(FieldDictionary.V_KEY, selectedName);
             // add to state manager.
             stateManager.addChange(new PObject(getFieldDictionary().getParent(),
-                    getFieldDictionary().getParent().getPObjectReference()));
+                    getFieldDictionary().getParent().getPObjectReference()), isNew);
         }
 
         if (originalAppearance == null){

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/ChoiceWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/ChoiceWidgetAnnotation.java
@@ -81,7 +81,7 @@ public class ChoiceWidgetAnnotation extends AbstractWidgetAnnotation<ChoiceField
      * @param dy            y offset of the annotation
      * @param pageTransform current page transform.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
         ChoiceFieldType choiceFieldType =
                 fieldDictionary.getChoiceFieldType();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/CircleAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/CircleAnnotation.java
@@ -139,7 +139,7 @@ public class CircleAnnotation extends MarkupAnnotation {
     /**
      * Resets the annotations appearance stream.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
         // grab the current appearance stream as we'll be updating the shapes.
         Appearance appearance = appearances.get(currentAppearance);
         AppearanceState appearanceState = appearance.getSelectedAppearanceState();
@@ -200,7 +200,7 @@ public class CircleAnnotation extends MarkupAnnotation {
         // update the appearance stream
         // create/update the appearance stream of the xObject.
         Form form = updateAppearanceStream(shapes, bbox, matrix,
-                PostScriptEncoder.generatePostScript(shapes.getShapes()));
+                PostScriptEncoder.generatePostScript(shapes.getShapes()), isNew);
         generateExternalGraphicsState(form, opacity);
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
@@ -398,7 +398,7 @@ public class FreeTextAnnotation extends MarkupAnnotation {
     }
 
     @Override
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
 
         Appearance appearance = appearances.get(currentAppearance);
         AppearanceState appearanceState = appearance.getSelectedAppearanceState();
@@ -532,7 +532,7 @@ public class FreeTextAnnotation extends MarkupAnnotation {
         // create/update the appearance stream of the xObject.
         StateManager stateManager = library.getStateManager();
         Form form = updateAppearanceStream(shapes, bbox, matrix,
-                PostScriptEncoder.generatePostScript(shapes.getShapes()));
+                PostScriptEncoder.generatePostScript(shapes.getShapes()), isNew);
         generateExternalGraphicsState(form, opacity);
 
         if (form != null) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/GenericAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/GenericAnnotation.java
@@ -39,7 +39,7 @@ public class GenericAnnotation extends Annotation {
     }
 
     @Override
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
 
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/InkAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/InkAnnotation.java
@@ -90,7 +90,7 @@ public class InkAnnotation extends MarkupAnnotation {
             if (rectangle != null) {
                 setBBox(rectangle.getBounds());
             }
-            resetAppearanceStream(new AffineTransform());
+            resetAppearanceStream(new AffineTransform(), false);
         }
 
         // try and generate an appearance stream.
@@ -178,7 +178,7 @@ public class InkAnnotation extends MarkupAnnotation {
     /**
      * Resets the annotations appearance stream.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew) {
 
         // setup clean shapes
         Appearance appearance = appearances.get(currentAppearance);
@@ -234,7 +234,7 @@ public class InkAnnotation extends MarkupAnnotation {
 
         // mark the change.
         StateManager stateManager = library.getStateManager();
-        stateManager.addChange(new PObject(this, this.getPObjectReference()));
+        stateManager.addChange(new PObject(this, this.getPObjectReference()), isNew);
 
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/InkAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/InkAnnotation.java
@@ -90,7 +90,7 @@ public class InkAnnotation extends MarkupAnnotation {
             if (rectangle != null) {
                 setBBox(rectangle.getBounds());
             }
-            resetAppearanceStream(new AffineTransform(), false);
+            resetAppearanceStream(new AffineTransform());
         }
 
         // try and generate an appearance stream.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LineAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LineAnnotation.java
@@ -539,7 +539,7 @@ public class LineAnnotation extends MarkupAnnotation {
             if (rectangle != null) {
                 setBBox(rectangle.getBounds());
             }
-            resetAppearanceStream(new AffineTransform());
+            resetAppearanceStream(new AffineTransform(), false);
         }
         // try and generate an appearance stream.
         resetNullAppearanceStream();
@@ -548,7 +548,7 @@ public class LineAnnotation extends MarkupAnnotation {
     /**
      * Resets the annotations appearance stream.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
 
         // nothing to reset,  creating new annotation.
         if (startOfLine == null || endOfLine == null) {
@@ -648,7 +648,7 @@ public class LineAnnotation extends MarkupAnnotation {
 
         // mark the change.
         StateManager stateManager = library.getStateManager();
-        stateManager.addChange(new PObject(this, this.getPObjectReference()));
+        stateManager.addChange(new PObject(this, this.getPObjectReference()), isNew);
     }
 
     public Point2D getStartOfLine() {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LineAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LineAnnotation.java
@@ -539,7 +539,7 @@ public class LineAnnotation extends MarkupAnnotation {
             if (rectangle != null) {
                 setBBox(rectangle.getBounds());
             }
-            resetAppearanceStream(new AffineTransform(), false);
+            resetAppearanceStream(new AffineTransform());
         }
         // try and generate an appearance stream.
         resetNullAppearanceStream();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LinkAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LinkAnnotation.java
@@ -210,7 +210,7 @@ public class LinkAnnotation extends Annotation {
     }
 
     @Override
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
 
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PolyAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PolyAnnotation.java
@@ -88,7 +88,7 @@ public class PolyAnnotation extends MarkupAnnotation {
     }
 
     @Override
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew) {
 
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PopupAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PopupAnnotation.java
@@ -120,7 +120,7 @@ public class PopupAnnotation extends Annotation {
     }
 
     @Override
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
 
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SignatureWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SignatureWidgetAnnotation.java
@@ -73,7 +73,7 @@ public class SignatureWidgetAnnotation extends AbstractWidgetAnnotation<Signatur
     }
 
     @Override
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew) {
 
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SquareAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SquareAnnotation.java
@@ -137,7 +137,7 @@ public class SquareAnnotation extends MarkupAnnotation {
     /**
      * Resets the annotations appearance stream.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
         // grab the current appearance stream as we'll be updating the shapes.
         Appearance appearance = appearances.get(currentAppearance);
         AppearanceState appearanceState = appearance.getSelectedAppearanceState();
@@ -188,7 +188,7 @@ public class SquareAnnotation extends MarkupAnnotation {
         // update the appearance stream
         // create/update the appearance stream of the xObject.
         Form form = updateAppearanceStream(shapes, bbox, matrix,
-                PostScriptEncoder.generatePostScript(shapes.getShapes()));
+                PostScriptEncoder.generatePostScript(shapes.getShapes()), isNew);
         generateExternalGraphicsState(form, opacity);
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextAnnotation.java
@@ -203,7 +203,7 @@ public class TextAnnotation extends MarkupAnnotation {
     /**
      * Resets the annotations appearance stream.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
         // setup the context
         Appearance appearance = appearances.get(currentAppearance);
         AppearanceState appearanceState = appearance.getSelectedAppearanceState();
@@ -271,7 +271,7 @@ public class TextAnnotation extends MarkupAnnotation {
         MessageFormat formatter = new MessageFormat(iconContentString);
         iconContentString = formatter.format(colorArgument);
 
-        Form form = updateAppearanceStream(null, bbox, matrix, null);
+        Form form = updateAppearanceStream(null, bbox, matrix, null, isNew);
         generateExternalGraphicsState(form, opacity);
         // parse the shapes and assign to this instance
         try {
@@ -285,7 +285,7 @@ public class TextAnnotation extends MarkupAnnotation {
 
         // update the appearance stream
         // create/update the appearance stream of the xObject.
-        form = updateAppearanceStream(shapes, bbox, matrix, iconContentString.getBytes());
+        form = updateAppearanceStream(shapes, bbox, matrix, iconContentString.getBytes(), isNew);
 //        generateExternalGraphicsState(form, opacity);
         if (form != null) {
             appearanceState.setShapes(shapes);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextMarkupAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextMarkupAnnotation.java
@@ -246,7 +246,7 @@ public class TextMarkupAnnotation extends MarkupAnnotation {
     /**
      * Resets the annotations appearance stream.
      */
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
 
         // check if we have anything to reset.
         if (markupBounds == null) {
@@ -330,7 +330,7 @@ public class TextMarkupAnnotation extends MarkupAnnotation {
         // update the appearance stream
         // create/update the appearance stream of the xObject.
         Form form = updateAppearanceStream(shapes, bbox, matrix,
-                PostScriptEncoder.generatePostScript(shapes.getShapes()));
+                PostScriptEncoder.generatePostScript(shapes.getShapes()), isNew);
         generateExternalGraphicsState(form, opacity);
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextWidgetAnnotation.java
@@ -56,7 +56,7 @@ public class TextWidgetAnnotation extends AbstractWidgetAnnotation<TextFieldDict
         }
     }
 
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageTransform, boolean isNew) {
 
         // we won't touch password fields, we'll used the original display
         TextFieldDictionary.TextFieldType textFieldType = fieldDictionary.getTextFieldType();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/WidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/WidgetAnnotation.java
@@ -43,7 +43,7 @@ public class WidgetAnnotation extends AbstractWidgetAnnotation {
         fieldDictionary = new FieldDictionary(library, entries);
     }
 
-    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace) {
+    public void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew) {
 
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/IncrementalUpdater.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/IncrementalUpdater.java
@@ -30,7 +30,7 @@ public class IncrementalUpdater {
         StateManager stateManager = document.getStateManager();
         PTrailer trailer = stateManager.getTrailer();
 
-        if (!stateManager.isChanged()) {
+        if (stateManager.isNoChange()) {
             return 0L;
         }
 
@@ -40,9 +40,9 @@ public class IncrementalUpdater {
         BaseWriter writer = new BaseWriter(trailer, securityManager, output, documentLength);
         writer.initializeWriters();
         writer.writeNewLine();
-        Iterator<PObject> changes = stateManager.iteratorSortedByObjectNumber();
+        Iterator<StateManager.Change> changes = stateManager.iteratorSortedByObjectNumber();
         while (changes.hasNext()) {
-            PObject pobject = changes.next();
+            PObject pobject = changes.next().getPObject();
             writer.writePObject(pobject);
         }
 

--- a/examples/annotation/creation/src/main/java/org/icepdf/os/examples/annotation/creation/NewAnnotationPrePageLoad.java
+++ b/examples/annotation/creation/src/main/java/org/icepdf/os/examples/annotation/creation/NewAnnotationPrePageLoad.java
@@ -161,7 +161,7 @@ public class NewAnnotationPrePageLoad {
                                 // add the action to the annotation
                                 linkAnnotation.addAction(action);
                                 // add it to the page.
-                                page.addAnnotation(linkAnnotation);
+                                page.addAnnotation(linkAnnotation, true);
                             }
                         }
                         // removed the search highlighting

--- a/logging.properties
+++ b/logging.properties
@@ -21,11 +21,11 @@ java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
 # Set the default logging level for the root logger
 #.level = OFF
 #.level = ALL
-.level=FINER
-#.level = INFO
+#.level=FINER
+.level=INFO
 # Set the default logging level for new ConsoleHandler instances
-java.util.logging.ConsoleHandler.level=FINER
-#java.util.logging.ConsoleHandler.level = INFO
+#java.util.logging.ConsoleHandler.level=FINER
+java.util.logging.ConsoleHandler.level=INFO
 # Set the default logging level for new FileHandler instances
 java.util.logging.FileHandler.level=OFF
 org.icepdf.core.util.parser.content.level=INFO

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/MyAnnotationCallback.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/MyAnnotationCallback.java
@@ -181,7 +181,7 @@ public class MyAnnotationCallback implements AnnotationCallback {
         Document document = documentViewController.getDocument();
         PageTree pageTree = document.getPageTree();
         Page page = pageTree.getPage(pageComponent.getPageIndex());
-        page.addAnnotation(annotationComponent.getAnnotation());
+        page.addAnnotation(annotationComponent.getAnnotation(), !annotationComponent.isSynthetic());
 
         // no we have let the pageComponent now about it.
         ((PageViewComponentImpl) pageComponent).addAnnotation(annotationComponent);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
@@ -3491,7 +3491,7 @@ public class SwingController extends ComponentAdapter
                                 fileOutputStream, 4096 * 2);
 
                         // We want 'save as' or 'save a copy to always occur
-                        if (!document.getStateManager().isChanged()) {
+                        if (document.getStateManager().isNoChange()) {
                             // save as copy
                             document.writeToOutputStream(buf);
                         } else {
@@ -3619,7 +3619,7 @@ public class SwingController extends ComponentAdapter
         // check if document changes have been made, if so ask the user if they
         // want to save the changes.
         if (document != null) {
-            boolean documentChanges = document.getStateManager().isChanged();
+            boolean documentChanges = document.getStateManager().isChange();
             if (documentChanges) {
 
                 MessageFormat formatter = new MessageFormat(

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextAnnotationHandler.java
@@ -156,7 +156,8 @@ public class TextAnnotationHandler extends CommonToolHandler implements ToolHand
 
     public static PopupAnnotation createPopupAnnotation(Library library, Rectangle bbox,
                                                         MarkupAnnotation parent,
-                                                        AffineTransform pageSpace) {
+                                                        AffineTransform pageSpace,
+                                                        boolean isNew) {
         // text annotation are special as the annotation has fixed size.
         PopupAnnotation popupAnnotation = (PopupAnnotation)
                 AnnotationFactory.buildAnnotation(
@@ -165,15 +166,14 @@ public class TextAnnotationHandler extends CommonToolHandler implements ToolHand
                         bbox);
         // save the annotation
         StateManager stateManager = library.getStateManager();
-        stateManager.addChange(new PObject(popupAnnotation,
-                popupAnnotation.getPObjectReference()));
+        stateManager.addChange(new PObject(popupAnnotation, popupAnnotation.getPObjectReference()), isNew);
         library.addObject(popupAnnotation, popupAnnotation.getPObjectReference());
 
         // setup up some default values
         popupAnnotation.setOpen(true);
         popupAnnotation.setParent(parent);
         parent.setPopupAnnotation(popupAnnotation);
-        popupAnnotation.resetAppearanceStream(0, 0, pageSpace);
+        popupAnnotation.resetAppearanceStream(0, 0, pageSpace, isNew);
         return popupAnnotation;
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AnnotationComponent.java
@@ -141,4 +141,8 @@ public interface AnnotationComponent {
      */
     void dispose();
 
+    boolean isSynthetic();
+
+    void setSynthetic(boolean synthetic);
+
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
@@ -1331,6 +1331,7 @@ public class DocumentViewControllerImpl
 
     public void updateAnnotation(AnnotationComponent annotationComponent) {
         if (documentViewModel != null && annotationComponent != null) {
+            annotationComponent.setSynthetic(false);
             if (annotationCallback != null) {
                 annotationCallback.updateAnnotation(annotationComponent);
             }
@@ -1345,6 +1346,7 @@ public class DocumentViewControllerImpl
 
     public void updatedSummaryAnnotation(AnnotationComponent annotationComponent) {
         if (documentViewModel != null && annotationComponent != null) {
+            annotationComponent.setSynthetic(false);
             if (annotationCallback != null) {
                 annotationCallback.updateAnnotation(annotationComponent);
             }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
@@ -1331,6 +1331,7 @@ public class DocumentViewControllerImpl
 
     public void updateAnnotation(AnnotationComponent annotationComponent) {
         if (documentViewModel != null && annotationComponent != null) {
+            // user initiated change, make sure to store the change
             annotationComponent.setSynthetic(false);
             if (annotationCallback != null) {
                 annotationCallback.updateAnnotation(annotationComponent);
@@ -1346,6 +1347,7 @@ public class DocumentViewControllerImpl
 
     public void updatedSummaryAnnotation(AnnotationComponent annotationComponent) {
         if (documentViewModel != null && annotationComponent != null) {
+            // user initiated change, make sure to store the change
             annotationComponent.setSynthetic(false);
             if (annotationCallback != null) {
                 annotationCallback.updateAnnotation(annotationComponent);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AbstractAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AbstractAnnotationComponent.java
@@ -93,6 +93,9 @@ public abstract class AbstractAnnotationComponent<T extends Annotation> extends 
         }
     }
 
+    // created for rendering only, not created by the user,  set when state manager shouldn't record the change
+    protected boolean isSynthetic;
+
     public static final int resizeBoxSize = 4;
 
     // reusable border
@@ -585,7 +588,7 @@ public abstract class AbstractAnnotationComponent<T extends Annotation> extends 
                 dy = endOfMousePress.getY() - startOfMousePress.getY();
             }
 
-            annotation.resetAppearanceStream(dx, -dy, getToPageSpaceTransform());
+            annotation.resetAppearanceStream(dx, -dy, getToPageSpaceTransform(), true);
 
             // fire new bounds change event, let the listener handle
             // how to deal with the bound change.
@@ -708,5 +711,13 @@ public abstract class AbstractAnnotationComponent<T extends Annotation> extends 
 
     public boolean isShowInvisibleBorder() {
         return isShowInvisibleBorder;
+    }
+
+    public boolean isSynthetic() {
+        return isSynthetic;
+    }
+
+    public void setSynthetic(boolean synthetic) {
+        isSynthetic = synthetic;
     }
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AnnotationState.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AnnotationState.java
@@ -120,7 +120,7 @@ public class AnnotationState implements Memento {
             // mark it as not deleted
             annotation.setDeleted(false);
             // re-add it to the page
-            page.addAnnotation(annotation);
+            page.addAnnotation(annotation, true);
             // finally update the pageComponent so we can see it again.
             ((Component) annotationComponent).setVisible(true);
             // refresh bounds for any resizes

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/InkAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/InkAnnotationComponent.java
@@ -49,7 +49,7 @@ public class InkAnnotationComponent extends MarkupAnnotationComponent<InkAnnotat
     public void resetAppearanceShapes() {
         super.resetAppearanceShapes();
         refreshAnnotationRect();
-        annotation.resetAppearanceStream(dx, dy, getToPageSpaceTransform());
+        annotation.resetAppearanceStream(dx, dy, getToPageSpaceTransform(), true);
     }
 
     @Override

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/LineAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/LineAnnotationComponent.java
@@ -62,7 +62,7 @@ public class LineAnnotationComponent extends MarkupAnnotationComponent<LineAnnot
     public void resetAppearanceShapes() {
         super.resetAppearanceShapes();
         refreshAnnotationRect();
-        annotation.resetAppearanceStream(dx, dy, getToPageSpaceTransform());
+        annotation.resetAppearanceStream(dx, dy, getToPageSpaceTransform(), true);
     }
 
     @Override

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationComponent.java
@@ -160,9 +160,10 @@ public abstract class MarkupAnnotationComponent<T extends MarkupAnnotation> exte
         }
         PopupAnnotation popupAnnotation = null;
         if (annotation != null && annotation.getPopupAnnotation() == null) {
+
             popupAnnotation = TextAnnotationHandler.createPopupAnnotation(
                     documentViewController.getDocument().getPageTree().getLibrary(),
-                    tBbox, annotation, getToPageSpaceTransform());
+                    tBbox, annotation, getToPageSpaceTransform(), isNew);
             annotation.setPopupAnnotation(popupAnnotation);
         } else if (annotation != null) {
             popupAnnotation = annotation.getPopupAnnotation();
@@ -177,6 +178,7 @@ public abstract class MarkupAnnotationComponent<T extends MarkupAnnotation> exte
             comp.setBounds(bBox);
             // resets user space rectangle to match bbox converted to page space
             comp.refreshAnnotationRect();
+            comp.setSynthetic(!isNew);
 
             // add them to the container, using absolute positioning.
             documentViewController.addNewAnnotation(comp);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationComponent.java
@@ -178,6 +178,7 @@ public abstract class MarkupAnnotationComponent<T extends MarkupAnnotation> exte
             comp.setBounds(bBox);
             // resets user space rectangle to match bbox converted to page space
             comp.refreshAnnotationRect();
+            // not new, which means the popup wasn't part of the document, we don't want to save it at this time
             comp.setSynthetic(!isNew);
 
             // add them to the container, using absolute positioning.
@@ -228,10 +229,9 @@ public abstract class MarkupAnnotationComponent<T extends MarkupAnnotation> exte
                     popupComponent.setBounds(popupBounds);
                 }
             }
-            // no markupAnnotation so we need to create one and display for
-            // the addition comments.
+            // no markupAnnotation so we need to create one and display for the addition comments.
             else {
-                // convert bbox and start and end line points.
+                // user initiated change, so we'll mark the popup state as changed and queue it for saving.
                 createPopupAnnotationComponent(true);
             }
         }


### PR DESCRIPTION
- still not happy with the api changes but it does work.  
- Users will only get save document prompt if they actually created or changed an annotatoin. 
- Previously missing content streams or popups would be added to stateManager which was confusing the end user. 