### PR TITLE
GH-203 check encoding for code name before checking if glyph exists.

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1C.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1C.java
@@ -119,6 +119,12 @@ public class ZFontType1C extends ZSimpleFont {
 
     @Override
     public boolean canDisplay(char ech) {
+        if (cffType1Font.getEncoding() != null) {
+            String name = cffType1Font.getEncoding().getName(ech);
+            if (name != null && !name.equals(".notdef")) {
+                return cffType1Font.hasGlyph(name);
+            }
+        }
         return cffType1Font.hasGlyph(String.valueOf(ech));
     }
 


### PR DESCRIPTION
Fixes issue finding some type1c glyphs in the font file. 