### PR TITLE
GH-245 address a coordinate space issue when calculating a glyphs bbox

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontDescriptor.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontDescriptor.java
@@ -18,6 +18,7 @@ package org.icepdf.core.pobjects.fonts;
 import org.icepdf.core.pobjects.*;
 import org.icepdf.core.util.Library;
 
+import java.awt.geom.Rectangle2D;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -222,22 +223,23 @@ public class FontDescriptor extends Dictionary {
     }
 
     /**
-     * Gets the fonts bounding box.
+     * Gets the fonts bounding box using the raw PRectangle values no conversion
+     * to Java2D coordinates are made.
      *
      * @return bounding box in PDF coordinate space.
      */
-    public PRectangle getFontBBox() {
+    public Rectangle2D getFontBBox() {
         Object value = library.getObject(entries, FONT_BBOX);
         if (value instanceof List) {
             List rectangle = (List) value;
-            return new PRectangle(rectangle);
+            return new PRectangle(rectangle).getOriginalPoints();
         } else if (value instanceof int[]) {
             int[] ints = (int[]) value;
             List<Integer> intList = new ArrayList<Integer>(ints.length);
             for (int i : ints) {
                 intList.add(i);
             }
-            return new PRectangle(intList);
+            return new PRectangle(intList).getOriginalPoints();
         }
         return null;
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1.java
@@ -1,6 +1,7 @@
 package org.icepdf.core.pobjects.fonts.zfont.fontFiles;
 
 import org.apache.fontbox.type1.Type1Font;
+import org.apache.fontbox.util.BoundingBox;
 import org.icepdf.core.pobjects.Name;
 import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.pobjects.fonts.CMap;
@@ -52,6 +53,7 @@ public class ZFontType1 extends ZSimpleFont {
                 }
             }
             fontBoxFont = type1Font;
+            calculateFontBbox();
         } catch (Throwable e) {
             logger.log(Level.FINE, "Error reading font file with ", e);
             throw new Exception(e);
@@ -62,6 +64,7 @@ public class ZFontType1 extends ZSimpleFont {
         byte[] fontBytes = url.openStream().readAllBytes();
         source = url;
         type1Font = Type1Font.createWithPFB(fontBytes);
+        calculateFontBbox();
     }
 
     private ZFontType1(ZFontType1 font) {
@@ -129,7 +132,9 @@ public class ZFontType1 extends ZSimpleFont {
             font.widths = widths;
         }
         font.cMap = diff != null ? diff : font.cMap;
-        font.bbox = bbox;
+        if (font.bbox == null) {
+            font.bbox = bbox;
+        }
         return font;
     }
 
@@ -164,6 +169,15 @@ public class ZFontType1 extends ZSimpleFont {
     @Override
     public String getName() {
         return type1Font.getName();
+    }
+
+    private void calculateFontBbox() {
+        BoundingBox fontBBox = type1Font.getFontBBox();
+        if (fontBBox.getWidth() > 0 && fontBBox.getHeight() > 0) {
+            bbox = new Rectangle2D.Double(
+                    fontBBox.getLowerLeftX(), fontBBox.getLowerLeftY(),
+                    fontBBox.getUpperRightX(), fontBBox.getUpperRightY());
+        }
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
@@ -195,15 +195,17 @@ public abstract class ZSimpleFont implements FontFile {
 
     @Override
     public Rectangle2D getMaxCharBounds() {
+        // bbox isn't a proper rectangle but p1x, p1y, p2x, p2y
         double[] bboxPrimitives = new double[]{
                 bbox.getX() * size, bbox.getY() * size, bbox.getWidth() * size, bbox.getHeight() * size};
-        // transform x,y coord, so we get the correct offset for painting
+        // transform the two points to the correct space
         fontMatrix.deltaTransform(bboxPrimitives, 0, bboxPrimitives, 0, 2);
-        // try and detect inverted layout, not a fan of this workaround.
+        // flip if needed
         if (bboxPrimitives[3] < 0.0) {
             bboxPrimitives[1] = -bboxPrimitives[1];
             bboxPrimitives[3] = -bboxPrimitives[3];
         }
+        // convert ot a proper java2d rectangle
         return new Rectangle2D.Double(
                 bboxPrimitives[0],
                 -bboxPrimitives[3],

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
@@ -88,9 +88,6 @@ public abstract class ZSimpleFont implements FontFile {
         if (maxCharBounds != null) {
             this.maxCharBounds = new Rectangle2D.Double(
                     maxCharBounds.getX(), maxCharBounds.getY(), maxCharBounds.getWidth(), maxCharBounds.getHeight());
-        } else {
-            // preload the max char points
-            this.maxCharBounds = getMaxCharBounds();
         }
     }
 


### PR DESCRIPTION
- fixes a coordinate space error when getting the font descriptor's bbox and defers the conversion to java2d space.  
- use delta transform to apply the fontMatrix transform to the PDF rectangle points.
- adds caching the maxCharBounds value that can span deriveFont calls. 