### PR TITLE
GH-118 fix errors painting annotations that use BlendComposite effect

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
@@ -1385,12 +1385,27 @@ public abstract class Annotation extends Dictionary {
             g.transform(tAs);
 
             AffineTransform preAf = g.getTransform();
+            boolean paintFailed = false;
             // regular paint
             try {
                 appearanceState.getShapes().paint(g);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.fine("Page Annotation Painting interrupted.");
+            } catch (InternalError e) {
+                logger.info("Java2D has encountered implementation issue, likely on Linux X11. ");
+                logger.info("Try using the system property -Dsun.java2d.opengl=true as a possible solution");
+                logger.info("Falling back to transparency effects instead of composite paint");
+                paintFailed = true;
+            }
+            if (paintFailed) {
+                try {
+                    appearanceState.getShapes().disableBlendComposite();
+                    appearanceState.getShapes().paint(g);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    logger.fine("Page Annotation Painting interrupted.");
+                }
             }
 
             g.setTransform(preAf);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
@@ -50,9 +50,6 @@ import java.awt.image.ColorModel;
 import java.awt.image.DataBuffer;
 import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.logging.Logger;
 
 public final class BlendComposite implements Composite {
@@ -95,44 +92,14 @@ public final class BlendComposite implements Composite {
         LUMINOSITY
     }
 
-    // System property to disable blending modes other then AlphaComposite.  Oracle's MacOS Java implementation is
+    // System property to disable blending modes other than AlphaComposite.  Oracle's MacOS Java implementation is
     // throwing a not implemented exception on JDK 1.8.0_131 when a custom blend composite is set on the graphics
-    // graphics context.
+    // context.
     private static boolean disableBlendComposite;
 
     static {
-        // sets the shadow colour of the decorator.
         disableBlendComposite = Defs.booleanProperty(
                 "org.icepdf.core.paint.disableBlendComposite", false);
-
-        /*
-        Check for XRSurfaceData.XRInternalSurfaceData.getRaster implementation
-        On Linux, the implementation simply returns InternalError
-        We have to preventatively disable it, otherwise it will cause an InternalError when annotations using
-        BlendComposite are rendered
-        */
-        try {
-            final Class xrSurfaceDataClass = Class.forName("sun.java2d.xr.XRSurfaceData$XRInternalSurfaceData");
-            final Constructor constructor = xrSurfaceDataClass.getDeclaredConstructor(Class.forName("sun.java2d.xr.XRBackend"), int.class);
-            final Object xrSurfaceData = constructor.newInstance(null, 0);
-            final Method getRaster = xrSurfaceDataClass.getMethod("getRaster", int.class, int.class, int.class, int.class);
-            getRaster.invoke(xrSurfaceData, 0, 0, 0, 0);
-        } catch (final InvocationTargetException e) {
-            if (e.getCause() instanceof InternalError) {
-                disableBlendComposite = true;
-            }
-            /*
-            If there is another cause, this means that getRaster implementation is not simply "throw
-            new InternalError()", in which case this implementation may perfectly work with real values.
-            */
-        } catch (final InternalError e) {
-            disableBlendComposite = true;
-        } catch (final Exception ignored) {
-            /*
-            If there are other exceptions (NoSuchClass, NoSuchMethod, etc), this probably means that the api changed
-            or that java2d.xr is not available, in which case the blend composite rendering could work perfectly.
-            */
-        }
     }
 
     public static final Name NORMAL_VALUE = new Name("Normal");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
@@ -16,10 +16,7 @@
 package org.icepdf.core.pobjects.graphics;
 
 import org.icepdf.core.pobjects.Page;
-import org.icepdf.core.pobjects.graphics.commands.DrawCmd;
-import org.icepdf.core.pobjects.graphics.commands.FormDrawCmd;
-import org.icepdf.core.pobjects.graphics.commands.ImageDrawCmd;
-import org.icepdf.core.pobjects.graphics.commands.ShapesDrawCmd;
+import org.icepdf.core.pobjects.graphics.commands.*;
 import org.icepdf.core.pobjects.graphics.text.PageText;
 import org.icepdf.core.util.Defs;
 
@@ -119,6 +116,21 @@ public class Shapes {
         this.paintAlpha = paintAlpha;
     }
 
+    /**
+     * Disable BlendComposites for compatibility with x11 windowing system that fail to paint this blending type.
+     * This is generally on done for annotation appearance streams were the numbers of shapes is quite small compared
+     * to a shapes associated with a page.
+     * Work around is to use -Dsun.java2d.opengl=true when available
+     */
+    public void disableBlendComposite() {
+        DrawCmd nextShape;
+        for (DrawCmd shape : shapes) {
+            nextShape = shape;
+            if (nextShape instanceof BlendCompositeDrawCmd) {
+                ((BlendCompositeDrawCmd) nextShape).enableAlphaCompositePaint();
+            }
+        }
+    }
 
     /**
      * Paint the graphics stack to the graphics context
@@ -126,7 +138,7 @@ public class Shapes {
      * @param g graphics context to paint to.
      * @throws InterruptedException thread interrupted.
      */
-    public void paint(Graphics2D g) throws InterruptedException{
+    public void paint(Graphics2D g) throws InterruptedException {
         try {
             interrupted = false;
             AffineTransform base = new AffineTransform(g.getTransform());


### PR DESCRIPTION
The "java.lang.InternalError: not implemented yet" is ultimately related to how we paint annotations on top of the page content in the Viewer RI.  The main page content paints fine with BlendingComposite because we paint all this content to an buffer before painting the buffer the swing/awt canvas.  The trouble starts when we try and paint the annotation content on top of the page content.  The swing/awt canvas doesn't like the blendingComposite and fails to paint with some loud logging and missing annotation content.  

The trick with this PR is that we want to leave page painting unaffected, as BlendingComposites are pretty important part of our current transparency group support.  However BlendingComposites are uses sparingly for annotation and one typically only sees them for highlighting effects in markup annotations.  A similar effect can be achieved by just using a transparency effect.  

So long story short.  If annotation painting runs into trouble we disable BlendingComposite for the annotations draw commands  and fallback to using a transparency effect leaving the page content streams unaffected. 