### PR TITLE
GH-327 markup annotation content escaping

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/AbstractStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/AbstractStringObject.java
@@ -28,7 +28,6 @@ public abstract class AbstractStringObject implements StringObject {
         }
     }
 
-
     /**
      * Decrypts or encrypts a string.
      *

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/AbstractStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/AbstractStringObject.java
@@ -1,0 +1,75 @@
+package org.icepdf.core.pobjects;
+
+import org.icepdf.core.pobjects.security.SecurityManager;
+import org.icepdf.core.util.Utils;
+
+public abstract class AbstractStringObject implements StringObject {
+
+    // Reference is need for standard encryption
+    protected Reference reference;
+    // if isModified, string is always unencrypted, otherwise is the raw string data which can be
+    // encrypted or not.
+    protected StringBuilder stringData;
+
+    // modified string need to be encrypted when writing to file.
+    protected boolean isModified;
+
+    /**
+     * Gets the decrypted stringData value of the data using the key provided by the
+     * security manager.
+     *
+     * @param securityManager security manager associated with parent document.
+     */
+    public String getDecryptedLiteralString(SecurityManager securityManager) {
+        if (!isModified) {
+            return encryption(getLiteralString(), reference, securityManager);
+        } else {
+            return getLiteralString();
+        }
+    }
+
+
+    /**
+     * Decrypts or encrypts a string.
+     *
+     * @param string          string to encrypt or decrypt
+     * @param securityManager security manager for document.
+     * @return encrypted or decrypted string, depends on value of decrypt param.
+     */
+    public String encryption(String string, Reference reference, SecurityManager securityManager) {
+        // get the security manager instance
+        if (securityManager != null && reference != null) {
+            // get the key
+            byte[] key = securityManager.getDecryptionKey();
+
+            // convert string to bytes.
+            byte[] textBytes = Utils.convertByteCharSequenceToByteArray(string);
+
+            // Decrypt/encrypt String
+            textBytes = securityManager.decrypt(reference, key, textBytes);
+
+            // convert back to a string
+            return Utils.convertByteArrayToByteString(textBytes);
+        }
+        return string;
+    }
+
+    /**
+     * Sets the parent PDF object's reference.
+     *
+     * @param reference parent object reference.
+     */
+    public void setReference(Reference reference) {
+        this.reference = reference;
+    }
+
+    /**
+     * Indicates a string has been modified.
+     *
+     * @return string has been modified and may no longer be encrypted.
+     */
+    @Override
+    public boolean isModified() {
+        return isModified;
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Dictionary.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Dictionary.java
@@ -224,8 +224,7 @@ public class Dictionary {
      * @return string value of the newly set string which will always be decrypted.
      */
     protected String setString(final Name key, String value) {
-        // make sure we store an encrypted documents string as encrypted
-        entries.put(key, new LiteralStringObject(value));
+        entries.put(key, new LiteralStringObject(value, getPObjectReference()));
         return value;
     }
 
@@ -237,8 +236,7 @@ public class Dictionary {
      * @return string value of the newly set string which will always be decrypted.
      */
     protected String setHexString(final Name key, String value) {
-        // make sure we store an encrypted documents string as encrypted
-        entries.put(key, new HexStringObject(value));
+        entries.put(key, HexStringObject.createHexString(value));
         return value;
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/LiteralStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/LiteralStringObject.java
@@ -36,7 +36,7 @@ public class LiteralStringObject extends AbstractStringObject {
      * <p>Creates a new literal string object so that it represents the same
      * sequence of character data specified by the argument.</p>
      *
-     * Crated via the content and object parsers.
+     * Created via the content and object parsers.
      *
      * @param string the initial contents of the literal string object
      */

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/LiteralStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/LiteralStringObject.java
@@ -17,7 +17,6 @@ package org.icepdf.core.pobjects;
 
 import org.icepdf.core.pobjects.fonts.Font;
 import org.icepdf.core.pobjects.fonts.FontFile;
-import org.icepdf.core.pobjects.security.SecurityManager;
 import org.icepdf.core.util.Utils;
 
 /**
@@ -27,28 +26,22 @@ import org.icepdf.core.util.Utils;
  *
  * @since 2.0
  */
-public class LiteralStringObject implements StringObject {
-
-    // core data used to represent the literal string information
-    private final StringBuilder stringData;
+public class LiteralStringObject extends AbstractStringObject {
 
     private static final char[] hexChar = {'0', '1', '2', '3', '4', '5', '6',
             '7', '8', '9', 'a', 'b', 'c', 'd',
             'e', 'f'};
-    // Reference is need for standard encryption
-    Reference reference;
 
     /**
      * <p>Creates a new literal string object so that it represents the same
-     * sequence of bytes as in the bytes argument.  In other words, the
-     * initial content of the literal string is the characters represented
-     * by the byte data.</p>
+     * sequence of character data specified by the argument.</p>
      *
-     * @param bytes array of bytes which will be interpreted as literal
-     *              character data.
+     * Crated via the content and object parsers.
+     *
+     * @param string the initial contents of the literal string object
      */
-    public LiteralStringObject(byte[] bytes) {
-        this(new StringBuilder(bytes.length).append(new String(bytes)));
+    public LiteralStringObject(String string) {
+        stringData = new StringBuilder(string);
     }
 
     public LiteralStringObject(StringBuilder chars, boolean dif) {
@@ -57,41 +50,19 @@ public class LiteralStringObject implements StringObject {
 
     /**
      * <p>Creates a new literal string object so that it represents the same
-     * sequence of character data specifed by the argument.</p>
-     *
-     * @param string the initial contents of the literal string object
-     */
-    public LiteralStringObject(String string) {
-        // append string data
-        // escape the string for any special characters.
-        //   \(  - left parenthesis
-        //   \)  - right parenthesis
-        //   \\  - backslash
-        stringData = new StringBuilder(string.replaceAll("(?=[()\\\\])", "\\\\"));
-    }
-
-    /**
-     * <p>Creates a new literal string object so that it represents the same
-     * sequence of character data specified by the arguments.  The string
-     * value is assumed to be unencrypted and will be encrypted.  The
-     * method #LiteralStringObject(String string) should be used if the string
-     * is all ready encrypted. This method is used for creating new
+     * sequence of character data specified by the arguments. This method is used for creating new
      * LiteralStringObject's that are created post document parse, like annotation
      * property values. </p>
      *
      * @param string          the initial contents of the literal string object,
      *                        unencrypted.
      * @param reference       of parent PObject
-     * @param securityManager security manager used ot encrypt the string.
      */
-    public LiteralStringObject(String string, Reference reference,
-                               SecurityManager securityManager) {
-        // append string data
+    public LiteralStringObject(String string, Reference reference) {
         this.reference = reference;
+        this.isModified = true;
         // convert string to octal encoded.
-        string = Utils.convertStringToOctal(string);
-        // decrypt the string.
-        stringData = new StringBuilder(encryption(string, false, securityManager));
+        stringData = new StringBuilder(Utils.convertStringToOctal(string));
     }
 
     /**
@@ -100,6 +71,8 @@ public class LiteralStringObject implements StringObject {
      * characters of the StringBuffer are removed.  This constructor should
      * only be used in the context of the parser which has leading and ending
      * parentheses which are removed by this method.</p>
+     *
+     * called from old Parser used for cmap parsing,  hopefully this can be rmeoved one day.
      *
      * @param stringBuffer the initial contents of the literal string object
      */
@@ -267,70 +240,6 @@ public class LiteralStringObject implements StringObject {
             hh.append(hexChar[charCode & 0x0f]);
         }
         return hh;
-    }
-
-    /**
-     * Sets the parent PDF object's reference.
-     *
-     * @param reference parent object reference.
-     */
-    public void setReference(Reference reference) {
-        this.reference = reference;
-    }
-
-    /**
-     * Sets the parent PDF object's reference.
-     *
-     * @return returns the reference used for encryption.
-     */
-    public Reference getReference() {
-        return reference;
-    }
-
-    /**
-     * Gets the decrypted literal string value of the data using the key provided by the
-     * security manager.
-     *
-     * @param securityManager security manager associated with parent document.
-     */
-    public String getDecryptedLiteralString(SecurityManager securityManager) {
-        return encryption(stringData.toString(), true, securityManager);
-    }
-
-    /**
-     * Decrypts or encrypts a string.
-     *
-     * @param string          string to encrypt or decrypt
-     * @param decrypt         true to decrypt string, false otherwise;
-     * @param securityManager security manager for document.
-     * @return encrypted or decrypted string, depends on value of decrypt param.
-     */
-    public String encryption(String string, boolean decrypt,
-                             SecurityManager securityManager) {
-        // get the security manager instance
-        if (securityManager != null && reference != null) {
-            // get the key
-            byte[] key = securityManager.getDecryptionKey();
-
-            // convert string to bytes.
-            byte[] textBytes =
-                    Utils.convertByteCharSequenceToByteArray(string);
-
-            // Decrypt String
-            if (decrypt) {
-                textBytes = securityManager.decrypt(reference,
-                        key,
-                        textBytes);
-            } else {
-                textBytes = securityManager.encrypt(reference,
-                        key,
-                        textBytes);
-            }
-
-            // convert back to a string
-            return Utils.convertByteArrayToByteString(textBytes);
-        }
-        return string;
     }
 
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/PInfo.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/PInfo.java
@@ -420,7 +420,7 @@ public class PInfo extends Dictionary {
     private LiteralStringObject getEncryptedString(final String value) {
         if (securityManager != null) {
             try {
-                return new LiteralStringObject(value, getPObjectReference(), securityManager);
+                return new LiteralStringObject(value, getPObjectReference());
             } catch (final Exception e){
                 return new LiteralStringObject(value);
             }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/StringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/StringObject.java
@@ -87,7 +87,7 @@ public interface StringObject {
      *                   Composite and Simple font types respectively
      * @param font       font used to render the literal string data.
      * @return StringBuffer which contains all renderaable characters for the
-     *         given font.
+     * given font.
      */
     StringBuilder getLiteralStringBuffer(final int fontFormat, FontFile font);
 
@@ -106,13 +106,6 @@ public interface StringObject {
     void setReference(Reference reference);
 
     /**
-     * Sets the parent PDF object's reference.
-     *
-     * @return returns the reference used for encryption.
-     */
-    Reference getReference();
-
-    /**
      * Gets the decrypted literal string value of the data using the key provided by the
      * security manager.
      *
@@ -120,5 +113,12 @@ public interface StringObject {
      * @return decrypted stream.
      */
     String getDecryptedLiteralString(SecurityManager securityManager);
+
+    /**
+     * Indicated the string data has been modified and may need to be encrypted if persisted
+     *
+     * @return true if the object has been modified.
+     */
+    boolean isModified();
 
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/ActionFactory.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/ActionFactory.java
@@ -65,7 +65,7 @@ public class ActionFactory {
             entries.put(Action.ACTION_TYPE_KEY, Action.ACTION_TYPE_URI);
             // add a null uri string entry
             Reference pObjectReference = stateManager.getNewReferenceNumber();
-            entries.put(URIAction.URI_KEY, new LiteralStringObject("", pObjectReference, library.getSecurityManager()));
+            entries.put(URIAction.URI_KEY, new LiteralStringObject("", pObjectReference));
             URIAction action = new URIAction(library, entries);
             action.setPObjectReference(stateManager.getNewReferenceNumber());
             return action;
@@ -75,7 +75,7 @@ public class ActionFactory {
             entries.put(Action.ACTION_TYPE_KEY, Action.ACTION_TYPE_LAUNCH);
             // add a null file string entry
             Reference pObjectReference = stateManager.getNewReferenceNumber();
-            entries.put(LaunchAction.FILE_KEY, new LiteralStringObject("", pObjectReference, library.getSecurityManager()));
+            entries.put(LaunchAction.FILE_KEY, new LiteralStringObject("", pObjectReference));
             LaunchAction action = new LaunchAction(library, entries);
             action.setPObjectReference(stateManager.getNewReferenceNumber());
             return action;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/LaunchAction.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/LaunchAction.java
@@ -92,8 +92,7 @@ public class LaunchAction extends Action {
      *                     with this launch action.
      */
     public void setExternalFile(String externalFile) {
-        StringObject tmp = new LiteralStringObject(
-                externalFile, getPObjectReference(), library.getSecurityManager());
+        StringObject tmp = new LiteralStringObject(externalFile, getPObjectReference());
         entries.put(FILE_KEY, tmp);
         this.externalFile = externalFile;
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/URIAction.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/URIAction.java
@@ -56,8 +56,7 @@ public class URIAction extends Action {
      * @param URI an string value except null.
      */
     public void setURI(String URI) {
-        StringObject tmp = new LiteralStringObject(
-                URI, getPObjectReference(), library.getSecurityManager());
+        StringObject tmp = new LiteralStringObject(URI, getPObjectReference());
         // StringObject detection should allow writer to pick on encryption.
         entries.put(URIAction.URI_KEY, tmp);
         this.URI = tmp;

--- a/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
@@ -208,7 +208,8 @@ public class Library {
         return new PObject(obj, reference);
     }
 
-    private boolean isSoftReferenceAble(Object object) {
+    private boolean isSoftReferenceAble(PObject pObject) {
+        Object object = pObject.getObject();
         if (object instanceof Dictionary) {
             DictionaryEntries entries = ((Dictionary) object).getEntries();
             Name type = getName(entries, Dictionary.TYPE_KEY);

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/HexStringObjectWriter.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/writeables/HexStringObjectWriter.java
@@ -20,11 +20,11 @@ public class HexStringObjectWriter extends BaseWriter {
     public void write(PObject pObject, CountingOutputStream output) throws IOException {
         HexStringObject writeable = (HexStringObject) pObject.getObject();
         if (pObject.isDoNotEncrypt()) {
-            writeRaw(writeable.toString(), output);
+            writeRaw(writeable.getHexString(), output);
         } else if (securityManager != null) {
             if (writeable.isModified()) {
                 // encryption will take care of any escape issue.
-                String writeableString = writeable.encryption(writeable.toString(), pObject.getReference(),
+                String writeableString = writeable.encryption(writeable.getHexString(), pObject.getReference(),
                         securityManager);
                 writeRaw(writeableString, output);
             } else {
@@ -33,7 +33,7 @@ public class HexStringObjectWriter extends BaseWriter {
             }
         } else {
             // plain string make sure it's properly escaped.
-            writeRaw(writeable.toString(), output);
+            writeRaw(writeable.getHexString(), output);
         }
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/PopupAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/PopupAnnotationComponent.java
@@ -301,14 +301,14 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
     private void buildGUI() {
 
         List<Annotation> annotations = pageViewComponent.getPage().getAnnotations();
-        MarkupAnnotation parentAnnotation = annotation.getParent();
+        selectedMarkupAnnotation = annotation.getParent();
 
         // check first if there are anny annotation that point to this one as
         // an IRT.  If there aren't any then the selectedAnnotation is the parent
         // other wise we need to build out
         DefaultMutableTreeNode root =
                 new DefaultMutableTreeNode("Root");
-        boolean isIRT = buildCommentTree(parentAnnotation, annotations, root);
+        boolean isIRT = buildCommentTree(selectedMarkupAnnotation, annotations, root);
         commentTree = new JTree(root);
         commentTree.setRootVisible(true);
         commentTree.setExpandsSelectedPaths(true);
@@ -330,13 +330,10 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
         // make sure the root node is selected by default.
         commentTree.setSelectionRow(0);
 
-        // Set the
-        selectedMarkupAnnotation = parentAnnotation;
-
         // try and make the popup the same colour as the annotations fill color
         popupBackgroundColor = backgroundColor;
-        if (parentAnnotation != null && parentAnnotation.getColor() != null) {
-            popupBackgroundColor = checkColor(parentAnnotation.getColor());
+        if (selectedMarkupAnnotation != null && selectedMarkupAnnotation.getColor() != null) {
+            popupBackgroundColor = checkColor(selectedMarkupAnnotation.getColor());
         }
 
         // minimize button
@@ -355,8 +352,8 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
 
         // lock button
         privateToggleButton = new JToggleButton();
-        boolean isPrivate = annotation.getParent() != null &&
-                annotation.getParent().getFlagPrivateContents();
+        boolean isPrivate = selectedMarkupAnnotation != null &&
+                selectedMarkupAnnotation.getFlagPrivateContents();
         privateToggleButton.setToolTipText(messageBundle.getString(
                 "viewer.utilityPane.markupAnnotation.view.publicToggleButton.tooltip.label"));
         privateToggleButton.setSelected(isPrivate);
@@ -369,8 +366,8 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
         privateToggleButton.setBorderPainted(true);
 
         // text area edited the selected annotation markup contents.
-        String contents = annotation.getParent() != null ?
-                annotation.getParent().getContents() : "";
+        String contents = selectedMarkupAnnotation != null ?
+                selectedMarkupAnnotation.getContents() : "";
         textArea = new JTextArea(contents != null ? contents : "");
         textArea.setFont(new JLabel().getFont());
         textArea.setWrapStyleWord(true);
@@ -427,8 +424,7 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
         constraints.insets = new Insets(1, 1, 1, 1);
         // user that created the comment is the only one that can actually make it private.
         if (SystemProperties.PRIVATE_PROPERTY_ENABLED) {
-            MarkupAnnotation markupAnnotation = annotation.getParent();
-            if (markupAnnotation != null && userName.equals(markupAnnotation.getTitleText())) {
+            if (selectedMarkupAnnotation != null && userName.equals(selectedMarkupAnnotation.getTitleText())) {
                 addGB(commentPanel, privateToggleButton, 2, 0, 1, 1);
             }
         }
@@ -521,7 +517,7 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
     }
 
     public AnnotationComponent getAnnotationParentComponent() {
-        return findAnnotationComponent(annotation.getParent());
+        return findAnnotationComponent(selectedMarkupAnnotation);
     }
 
     /**
@@ -549,7 +545,7 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
         removeMarkupInReplyTo(selectedMarkupAnnotation.getPObjectReference());
 
 
-        // rebuild the tree, which is easier then pruning at this point
+        // rebuild the tree, which is easier than pruning at this point
         rebuildTree();
         commentPanel.revalidate();
         refreshPopupState();
@@ -786,7 +782,7 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
 
         // check first if there are anny annotation that point to this one as
         // an IRT.  If there aren't any then the selectedAnnotation is the parent
-        // other wise we need to build out
+        // otherwise we need to build out
         DefaultMutableTreeNode root = new DefaultMutableTreeNode("Root");
         boolean isIRT = buildCommentTree(parentAnnotation, annotations, root);
         commentTree.removeTreeSelectionListener(this);
@@ -934,7 +930,7 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
 
     public MarkupAnnotationComponent getMarkupAnnotationComponent() {
         if (annotation != null) {
-            MarkupAnnotation markupAnnotation = annotation.getParent();
+            MarkupAnnotation markupAnnotation = selectedMarkupAnnotation;
             if (markupAnnotation != null) {
                 // find the popup component
                 ArrayList<AbstractAnnotationComponent> annotationComponents = pageViewComponent.getAnnotationComponents();


### PR DESCRIPTION
- corrects an escape issue that was basically double escaping text on re-saves. 
- normalizing a bunch of the encryption handling of StringObjects
- fixes broken weak reference library cache. 