### PR TITLE
Gh-279 left page view layout regressions

### DIFF
--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/MouseWheelListenerPageChanger.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/MouseWheelListenerPageChanger.java
@@ -118,21 +118,9 @@ public class MouseWheelListenerPageChanger implements MouseWheelListener {
         if (deltaPage == 0)
             return;
 
-        int newPage = controller.getCurrentPageNumber() + deltaPage;
         if (controller.getDocument() == null) {
             return;
         }
-        if (newPage < 0) {
-            deltaPage = -controller.getCurrentPageNumber();
-        }
-        if (newPage >= controller.getDocument().getNumberOfPages()) {
-            deltaPage = controller.getDocument().getNumberOfPages() - controller.getCurrentPageNumber() - 1;
-        }
-
-        if (deltaPage == 0) {
-            return;
-        }
-//        System.out.println("Delta " + deltaPage + " " + controller.getCurrentPageNumber() + " " + visibleVerticalScrollBar);
 
         changingPage = true;
         final int dp = deltaPage;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
@@ -47,7 +47,6 @@ import java.util.regex.Pattern;
  *
  * @since 2.5
  */
-@SuppressWarnings("serial")
 public class DocumentViewControllerImpl
         implements DocumentViewController, ComponentListener, PropertyChangeListener {
 
@@ -58,11 +57,11 @@ public class DocumentViewControllerImpl
     private static final Pattern DASH_NEWLINE_PATTERN = Pattern.compile("- *\n");
 
     /**
-     * Displays a one page at a time view.
+     * Displays a one page at a time.
      */
     public static final int ONE_PAGE_VIEW = 1;
     /**
-     * Displays a the pages in one column.
+     * Displays all pages in a single column.
      */
     public static final int ONE_COLUMN_VIEW = 2;
     /**
@@ -74,15 +73,15 @@ public class DocumentViewControllerImpl
      */
     public static final int TWO_COLUMN_LEFT_VIEW = 4;
     /**
-     * Displays the pages two at a time, with event-numbered pages on the left.
+     * Displays the pages two at a time, with odd-numbered pages on the right.
      */
     public static final int TWO_PAGE_RIGHT_VIEW = 5;
     /**
-     * Displays the pages in two columns, with even-numbered pages on the left.
+     * Displays the pages in two columns, with odd-numbered pages on the right.
      */
     public static final int TWO_COLUMN_RIGHT_VIEW = 6;
     /**
-     * Displays the pages in two columns, with even-numbered pages on the left.
+     * Displays document using the attachment view,  showing thumbnails for each child document.
      */
     public static final int USE_ATTACHMENTS_VIEW = 7;
     /**
@@ -90,11 +89,11 @@ public class DocumentViewControllerImpl
      */
     public static final int FULL_SCREEN_VIEW = 8;
     /**
-     * Zoom factor used when zooming in or out.
+     * Zoom factor multiplier when zooming in or out.
      */
     public static final float ZOOM_FACTOR = 1.2F;
     /**
-     * Rotation factor used with rotating document.
+     * Rotation factor multiplier when rotating document.
      */
     public static final float ROTATION_FACTOR = 90F;
 
@@ -1420,7 +1419,7 @@ public class DocumentViewControllerImpl
                         }
                     }
                 }
