### PR TITLE
GH-291 fixing encryption related problems during document rewrites. 

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Dictionary.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Dictionary.java
@@ -217,7 +217,7 @@ public class Dictionary {
     }
 
     /**
-     * Sets the dictionary key value, handling any encryption so dictionary can be written correctly.
+     * Sets the dictionary key value. Encryption is handled by the writers
      *
      * @param key   dictionary key
      * @param value key value.
@@ -225,12 +225,12 @@ public class Dictionary {
      */
     protected String setString(final Name key, String value) {
         // make sure we store an encrypted documents string as encrypted
-        entries.put(key, new LiteralStringObject(value, getPObjectReference(), library.getSecurityManager()));
+        entries.put(key, new LiteralStringObject(value));
         return value;
     }
 
     /**
-     * Sets the dictionary key value, handling any encryption so dictionary can be written correctly.
+     * Sets the dictionary key value. Encryption is handled by the writers.
      *
      * @param key   dictionary key
      * @param value key value.
@@ -238,7 +238,7 @@ public class Dictionary {
      */
     protected String setHexString(final Name key, String value) {
         // make sure we store an encrypted documents string as encrypted
-        entries.put(key, new HexStringObject(value, getPObjectReference(), library.getSecurityManager()));
+        entries.put(key, new HexStringObject(value));
         return value;
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/HexStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/HexStringObject.java
@@ -362,10 +362,14 @@ public class HexStringObject implements StringObject {
         // otherwise, assume 4 byte character codes
         else {
             int length = hh.length();
+            // check for the need to add padding
+            if (((length - 4) / 4) % 2 != 0) {
+                hh.append("00");
+            }
             sb = new StringBuilder(length / 4);
             String subStr;
             // make sure to skip the marker
-            for (int i = 4; i < length; i = i + 4) {
+            for (int i = 4, max = length - 4; i < max; i = i + 4) {
                 subStr = hh.substring(i, i + 4);
                 sb.append((char) Integer.parseInt(subStr, 16));
             }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/LiteralStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/LiteralStringObject.java
@@ -91,8 +91,7 @@ public class LiteralStringObject implements StringObject {
         // convert string to octal encoded.
         string = Utils.convertStringToOctal(string);
         // decrypt the string.
-        stringData = new StringBuilder(
-                encryption(string, false, securityManager));
+        stringData = new StringBuilder(encryption(string, false, securityManager));
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/PObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/PObject.java
@@ -30,6 +30,8 @@ public class PObject {
     private final Reference objectReference;
     private int linearTraversalOffset;
 
+    private boolean doNotEncrypt;
+
     /**
      * Create a new PObject.
      *
@@ -58,6 +60,12 @@ public class PObject {
     public PObject(Object object, Reference objectReference) {
         this.object = object;
         this.objectReference = objectReference;
+    }
+
+    public PObject(Object object, Reference objectReference, boolean doNotEncrypt) {
+        this.object = object;
+        this.objectReference = objectReference;
+        this.doNotEncrypt = doNotEncrypt;
     }
 
     /**
@@ -109,6 +117,20 @@ public class PObject {
 
     public void setLinearTraversalOffset(int linearTraversalOffset) {
         this.linearTraversalOffset = linearTraversalOffset;
+    }
+
+    /**
+     * Flag dictionary as do not encrypt.  This is mainly used for the root xref dictionary, so we don't encrypt
+     * StringObjects that are needed to open a document
+     *
+     * @return true if the dictionary StringObject values should not be encrypted on a document rewrite.
+     */
+    public boolean isDoNotEncrypt() {
+        return doNotEncrypt;
+    }
+
+    public void setDoNotEncrypt(boolean doNotEncrypt) {
+        this.doNotEncrypt = doNotEncrypt;
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
@@ -560,6 +560,7 @@ public abstract class Annotation extends Dictionary {
      */
     public Annotation(Library library, DictionaryEntries entries) {
         super(library, entries);
+        securityManager = library.getSecurityManager();
     }
 
     /**
@@ -633,8 +634,6 @@ public abstract class Annotation extends Dictionary {
         super.init();
         // type of Annotation
         subtype = (Name) getObject(SUBTYPE_KEY);
-
-        securityManager = library.getSecurityManager();
 
         content = getContents();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
@@ -142,7 +142,11 @@ public class Library {
      * object reference can not be found.
      */
     public Object getObject(Reference reference) {
-        return getObject(reference, null).getObject();
+        Object obj = getObject(reference, null);
+        if (obj != null) {
+            return getObject(reference, null).getObject();
+        }
+        return null;
     }
 
     public PObject getPObject(Reference reference) {

--- a/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
@@ -142,10 +142,14 @@ public class Library {
      * object reference can not be found.
      */
     public Object getObject(Reference reference) {
+        return getObject(reference, null).getObject();
+    }
+
+    public PObject getPObject(Reference reference) {
         return getObject(reference, null);
     }
 
-    private Object getObject(Reference reference, Name hint) {
+    private PObject getObject(Reference reference, Name hint) {
         Object obj;
         java.lang.ref.Reference<Object> obRef = objectStore.get(reference);
         // check stateManager first to allow for annotations to be injected
@@ -154,9 +158,9 @@ public class Library {
             if (stateManager.contains(reference)) {
                 obj = stateManager.getChange(reference);
                 if (obj != null) {
-                    return ((StateManager.Change) obj).getPObject().getObject();
+                    return ((StateManager.Change) obj).getPObject();
                 }
-                return obj;
+                return null;
             }
         }
         obj = obRef != null ? obRef.get() : null;
@@ -182,7 +186,7 @@ public class Library {
             }
             if (obj == null) return null;
             // keep expensive like fonts, images, page tree
-            Object object = ((PObject) obj).getObject();
+            PObject object = ((PObject) obj);
             if (isSoftReferenceAble(object)) {
                 objectStore.put(reference, new SoftReference<>(obj));
             } else {
@@ -191,13 +195,13 @@ public class Library {
             return object;
         }
         if (obj instanceof PObject) {
-            return ((PObject) obj).getObject();
+            return (PObject) obj;
         } else if (obj instanceof Reference) {
             Reference secondReference = (Reference) obj;
             logger.log(Level.WARNING, () -> "Found a reference to a reference: " + secondReference);
-            return getObject(secondReference);
+            return getPObject(secondReference);
         }
-        return obj;
+        return new PObject(obj, reference);
     }
 
     private boolean isSoftReferenceAble(Object object) {
@@ -480,6 +484,13 @@ public class Library {
             return getObject((Reference) referenceObject);
         }
         return referenceObject;
+    }
+
+    public PObject getPObject(Object referenceObject) {
+        if (referenceObject instanceof Reference) {
+            return getPObject((Reference) referenceObject);
+        }
+        return null;
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
@@ -69,7 +69,11 @@ public class ContentParser extends AbstractContentParser {
             for (byte[] streamByte : streamBytes) {
                 if (streamByte != null) {
                     String tmp = new String(streamByte, StandardCharsets.ISO_8859_1);
-                    logger.finer("Content " + references[i].toString() + " = " + tmp);
+                    if (references[i] != null) {
+                        logger.finer("Content " + references[i].toString() + " = " + tmp);
+                    } else {
+                        logger.finer("Content = " + tmp);
+                    }
                 }
                 i++;
             }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/object/Parser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/object/Parser.java
@@ -135,7 +135,7 @@ public class Parser {
         return ObjectFactory.getInstance(library, objectNumber, objectGeneration, objectData, streamByteBuffer);
     }
 
-    private int getLength(Object objectData){
+    private int getLength(Object objectData) {
         if (objectData instanceof DictionaryEntries) {
             return library.getInt((DictionaryEntries) objectData, Dictionary.LENGTH_KEY);
         } else if (objectData instanceof Dictionary) {
@@ -158,10 +158,10 @@ public class Parser {
         return ObjectFactory.getInstance(library, objectNumber, 0, objectData, null);
     }
 
-    public CrossReference getCrossReference(ByteBuffer byteBuffer, int starXref)
+    public CrossReference getCrossReference(ByteBuffer byteBuffer, int startXref)
             throws CrossReferenceStateException, ObjectStateException, IOException {
         // sometimes the offset is off just by a few bytes
-        byteBuffer.position(starXref - 10);
+        byteBuffer.position(startXref - 10);
         int xrefPositionStart = byteBuffer.position();
 
         // make sure we have a xref declaration
@@ -176,9 +176,9 @@ public class Parser {
         // see if we found xref marking and thus an < 1.5 formatted xref table.
         if (foundXrefMarker) {
             // update the xref position as we will have removed any white space.
-            starXref = xrefPositionStart + lookAheadBuffer.position();
+            startXref = xrefPositionStart + lookAheadBuffer.position();
             // scan ahead to find the trailer position
-            byteBuffer.position(starXref);
+            byteBuffer.position(startXref);
             boolean foundTrailerMarker = ByteBufferUtil.findString(byteBuffer, TRAILER_MARKER);
             if (!foundTrailerMarker || byteBuffer.position() == byteBuffer.limit()) {
                 throw new CrossReferenceStateException();
@@ -189,19 +189,22 @@ public class Parser {
             Object token = objectLexer.nextToken();
             if (token instanceof DictionaryEntries) {
                 DictionaryEntries xrefDictionary = (DictionaryEntries) token;
-                return parseCrossReferenceTable(xrefDictionary, objectLexer, byteBuffer, starXref, startTrailer);
+                return parseCrossReferenceTable(xrefDictionary, objectLexer, byteBuffer,
+                        startXref, startTrailer);
             }
         }
         // if there is an entry we can ignore parsing the table as it's redundant and just parse the strmObject
-        return parseCrossReferenceStream(byteBuffer, starXref);
+        return parseCrossReferenceStream(byteBuffer, startXref);
     }
 
-    private CrossReference parseCrossReferenceTable(DictionaryEntries dictionaryEntries, Lexer objectLexer, ByteBuffer byteBuffer,
+    private CrossReference parseCrossReferenceTable(DictionaryEntries dictionaryEntries, Lexer objectLexer,
+                                                    ByteBuffer byteBuffer,
                                                     int start, int end) throws IOException {
         // mark the xref start, so it can be used to write future /prev entries.
         // allocate to a new buffer as the data is well-defined.
         ByteBuffer xrefTableBuffer = ByteBufferUtil.sliceObjectStream(byteBuffer, start, end);
-        CrossReferenceTable crossReferenceTable = new CrossReferenceTable(library, dictionaryEntries, start);
+        CrossReferenceTable crossReferenceTable = new CrossReferenceTable(library, dictionaryEntries,
+                start - XREF_MARKER.length);
         objectLexer.setByteBuffer(xrefTableBuffer);
         // parse the sub groupings
         while (true) {
@@ -239,7 +242,7 @@ public class Parser {
         // use parser to get xref stream object.
         CrossReferenceStream crossReferenceStream = (CrossReferenceStream) getPObject(byteBuffer, offset).getObject();
         crossReferenceStream.initialize();
-        crossReferenceStream.setXrefStartPos(offset);
+        crossReferenceStream.setXrefStartPos(offset - XREF_MARKER.length);
         return crossReferenceStream;
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/FullUpdater.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/FullUpdater.java
@@ -106,6 +106,10 @@ public class FullUpdater {
     private void writePObject(BaseWriter writer, Name name, Object object) throws IOException {
         if (object instanceof Reference && writer.hasNotWrittenReference((Reference) object)) {
             PObject pobject = library.getPObject(object);
+            // possible to have unreferenced object in a file,  todo: file could be corrected
+            if (pobject == null) {
+                return;
+            }
             Object objectReferenceValue = pobject.getObject();
             StateManager.Change change = stateManager.getChange((Reference) object);
             if (change != null) {

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/ArrayWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/ArrayWriter.java
@@ -1,6 +1,7 @@
 package org.icepdf.core.util.updater.writeables;
 
 import org.icepdf.core.io.CountingOutputStream;
+import org.icepdf.core.pobjects.PObject;
 
 import java.io.IOException;
 import java.util.List;
@@ -10,10 +11,11 @@ public class ArrayWriter extends BaseWriter {
     private static final byte[] BEGIN_ARRAY = "[".getBytes();
     private static final byte[] END_ARRAY = "]".getBytes();
 
-    public void write(List<Object> writeable, CountingOutputStream output) throws IOException {
+    public void write(PObject pObject, CountingOutputStream output) throws IOException {
+        List<Object> writeable = (List<Object>) pObject.getObject();
         output.write(BEGIN_ARRAY);
         for (int i = 0, size = writeable.size(); i < size; i++) {
-            writeValue(writeable.get(i), output);
+            writeValue(new PObject(writeable.get(i), pObject.getReference(), pObject.isDoNotEncrypt()), output);
             if (i < size - 1) {
                 output.write(SPACE);
             }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/BaseWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/BaseWriter.java
@@ -44,7 +44,7 @@ public class BaseWriter {
     private static CompressedXrefTableWriter compressedXrefTableWriter;
 
     private CountingOutputStream output;
-    private SecurityManager securityManager;
+    protected SecurityManager securityManager;
     private CrossReferenceRoot crossReferenceRoot;
     private long startingPosition;
     private ArrayList<Entry> entries;
@@ -73,8 +73,8 @@ public class BaseWriter {
         nameWriter = new NameWriter();
         dictionaryWriter = new DictionaryWriter();
         referenceWriter = new ReferenceWriter();
-        hexStringObjectWriter = new HexStringObjectWriter();
-        literalObjectWriter = new LiteralStringWriter();
+        hexStringObjectWriter = new HexStringObjectWriter(securityManager);
+        literalObjectWriter = new LiteralStringWriter(securityManager);
         arrayWriter = new ArrayWriter();
         affineTransformWriter = new AffineTransformWriter();
         pObjectWriter = new PObjectWriter();
@@ -141,7 +141,8 @@ public class BaseWriter {
         headerWriter.write(header, output);
     }
 
-    protected void writeValue(Object val, CountingOutputStream output) throws IOException {
+    protected void writeValue(PObject pObject, CountingOutputStream output) throws IOException {
+        Object val = pObject.getObject();
         if (val == null) {
             output.write(NULL);
         } else if (val instanceof Name) {
@@ -166,16 +167,15 @@ public class BaseWriter {
             }
 
         } else if (val instanceof LiteralStringObject) {
-            literalObjectWriter.write(((LiteralStringObject) val), output);
+            literalObjectWriter.write(pObject, output);
         } else if (val instanceof HexStringObject) {
-            hexStringObjectWriter.write((HexStringObject) val, output);
+            hexStringObjectWriter.write(pObject, output);
         } else if (val instanceof List) {
-            //noinspection unchecked
-            arrayWriter.write((List<Object>) val, output);
+            arrayWriter.write(pObject, output);
         } else if (val instanceof Dictionary) {
-            writeDictionary((Dictionary) val, output);
+            writeDictionary(pObject, output);
         } else if (val instanceof DictionaryEntries) {
-            dictionaryWriter.write((DictionaryEntries) val, output);
+            dictionaryWriter.write(pObject, output);
         } else if (val instanceof AffineTransform) {
             affineTransformWriter.write((AffineTransform) val, output);
         } else {
@@ -187,8 +187,8 @@ public class BaseWriter {
         nameWriter.write(name, output);
     }
 
-    protected void writeDictionary(Dictionary dictionary, CountingOutputStream output) throws IOException {
-        dictionaryWriter.write(dictionary, output);
+    protected void writeDictionary(PObject pObject, CountingOutputStream output) throws IOException {
+        dictionaryWriter.write(pObject, output);
     }
 
     protected void writeBoolean(boolean bool, CountingOutputStream output) throws IOException {

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/DictionaryWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/DictionaryWriter.java
@@ -4,6 +4,7 @@ import org.icepdf.core.io.CountingOutputStream;
 import org.icepdf.core.pobjects.Dictionary;
 import org.icepdf.core.pobjects.DictionaryEntries;
 import org.icepdf.core.pobjects.Name;
+import org.icepdf.core.pobjects.PObject;
 
 import java.io.IOException;
 import java.util.Set;
@@ -13,20 +14,25 @@ public class DictionaryWriter extends BaseWriter {
     private static final byte[] BEGIN_DICTIONARY = "<<".getBytes();
     private static final byte[] END_DICTIONARY = ">>".getBytes();
 
-
-    public void write(Dictionary dictionary, CountingOutputStream output) throws IOException {
-        DictionaryEntries dictEntries = dictionary.getEntries();
-        write(dictEntries, output);
+    public void write(PObject pObject, CountingOutputStream output) throws IOException {
+        if (pObject.getObject() instanceof Dictionary) {
+            Dictionary dictionary = (Dictionary) pObject.getObject();
+            DictionaryEntries dictEntries = dictionary.getEntries();
+            write(dictEntries, pObject, output);
+        } else {
+            DictionaryEntries dictEntries = (DictionaryEntries) pObject.getObject();
+            write(dictEntries, pObject, output);
+        }
     }
 
-    public void write(DictionaryEntries dictEntries, CountingOutputStream output) throws IOException {
+    public void write(DictionaryEntries dictEntries, PObject pObject, CountingOutputStream output) throws IOException {
         output.write(BEGIN_DICTIONARY);
         Set<Name> keys = dictEntries.keySet();
         for (Name key : keys) {
             Object val = dictEntries.get(key);
             writeName(key, output);
             output.write(SPACE);
-            writeValue(val, output);
+            writeValue(new PObject(val, pObject.getReference(), pObject.isDoNotEncrypt()), output);
             output.write(SPACE);
         }
         output.write(END_DICTIONARY);

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/HexStringObjectWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/HexStringObjectWriter.java
@@ -2,6 +2,9 @@ package org.icepdf.core.util.updater.writeables;
 
 import org.icepdf.core.io.CountingOutputStream;
 import org.icepdf.core.pobjects.HexStringObject;
+import org.icepdf.core.pobjects.PObject;
+import org.icepdf.core.pobjects.security.SecurityManager;
+import org.icepdf.core.util.Utils;
 
 import java.io.IOException;
 
@@ -13,10 +16,29 @@ public class HexStringObjectWriter extends BaseWriter {
     private static final String HEX_REGEX = "(?=[<>\\\\])";
     private static final String HEX_REPLACEMENT = "\\\\";
 
+    public HexStringObjectWriter(SecurityManager securityManager) {
+        this.securityManager = securityManager;
+    }
+
+    public void write(PObject pObject, CountingOutputStream output) throws IOException {
+        HexStringObject writeable = (HexStringObject) pObject.getObject();
+        if (pObject.isDoNotEncrypt()) {
+            writeRaw(writeable.getHexString(), output);
+        } else {
+            write(new HexStringObject(writeable.toString(), pObject.getReference(), securityManager), output);
+        }
+    }
 
     public void write(HexStringObject writeable, CountingOutputStream output) throws IOException {
         output.write(BEGIN_HEX_STRING);
         writeByteString(writeable.getHexString().replaceAll(HEX_REGEX, HEX_REPLACEMENT), output);
+        output.write(END_HEX_STRING);
+    }
+
+    public void writeRaw(String writeable, CountingOutputStream output) throws IOException {
+        output.write(BEGIN_HEX_STRING);
+        byte[] textBytes = Utils.convertByteCharSequenceToByteArray(writeable);
+        output.write(textBytes);
         output.write(END_HEX_STRING);
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/HexStringObjectWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/HexStringObjectWriter.java
@@ -25,7 +25,8 @@ public class HexStringObjectWriter extends BaseWriter {
         if (pObject.isDoNotEncrypt()) {
             writeRaw(writeable.getHexString(), output);
         } else {
-            write(new HexStringObject(writeable.toString(), pObject.getReference(), securityManager), output);
+            write(new HexStringObject(writeable.toString().replaceAll(HEX_REGEX, HEX_REPLACEMENT),
+                    pObject.getReference(), securityManager), output);
         }
     }
 
@@ -37,7 +38,7 @@ public class HexStringObjectWriter extends BaseWriter {
 
     public void writeRaw(String writeable, CountingOutputStream output) throws IOException {
         output.write(BEGIN_HEX_STRING);
-        byte[] textBytes = Utils.convertByteCharSequenceToByteArray(writeable);
+        byte[] textBytes = Utils.convertByteCharSequenceToByteArray(writeable.replaceAll(HEX_REGEX, HEX_REPLACEMENT));
         output.write(textBytes);
         output.write(END_HEX_STRING);
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/LiteralStringWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/LiteralStringWriter.java
@@ -2,6 +2,9 @@ package org.icepdf.core.util.updater.writeables;
 
 import org.icepdf.core.io.CountingOutputStream;
 import org.icepdf.core.pobjects.LiteralStringObject;
+import org.icepdf.core.pobjects.PObject;
+import org.icepdf.core.pobjects.security.SecurityManager;
+import org.icepdf.core.util.Utils;
 
 import java.io.IOException;
 
@@ -13,13 +16,30 @@ public class LiteralStringWriter extends BaseWriter {
     protected static final String LITERAL_REGEX = "(?=[()\\\\])";
     protected static final String LITERAL_REPLACEMENT = "\\\\";
 
-    public void write(LiteralStringObject writeable, CountingOutputStream output) throws IOException {
-        write(writeable.getLiteralString(), output);
+    public LiteralStringWriter(SecurityManager securityManager) {
+        this.securityManager = securityManager;
+    }
+
+    public void write(PObject pObject, CountingOutputStream output) throws IOException {
+        LiteralStringObject writeable = (LiteralStringObject) pObject.getObject();
+        if (pObject.isDoNotEncrypt()) {
+            writeRaw(writeable.getLiteralString(), output);
+        } else {
+            write(new LiteralStringObject(writeable.toString(), pObject.getReference(), securityManager).toString(),
+                    output);
+        }
     }
 
     public void write(String writeable, CountingOutputStream output) throws IOException {
         output.write(BEGIN_LITERAL_STRING);
         writeByteString(writeable.replaceAll(LITERAL_REGEX, LITERAL_REPLACEMENT), output);
+        output.write(END_LITERAL_STRING);
+    }
+
+    public void writeRaw(String writeable, CountingOutputStream output) throws IOException {
+        output.write(BEGIN_LITERAL_STRING);
+        byte[] textBytes = Utils.convertByteCharSequenceToByteArray(writeable);
+        output.write(textBytes);
         output.write(END_LITERAL_STRING);
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/LiteralStringWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/LiteralStringWriter.java
@@ -25,7 +25,8 @@ public class LiteralStringWriter extends BaseWriter {
         if (pObject.isDoNotEncrypt()) {
             writeRaw(writeable.getLiteralString(), output);
         } else {
-            write(new LiteralStringObject(writeable.toString(), pObject.getReference(), securityManager).toString(),
+            write(new LiteralStringObject(writeable.toString().replaceAll(LITERAL_REGEX, LITERAL_REPLACEMENT),
+                            pObject.getReference(), securityManager).toString(),
                     output);
         }
     }
@@ -38,7 +39,8 @@ public class LiteralStringWriter extends BaseWriter {
 
     public void writeRaw(String writeable, CountingOutputStream output) throws IOException {
         output.write(BEGIN_LITERAL_STRING);
-        byte[] textBytes = Utils.convertByteCharSequenceToByteArray(writeable);
+        byte[] textBytes = Utils.convertByteCharSequenceToByteArray(
+                writeable.replaceAll(LITERAL_REGEX, LITERAL_REPLACEMENT));
         output.write(textBytes);
         output.write(END_LITERAL_STRING);
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/PObjectWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/PObjectWriter.java
@@ -17,7 +17,7 @@ public class PObjectWriter extends BaseWriter {
         writeInteger(ref.getGenerationNumber(), output);
         output.write(SPACE);
         output.write(BEGIN_OBJECT);
-        writeValue(obj, output);
+        writeValue(writeable, output);
         output.write(END_OBJECT);
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/StreamWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/StreamWriter.java
@@ -2,6 +2,7 @@ package org.icepdf.core.util.updater.writeables;
 
 import org.icepdf.core.io.CountingOutputStream;
 import org.icepdf.core.pobjects.DictionaryEntries;
+import org.icepdf.core.pobjects.PObject;
 import org.icepdf.core.pobjects.Reference;
 import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.pobjects.security.SecurityManager;
@@ -65,7 +66,7 @@ public class StreamWriter extends BaseWriter {
 
         obj.getEntries().put(Stream.LENGTH_KEY, outputData.length);
         obj.getEntries().put(Stream.FORM_TYPE_KEY, 1);
-        writeDictionary(obj, output);
+        writeDictionary(new PObject(obj, ref), output);
         output.write(NEWLINE);
         output.write(BEGIN_STREAM);
         output.write(outputData);

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/TrailerWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/TrailerWriter.java
@@ -3,6 +3,7 @@ package org.icepdf.core.util.updater.writeables;
 import org.icepdf.core.io.CountingOutputStream;
 import org.icepdf.core.pobjects.Dictionary;
 import org.icepdf.core.pobjects.DictionaryEntries;
+import org.icepdf.core.pobjects.PObject;
 import org.icepdf.core.pobjects.PTrailer;
 import org.icepdf.core.pobjects.structure.CrossReferenceRoot;
 
@@ -24,7 +25,7 @@ public class TrailerWriter extends BaseTableWriter {
         }
 
         output.write(TRAILER);
-        this.writeDictionary(new Dictionary(null, newTrailer), output);
+        this.writeDictionary(new PObject(new Dictionary(null, newTrailer), null), output);
         output.write(STARTXREF);
         this.writeLong(xrefPosition, output);
         output.write(COMMENT_EOF);
@@ -41,7 +42,7 @@ public class TrailerWriter extends BaseTableWriter {
         // todo update the ID with something fun.
 
         output.write(TRAILER);
-        this.writeDictionary(new Dictionary(null, newTrailer), output);
+        this.writeDictionary(new PObject(new Dictionary(null, newTrailer), null, true), output);
         output.write(STARTXREF);
         this.writeLong(xrefPosition, output);
         output.write(COMMENT_EOF);

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/TrailerWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/TrailerWriter.java
@@ -25,7 +25,7 @@ public class TrailerWriter extends BaseTableWriter {
         }
 
         output.write(TRAILER);
-        this.writeDictionary(new PObject(new Dictionary(null, newTrailer), null), output);
+        this.writeDictionary(new PObject(new Dictionary(null, newTrailer), null, true), output);
         output.write(STARTXREF);
         this.writeLong(xrefPosition, output);
         output.write(COMMENT_EOF);

--- a/core/core-awt/src/test/java/org/icepdf/core/util/updater/RewriteTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/util/updater/RewriteTest.java
@@ -5,6 +5,7 @@ import org.icepdf.core.pobjects.Document;
 import org.icepdf.core.pobjects.Page;
 import org.icepdf.core.pobjects.PageTree;
 import org.icepdf.core.pobjects.annotations.Annotation;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -124,15 +125,16 @@ public class RewriteTest {
 
     @DisplayName("full write - write and open and fail if there is an exception loading the new file")
     @Test
-//    @Disabled
+    @Disabled
     public void testAnnotationFullUpdate() {
-        String testDirectory = "/home/pcorless/dev/pdf-qa/metrics/full-monty/";
+        String testDirectory = "/test-suite-path/";
         Path contentPath = Paths.get(testDirectory);
         if (Files.isDirectory(contentPath)) {
             try (DirectoryStream<Path> stream = Files.newDirectoryStream(contentPath)) {
+                int count = 0;
                 for (Path entry : stream) {
                     if (entry.getFileName().toString().toLowerCase().endsWith(".pdf")) {
-                        System.out.println("rewriting: " + entry.toString());
+                        System.out.println("rewriting: " + entry.toString() + " " + count++);
                         Document document = new Document();
                         document.setFile(entry.toString());
 

--- a/core/core-awt/src/test/java/org/icepdf/core/util/updater/RewriteTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/util/updater/RewriteTest.java
@@ -126,7 +126,7 @@ public class RewriteTest {
     @DisplayName("full write - write and open and fail if there is an exception loading the new file")
     @Test
     @Disabled
-    public void testAnnotationFullUpdate() {
+    public void testBatchFullUpdate() {
         String testDirectory = "/test-suite-path/";
         Path contentPath = Paths.get(testDirectory);
         if (Files.isDirectory(contentPath)) {


### PR DESCRIPTION
Problem
- issues writing full document writes when document is encrypted. 
- incremental updates always encrypted the annotation edits on the fly storing the encrypted value, this can't be done for full writes.   This is further compounded by the fact that object coming out of compress Object streams have values that aren't enccrypted.  
- so we need to make sure all objects are unencrypted, no exception then we can write them all at once. 

Solution
- add parser hint to make sure we don't encrypt the /encrypt dictionary and trailer fileID. 
- normalized all the annotation class so we store values unencrypted. 
- make sure we escape encrypted string.
- update the parser and writer to keep track of the parent PObject so we have access the reference when encryption starts. 
- 