### PR TITLE
GH-323 fix file descriptor leak on window

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
@@ -193,18 +193,21 @@ public class Document {
 
         File file = new File(filepath);
         try {
-            randomAccessFile = new RandomAccessFile(file, "r");
-            documentFileChannel = randomAccessFile.getChannel();
-            long fileSize = documentFileChannel.size();
-            // Create an in memory file opy
-            ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
-            documentFileChannel.read(buffer);
-            buffer.flip();
-            setInputStream(buffer);
+            setInputStream(copyFileToByteBuffer(file));
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Failed to set document file path", e);
             throw e;
         }
+    }
+
+    private ByteBuffer copyFileToByteBuffer(File file) throws IOException {
+        randomAccessFile = new RandomAccessFile(file, "r");
+        documentFileChannel = randomAccessFile.getChannel();
+        long fileSize = documentFileChannel.size();
+        ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
+        documentFileChannel.read(buffer);
+        buffer.flip();
+        return buffer;
     }
 
     /**
@@ -331,14 +334,7 @@ public class Document {
             setDocumentCachedFilePath(tempFile.getAbsolutePath());
 
             try {
-                randomAccessFile = new RandomAccessFile(tempFile, "r");
-                documentFileChannel = randomAccessFile.getChannel();
-                long fileSize = documentFileChannel.size();
-                // Create an in memory file opy
-                ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
-                documentFileChannel.read(buffer);
-                buffer.flip();
-                setInputStream(buffer);
+                setInputStream(copyFileToByteBuffer(tempFile));
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "Failed to set document input stream", e);
                 throw e;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
@@ -275,14 +275,7 @@ public class Document {
             setDocumentCachedFilePath(tempFile.getAbsolutePath());
 
             try {
-                randomAccessFile = new RandomAccessFile(tempFile, "r");
-                documentFileChannel = randomAccessFile.getChannel();
-                long fileSize = documentFileChannel.size();
-                // Create an in memory file opy
-                ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
-                documentFileChannel.read(buffer);
-                buffer.flip();
-                setInputStream(buffer);
+                setInputStream(copyFileToByteBuffer(tempFile));
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "Failed to set document input stream", e);
                 throw e;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
@@ -195,9 +195,12 @@ public class Document {
         try {
             randomAccessFile = new RandomAccessFile(file, "r");
             documentFileChannel = randomAccessFile.getChannel();
-            ByteBuffer mappedFileByteBuffer = documentFileChannel.map(
-                    FileChannel.MapMode.READ_ONLY, 0, documentFileChannel.size());
-            setInputStream(mappedFileByteBuffer);
+            long fileSize = documentFileChannel.size();
+            // Create an in memory file opy
+            ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
+            documentFileChannel.read(buffer);
+            buffer.flip();
+            setInputStream(buffer);
         } catch (Exception e) {
             logger.log(Level.SEVERE, "Failed to set document file path", e);
             throw e;
@@ -271,9 +274,12 @@ public class Document {
             try {
                 randomAccessFile = new RandomAccessFile(tempFile, "r");
                 documentFileChannel = randomAccessFile.getChannel();
-                ByteBuffer mappedFileByteBuffer = documentFileChannel.map(
-                        FileChannel.MapMode.READ_ONLY, 0, documentFileChannel.size());
-                setInputStream(mappedFileByteBuffer);
+                long fileSize = documentFileChannel.size();
+                // Create an in memory file opy
+                ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
+                documentFileChannel.read(buffer);
+                buffer.flip();
+                setInputStream(buffer);
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "Failed to set document input stream", e);
                 throw e;
@@ -327,9 +333,12 @@ public class Document {
             try {
                 randomAccessFile = new RandomAccessFile(tempFile, "r");
                 documentFileChannel = randomAccessFile.getChannel();
-                ByteBuffer mappedFileByteBuffer = documentFileChannel.map(
-                        FileChannel.MapMode.READ_ONLY, 0, documentFileChannel.size());
-                setInputStream(mappedFileByteBuffer);
+                long fileSize = documentFileChannel.size();
+                // Create an in memory file opy
+                ByteBuffer buffer = ByteBuffer.allocate((int) fileSize);
+                documentFileChannel.read(buffer);
+                buffer.flip();
+                setInputStream(buffer);
             } catch (Exception e) {
                 logger.log(Level.SEVERE, "Failed to set document input stream", e);
                 throw e;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
@@ -112,8 +112,9 @@ public class Document {
     private static boolean isCachingEnabled;
 
     private final Library library;
-    // todo put file channel input library?
+
     private FileChannel documentFileChannel;
+    private RandomAccessFile randomAccessFile;
     private ByteBuffer documentByteBuffer;
     private CrossReferenceRoot crossReferenceRoot;
 
@@ -191,7 +192,8 @@ public class Document {
         setDocumentOrigin(filepath);
 
         File file = new File(filepath);
-        try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+        try {
+            randomAccessFile = new RandomAccessFile(file, "r");
             documentFileChannel = randomAccessFile.getChannel();
             ByteBuffer mappedFileByteBuffer = documentFileChannel.map(
                     FileChannel.MapMode.READ_ONLY, 0, documentFileChannel.size());
@@ -266,7 +268,8 @@ public class Document {
 
             setDocumentCachedFilePath(tempFile.getAbsolutePath());
 
-            try (RandomAccessFile randomAccessFile = new RandomAccessFile(tempFile, "r")) {
+            try {
+                randomAccessFile = new RandomAccessFile(tempFile, "r");
                 documentFileChannel = randomAccessFile.getChannel();
                 ByteBuffer mappedFileByteBuffer = documentFileChannel.map(
                         FileChannel.MapMode.READ_ONLY, 0, documentFileChannel.size());
@@ -321,7 +324,8 @@ public class Document {
 
             setDocumentCachedFilePath(tempFile.getAbsolutePath());
 
-            try (RandomAccessFile randomAccessFile = new RandomAccessFile(tempFile, "r")) {
+            try {
+                randomAccessFile = new RandomAccessFile(tempFile, "r");
                 documentFileChannel = randomAccessFile.getChannel();
                 ByteBuffer mappedFileByteBuffer = documentFileChannel.map(
                         FileChannel.MapMode.READ_ONLY, 0, documentFileChannel.size());
@@ -530,13 +534,14 @@ public class Document {
      * Dispose of Document, freeing up all used resources.
      */
     public void dispose() {
-
-        if (documentFileChannel != null) {
+        // clean up file it will clean up any file channels and file descriptors too
+        if (randomAccessFile != null) {
             try {
-                documentFileChannel.close();
+                randomAccessFile.close();
             } catch (IOException e) {
-                logger.log(Level.FINE, "Error closing document input stream.", e);
+                logger.log(Level.FINE, "Error closing document random access file.", e);
             }
+            randomAccessFile = null;
             documentFileChannel = null;
         }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/DocumentBuilder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/DocumentBuilder.java
@@ -43,7 +43,7 @@ public class DocumentBuilder {
                         document,
                         out,
                         documentLength);
-
+                channel.close();
                 return documentLength + appendedLength;
             }
         } catch (IOException e) {

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/FullUpdater.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/FullUpdater.java
@@ -83,6 +83,7 @@ public class FullUpdater {
                 writer.writeFullTrailer();
             }
         }
+        output.close();
 
         return writer.getBytesWritten();
     }


### PR DESCRIPTION
- it's document in a few JDK bug tracks but the basic problem is there appears to be a file descriptor leak on Windows when using 
```
ByteBuffer mappedFileByteBuffer = documentFileChannel.map(
    FileChannel.MapMode.READ_ONLY, 0, documentFileChannel.size());
```
Reworked the file copy to play more nicely with the windows JDK. 