-                // else we need to to remove the old component and add the new destination component.
+                // else we need to remove the old component and add the new destination component.
                 else {
                     // remove the old component
                     Page oldPage = (Page) library.getObject(oldDestination.getPageReference());

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoColumnPageView.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoColumnPageView.java
@@ -56,7 +56,7 @@ public class TwoColumnPageView extends AbstractDocumentView {
         // put all the gui elements together
         buildGUI();
 
-        // add the first of many tools need for this views and others like it.
+        // add the first of many tools needed for this view and others like it.
         currentPageChanger =
                 new CurrentPageChanger(documentScrollpane, this,
                         documentViewModel.getPageComponents());
@@ -83,11 +83,6 @@ public class TwoColumnPageView extends AbstractDocumentView {
         if (pageComponents != null) {
             AbstractPageViewComponent pageViewComponent;
             for (int i = 0, max = pageComponents.size(); i < max; i++) {
-                // save for facing page
-                if (i == 0 && max > 2 && viewAlignment == RIGHT_VIEW) {
-                    // should be adding spacer
-                    add(new JLabel());
-                }
                 pageViewComponent = pageComponents.get(i);
                 if (pageViewComponent != null) {
                     pageViewComponent.setDocumentViewCallback(this);
@@ -216,26 +211,4 @@ public class TwoColumnPageView extends AbstractDocumentView {
         // paint selection box
         super.paintComponent(g);
     }
-
-//    public void adjustmentValueChanged(AdjustmentEvent e){
-//
-////        System.out.println("Adjusting " + e.getAdjustable().getValue());
-//          if (e.getAdjustable().getOrientation() == Adjustable.HORIZONTAL){
-////              System.out.println("horizontal");
-//          }
-//          else if (e.getAdjustable().getOrientation() == Adjustable.VERTICAL){
-////              System.out.println("vertical");
-////              int newValue = e.getAdjustable().getValue();
-////              System.out.println("value " + newValue);
-////              e.getAdjustable().setValue(0);
-//          }
-//    }
-
-//    public void mouseDragged(MouseEvent e) {
-//        Point point = e.getPoint();
-//        super.mouseDragged(e);
-//        Point currentLocation = getLocation();
-//        pageViewComponentImpl.setBounds(point.x,
-//                                        point.y, 640,480);
-//    }
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoColumnPageViewLayout.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoColumnPageViewLayout.java
@@ -27,79 +27,35 @@ public class TwoColumnPageViewLayout extends TwoPageViewLayout{
                 .toArray(PageViewDecorator[]::new);
 
         int count = 0;
-        Dimension previousDimension = null;
-        if (viewType == DocumentView.RIGHT_VIEW) {
-            for (PageViewDecorator pageViewDecorator : pages) {
-                int pageIndex = pageViewDecorator.getPageViewComponent().getPageIndex();
-                Dimension d = pageViewDecorator.getPreferredSize();
-                // apply left to right reading
-                if (pageIndex == 0) {
-                    // offset to the right side
-                    if (pages.length > 2 ){
-                        xCord = ((maxWidth - preferredWidth) / 2) + d.width + PAGE_SPACING_HORIZONTAL + insets.left;
-                    } else {
-                        xCord = (maxWidth - preferredWidth) / 2;
-                        count++;
-                    }
-                    if (preferredHeight < maxHeight){
-                        yCord = (maxHeight - preferredHeight) / 2;
-                    }
-                    xCord += insets.left;
-                    yCord += insets.top;
-                } else if (count == 0) {
-                    // start layout left to right
-                    xCord = (maxWidth - preferredWidth) / 2;
-                    xCord += insets.left;
-                    yCord += previousDimension.height + PAGE_SPACING_VERTICAL;
-                    count++;
-                } else {
-                    count = 0;
-                    xCord += previousDimension.width + PAGE_SPACING_HORIZONTAL;
+        Dimension previousDimension = new Dimension();
+        for (PageViewDecorator pageViewDecorator : pages) {
+            int pageIndex = pageViewDecorator.getPageViewComponent().getPageIndex();
+            Dimension d = pageViewDecorator.getPreferredSize();
+            // apply left to right reading
+            if (viewType == DocumentView.RIGHT_VIEW && pageIndex == 0 &&
+                    (pages.length != 2)) {
+                // offset to the right side
+                xCord = ((maxWidth - preferredWidth) / 2) + d.width + PAGE_SPACING_HORIZONTAL + insets.left;
+                if (preferredHeight < maxHeight) {
+                    yCord = (maxHeight - preferredHeight) / 2;
                 }
-                previousDimension = d;
-                pageViewDecorator.setBounds(xCord, yCord, d.width, d.height);
-                updatePopupAnnotationComponents(pageViewDecorator);
-            }
-        }
-        else {
-            PageViewDecorator pageViewDecorator, nexPageViewDecorator;
-            for (int i = 0; i < pages.length; i++) {
-                pageViewDecorator = pages[i];
-                int pageIndex = pageViewDecorator.getPageViewComponent().getPageIndex();
-                Dimension currentPageDimension = pageViewDecorator.getPreferredSize();
-                // apply right to left reading
-                if ((pageIndex == 0)) {
-                    if (minWidth < maxWidth){
-                        xCord = (maxWidth - preferredWidth) / 2;
-                    }
-                    if (minHeight < maxHeight){
-                        yCord = (maxHeight - preferredHeight) / 2;
-                    }
-                    if (xCord < 0) xCord = 0;
-                    if (yCord < 0) yCord = 0;
-
-                    xCord += insets.left;
-                    yCord += insets.top;
-
-                    // otherwise move to right
-                    if (pages.length == 2){
-                        xCord += currentPageDimension.width + PAGE_SPACING_HORIZONTAL;
-                        count++;
-                    }
-
-                } else if (count == 0) {
-                    xCord += previousDimension.width + PAGE_SPACING_HORIZONTAL;
-                    yCord += previousDimension.height + PAGE_SPACING_VERTICAL;
-                    count++;
-                } else {
-                    xCord -= currentPageDimension.width + PAGE_SPACING_HORIZONTAL;
-                    count = 0;
+                xCord += insets.left;
+            } else if (count == 0) {
+                xCord = (maxWidth - preferredWidth) / 2;
+                xCord += insets.left;
+                yCord += previousDimension.height + PAGE_SPACING_VERTICAL;
+                if (preferredHeight < maxHeight) {
+                    yCord = (maxHeight - preferredHeight) / 2;
+                    yCord += PAGE_SPACING_VERTICAL;
                 }
-
-                previousDimension = currentPageDimension;
-
-                pageViewDecorator.setBounds(xCord, yCord, currentPageDimension.width, currentPageDimension.height);
+                count++;
+            } else {
+                count = 0;
+                xCord += previousDimension.width + PAGE_SPACING_HORIZONTAL;
             }
+            previousDimension = d;
+            pageViewDecorator.setBounds(xCord, yCord, d.width, d.height);
+            updatePopupAnnotationComponents(pageViewDecorator);
         }
     }
 
@@ -115,7 +71,7 @@ public class TwoColumnPageViewLayout extends TwoPageViewLayout{
                 .filter(component -> component instanceof PageViewDecorator && component.isVisible())
                 .toArray(PageViewDecorator[]::new);
 
-        for (int i = 0, max = pages.length / 2 ; i < max; i++) {
+        for (int i = 0, max = pages.length; i < max; i += 2) {
             Component component = pages[i];
             dimension = component.getPreferredSize();
             preferredWidth = Math.max((dimension.width * 2 + PAGE_SPACING_HORIZONTAL), preferredWidth);
@@ -124,7 +80,8 @@ public class TwoColumnPageViewLayout extends TwoPageViewLayout{
             minWidth = Math.max(component.getMinimumSize().width * 2, minWidth);
             minHeight += preferredHeight;
         }
-        if (pages.length > 0 && pages.length != 2) {
+        // add height of right side page height for even number documents, otherwise height will be off.
+        if (pages.length > 2 && pages.length % 2 == 0) {
             preferredHeight += pages[0].getPreferredSize().height + PAGE_SPACING_VERTICAL;
             minHeight += preferredHeight;
         }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoPageView.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoPageView.java
@@ -104,7 +104,8 @@ public class TwoPageView extends AbstractDocumentView {
             if (viewAlignment == RIGHT_VIEW &&
                     ((index > 0 && index % 2 == 0) || (index > 0 && docLength == 2))) {
                 index--;
-            } else if ((index > 0 && index % 2 != 0) || (index > 0 && docLength == 2)) {
+            } else if (viewAlignment == LEFT_VIEW &&
+                    (index > 0 && index % 2 != 0) || (index > 0 && docLength == 2)) {
                 index--;
             }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoPageView.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoPageView.java
@@ -104,6 +104,8 @@ public class TwoPageView extends AbstractDocumentView {
             if (viewAlignment == RIGHT_VIEW &&
                     ((index > 0 && index % 2 == 0) || (index > 0 && docLength == 2))) {
                 index--;
+            } else if ((index > 0 && index % 2 != 0) || (index > 0 && docLength == 2)) {
+                index--;
             }
 
             for (int i = index; i < docLength && count < 2; i++) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoPageViewLayout.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/TwoPageViewLayout.java
@@ -39,58 +39,33 @@ public class TwoPageViewLayout extends BasePageViewLayout implements LayoutManag
 
         int count = 0;
         int previousWidth = 0;
-        if (viewType == DocumentView.RIGHT_VIEW) {
-            for (PageViewDecorator pageViewDecorator : pages) {
-                int pageIndex = pageViewDecorator.getPageViewComponent().getPageIndex();
-                Dimension d = pageViewDecorator.getPreferredSize();
-                // apply left to right reading
-                if (pageIndex == 0 && pages.length == 1) {
-                    // offset to the right side
-                    xCord = ((maxWidth - preferredWidth) / 2) + d.width + PAGE_SPACING_HORIZONTAL;
-                    xCord += insets.left;
-                } else if (count == 0) {
-                    // start layout left to right
-                    xCord += PAGE_SPACING_HORIZONTAL + (maxWidth - preferredWidth) / 2;
-                    previousWidth = d.width;
-                    count++;
-                } else {
-                    xCord += previousWidth + PAGE_SPACING_HORIZONTAL;
-                }
-                yCord = (maxHeight - d.height) / 2;
-
-                if (xCord < 0) xCord = 0;
-                if (yCord < 0) yCord = 0;
-
-                yCord += insets.top;
-
-                pageViewDecorator.setBounds(xCord, yCord, d.width, d.height);
-                updatePopupAnnotationComponents(pageViewDecorator);
+        for (PageViewDecorator pageViewDecorator : pages) {
+            int pageIndex = pageViewDecorator.getPageViewComponent().getPageIndex();
+            Dimension d = pageViewDecorator.getPreferredSize();
+            // apply odd pages right offset
+            if (viewType == DocumentView.RIGHT_VIEW &&
+                    pageIndex == 0 && pages.length == 1) {
+                // offset to the right side
+                xCord = ((maxWidth - preferredWidth) / 2) + d.width + PAGE_SPACING_HORIZONTAL;
+                xCord += insets.left;
+            } else if (count == 0) {
+                // regular layout
+                xCord += (maxWidth - preferredWidth) / 2;
+                xCord += insets.left;
+                previousWidth = d.width;
+                count++;
+            } else {
+                xCord += previousWidth + PAGE_SPACING_HORIZONTAL;
             }
-        } else {
-            PageViewDecorator pageViewDecorator;
-            for (int i = pages.length - 1; i >= 0; i--) {
-                pageViewDecorator = pages[i];
-                int pageIndex = pageViewDecorator.getPageViewComponent().getPageIndex();
-                Dimension d = pageViewDecorator.getPreferredSize();
-                // apply right to left reading
-                if ((pageIndex == 0 && pages.length == 1) || count == 0) {
-                    // left side
-                    xCord += PAGE_SPACING_HORIZONTAL + (maxWidth - preferredWidth) / 2;
-                    previousWidth = d.width;
-                    count++;
-                } else {
-                    xCord += previousWidth + PAGE_SPACING_HORIZONTAL;
-                }
-                yCord = (maxHeight - d.height) / 2;
+            yCord = (maxHeight - d.height) / 2;
 
-                if (xCord < 0) xCord = 0;
-                if (yCord < 0) yCord = 0;
+            if (xCord < 0) xCord = 0;
+            if (yCord < 0) yCord = 0;
 
-                yCord += insets.top;
+            yCord += insets.top;
 
-                pageViewDecorator.setBounds(xCord, yCord, d.width, d.height);
-                updatePopupAnnotationComponents(pageViewDecorator);
-            }
+            pageViewDecorator.setBounds(xCord, yCord, d.width, d.height);
+            updatePopupAnnotationComponents(pageViewDecorator);
         }
     }
 


### PR DESCRIPTION
- 7.1.0 was a rewrite of the page views to get the popup annotation to be draggable outside of a page. 
- for some reason I got in my head the left view type was a right to left page layout which it isn't. 
- this pr address the layout issues and odd pages numbers are correctly on the left when LEFT_VIEW is used when creating two page views. 