### PR TITLE
GH-206 fixes layout issues when selecting free text annotation fonts

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
@@ -1996,10 +1996,12 @@ public abstract class Annotation extends Dictionary {
 
     /**
      * Reset the appearance stream given the specified location and page space transform.
-     * @param dx coord-x
-     * @param dy coord-y
+     *
+     * @param dx        coord-x
+     * @param dy        coord-y
      * @param pageSpace page space transform
-     * @param isNew marks the reset as happening because of a
+     * @param isNew     marks the reset as happening because of user interaction not created because of a missing content
+     *                  stream.
      */
     public abstract void resetAppearanceStream(double dx, double dy, AffineTransform pageSpace, boolean isNew);
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
@@ -18,6 +18,7 @@ package org.icepdf.core.pobjects.annotations;
 import org.icepdf.core.pobjects.*;
 import org.icepdf.core.pobjects.fonts.FontFile;
 import org.icepdf.core.pobjects.fonts.FontManager;
+import org.icepdf.core.pobjects.fonts.zfont.Encoding;
 import org.icepdf.core.pobjects.graphics.Shapes;
 import org.icepdf.core.pobjects.graphics.TextSprite;
 import org.icepdf.core.pobjects.graphics.TextState;
@@ -409,11 +410,10 @@ public class FreeTextAnnotation extends MarkupAnnotation {
         // create the new font to draw with
         if (fontFile == null || fontPropertyChanged) {
             fontFile = FontManager.getInstance().initialize().getInstance(fontName, 0);
+            fontFile = fontFile.deriveFont(Encoding.standardEncoding, null);
             fontPropertyChanged = false;
         }
         fontFile = fontFile.deriveFont(fontSize);
-        // init font's metrics
-        fontFile.getAdvance(' ');
         TextSprite textSprites =
                 new TextSprite(fontFile,
                         content.length(),
@@ -450,7 +450,6 @@ public class FreeTextAnnotation extends MarkupAnnotation {
             currentX = advanceX + lastx;
             lastx += newAdvanceX;
 
-            // get normalized from from text sprite
             if (!(currentChar == '\n' || currentChar == '\r')) {
                 textSprites.addText(
                         String.valueOf(currentChar), // cid

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextWidgetAnnotation.java
@@ -22,6 +22,7 @@ import org.icepdf.core.pobjects.acroform.TextFieldDictionary;
 import org.icepdf.core.pobjects.acroform.VariableTextFieldDictionary;
 import org.icepdf.core.pobjects.fonts.FontFile;
 import org.icepdf.core.pobjects.fonts.FontManager;
+import org.icepdf.core.pobjects.fonts.zfont.Encoding;
 import org.icepdf.core.util.Library;
 
 import java.awt.geom.AffineTransform;
@@ -53,6 +54,7 @@ public class TextWidgetAnnotation extends AbstractWidgetAnnotation<TextFieldDict
         if (fontFile == null) {
             fontFile = FontManager.getInstance().initialize().getInstance(
                     fieldDictionary.getFontName().toString(), 0);
+            fontFile = fontFile.deriveFont(Encoding.standardEncoding, null);
         }
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
@@ -3737,7 +3737,15 @@ public class SwingController extends ComponentAdapter
      * Show tabbed pane interface for annotation properties.
      */
     public void showAnnotationProperties(AnnotationComponent annotationComponent) {
-        showAnnotationProperties(annotationComponent, viewer);
+        // grab a reference to the page so that it isn't de-referenced when the new
+        // dialog get referenced. At least I think that's what might be happening.
+        PageTree pageTree = getPageTree();
+        Page page = pageTree.getPage(documentViewController.getCurrentPageIndex());
+        try {
+            showAnnotationProperties(annotationComponent, viewer);
+        } finally {
+            page = null;
+        }
     }
 
     /**


### PR DESCRIPTION
I believe this issue was introduced when the new font library was integrated.  Basically some fonts like Type1 require an encoding to allow for glyph selection and in this particular case get a valid glyph width for layout.  

This PR will fix any layout issue when changing a free text annotations font (all squished up).  And a potential memory reference issue with open dialogs and saving an edited annotations properties. 