### PR TITLE
GH-243 make adjustment for non-text operands in a text block

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
@@ -244,7 +244,7 @@ public class ContentParser extends AbstractContentParser {
                         // the XObject's Subtype entry, which may be Image , Form, or PS
                         case Operands.Do:
                             graphicState = consume_Do(graphicState, stack, shapes,
-                                    resources, true, imageIndex, page);
+                                    resources, true, imageIndex, page, false);
                             break;
 
                         // Fill the path, using the even-odd rule to determine the
@@ -627,7 +627,7 @@ public class ContentParser extends AbstractContentParser {
                             stack.clear();
                             break;
                         case Operands.Do:
-                            consume_Do(graphicState, stack, shapes, resources, false, null, null);
+                            consume_Do(graphicState, stack, shapes, resources, false, imageIndex, null, true);
                             stack.clear();
                             break;
                         case Operands.BI:
@@ -941,6 +941,10 @@ public class ContentParser extends AbstractContentParser {
                     case Operands.DOUBLE_QUOTE:
                         consume_double_quote(graphicState, stack, shapes, textMetrics,
                                 glyphOutlineClip, oCGs);
+                        break;
+                    // not supposed to have a Do in text block but hey so be it. .
+                    case Operands.Do:
+                        consume_Do(graphicState, stack, shapes, resources, true, imageIndex, null, true);
                         break;
                 }
             }


### PR DESCRIPTION
GH-243
- this issue showed up years ago when a series of PDF was using a cm instead of tm to flip text.  To get around this issue I put in a horizontal flip as for the specific case.  
- this ticket is for a generator that is inserted in Do in a text block.   So I ended up using a similar flip technique and token handling inside a text block.  
- Still don't have enough clues to go on to how to deal with properly.  But qa passed so I'm going to merge and wait for another file to show up to shed more light on how to handle these elements. 