### PR TITLE
GH-336 allows text selection to work on text that is already covered by markup annotation

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/HexStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/HexStringObject.java
@@ -150,7 +150,7 @@ public class HexStringObject extends AbstractStringObject {
      * <p>Gets a hexadecimal StringBuffer representation of this object's data,
      * which is in fact the raw data contained in this object.</p>
      *
-     * @return a StringBufffer representation of the objects data in hexadecimal.
+     * @return a StringBuffer representation of the objects data in hexadecimal.
      */
     public StringBuilder getHexStringBuffer() {
         return stringData;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/SelectionBoxHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/SelectionBoxHandler.java
@@ -194,7 +194,7 @@ public abstract class SelectionBoxHandler extends CommonToolHandler {
         if (comp instanceof PageViewComponentImpl) {
             return (PageViewComponentImpl) comp;
         } else if (comp instanceof MarkupGlueComponent) {
-            comp = comp.getParent();
+            comp = ((MarkupGlueComponent) comp).getMarkupAnnotationComponent().getPageViewComponent();
             if (comp instanceof PageViewComponentImpl) return (PageViewComponentImpl) comp;
         }
         return null;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelectionPageHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelectionPageHandler.java
@@ -62,7 +62,7 @@ public class TextSelectionPageHandler extends TextSelection
     }
 
     /**
-     * When mouse is double clicked we select the word the mouse if over.  When
+     * When mouse is double-clicked we select the word the mouse if over.  When
      * the mouse is triple clicked we select the line of text that the mouse
      * is over.
      */

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupGlueComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupGlueComponent.java
@@ -125,4 +125,7 @@ public class MarkupGlueComponent extends JComponent implements PageViewAnnotatio
         parentPageViewComponent = pageViewComponent;
     }
 
+    public MarkupAnnotationComponent getMarkupAnnotationComponent() {
+        return markupAnnotationComponent;
+    }
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/TextMarkupAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/TextMarkupAnnotationComponent.java
@@ -18,6 +18,7 @@ package org.icepdf.ri.common.views.annotations;
 import org.icepdf.core.pobjects.annotations.TextMarkupAnnotation;
 import org.icepdf.ri.common.views.AbstractPageViewComponent;
 import org.icepdf.ri.common.views.DocumentViewController;
+import org.icepdf.ri.common.views.DocumentViewModel;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
@@ -48,6 +49,10 @@ public class TextMarkupAnnotationComponent extends MarkupAnnotationComponent<Tex
 
     @Override
     public boolean contains(int x, int y) {
+        // avoid interference if text selection tool is selected
+        int toolMode = documentViewController.getDocumentViewModel().getViewToolMode();
+        if (toolMode == DocumentViewModel.DISPLAY_TOOL_TEXT_SELECTION) return false;
+
         boolean contains = super.contains(x, y);
         if (contains && annotation != null && annotation.getMarkupPath() != null) {
             // page space


### PR DESCRIPTION
Allows text selection when markup annotation are present on the screen. 