### PR TITLE
GH-340 fix encoding issues 

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
@@ -3,6 +3,7 @@ package org.icepdf.core.pobjects.fonts.zfont;
 import org.icepdf.core.pobjects.DictionaryEntries;
 import org.icepdf.core.pobjects.Name;
 import org.icepdf.core.pobjects.Reference;
+import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.pobjects.fonts.zfont.cmap.CMap;
 import org.icepdf.core.util.Library;
 
@@ -48,9 +49,18 @@ public class Type0Font extends SimpleFont {
             cMap = CMap.getInstance(name);
             Encoding encoding = Encoding.getInstance((name).getName());
             font = font.deriveFont(encoding, toUnicodeCMap);
+            return;
         }
-        if (cMap != null) {
-            boolean isCMapPredefined = true;
+        Object object = library.getObject(entries, ENCODING_KEY);
+        if (object instanceof Stream) {
+            Stream gidMap = (Stream) object;
+            Name cmapName = library.getName(gidMap.getEntries(), new Name("CMapName"));
+            // update font with oneByte information from the cmap, so far I've only
+            // scene this on a handful of CID font but fix encoding issue in each case.
+            if (cmapName.equals("OneByteIdentityH")) {
+                subTypeFormat = SIMPLE_FORMAT;
+            }
+            return;
         }
     }
 


### PR DESCRIPTION
- a sample wasn't rendering correctly
- on closer inspection the strings were being parsed using the multi-byte code paths.   
- This is normal for CID font but after closer inspection of the font's cmap file there was a property /CMapName OneByteIdentityH that I had never seen before.  
- Adjusted parsing flags appropriately and the file renders correctly.  
- No regression in the QA suite and a few other files where fixed by this finding. 