### PR TITLE
GH-345 icon followup tweaks

### DIFF
--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/DestinationCellRender.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/DestinationCellRender.java
@@ -30,7 +30,7 @@ import java.awt.*;
 @SuppressWarnings("serial")
 public class DestinationCellRender extends DefaultTreeCellRenderer {
 
-    protected static final Icon IMAGE_ICON = Images.getSingleIcon ("page", IconPack.Variant.NONE, Images.IconSize.TINY);
+    protected static final Icon IMAGE_ICON = Images.getSingleIcon("page", IconPack.Variant.NONE, Images.IconSize.TINY);
 
     @Override
     public Component getTreeCellRendererComponent(

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/DropDownButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/DropDownButton.java
@@ -55,10 +55,10 @@ public class DropDownButton extends JButton
         this.imageSize = imageSize;
 
         if (imageName != null) {
-            Images.applyIcons (this, imageName, imageSize);
+            Images.applyIcons(this, imageName, imageSize);
 
-            int h = Images.getHeightValueForIconSize (imageSize);
-            setPreferredSize (new Dimension (h, h));
+            int h = Images.getHeightValueForIconSize(imageSize);
+            setPreferredSize(new Dimension(h, h));
         }
 
         popupMenu = new JPopupMenu();
@@ -76,7 +76,7 @@ public class DropDownButton extends JButton
     @Override
     public void setSelected(boolean b) {
         super.setSelected(b);
-        Images.applyIcon (this, imageName, b ? IconPack.Variant.SELECTED : IconPack.Variant.NORMAL, imageSize);
+        Images.applyIcon(this, imageName, b ? IconPack.Variant.SELECTED : IconPack.Variant.NORMAL, imageSize);
     }
 
     public void add(JMenuItem menuItem, int idx) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
@@ -415,7 +415,8 @@ public class SwingViewBuilder implements ViewBuilder {
         overrideHighlightColor(propertiesManager);
 
         // update View Controller with previewer document page fit and view type info
-        DocumentViewControllerImpl documentViewController = (DocumentViewControllerImpl) viewerController.getDocumentViewController();
+        DocumentViewControllerImpl documentViewController =
+                (DocumentViewControllerImpl) viewerController.getDocumentViewController();
         documentViewController.setDocumentViewType(documentViewType, documentPageFitMode);
 
         buttonFont = bf;
@@ -433,7 +434,7 @@ public class SwingViewBuilder implements ViewBuilder {
         // set default view mode type, fit page, fit width, no-fit.
         this.documentPageFitMode = documentPageFitMode;
         // apply default button size
-        iconSize = Images.getDefaultIconSizeOr (propertiesManager, Images.IconSize.LARGE);
+        iconSize = Images.getDefaultIconSizeOr(propertiesManager, Images.IconSize.LARGE);
     }
 
     /**
@@ -514,8 +515,10 @@ public class SwingViewBuilder implements ViewBuilder {
                 // Generate and register the MacOSAdapter, passing it a hash of all the methods we wish to
                 // use as delegates for various com.apple.eawt.ApplicationListener methods
                 // for legacy OS X,  no longer works on macOS
-                MacOSAdapter.setQuitHandler(viewerController, viewerController.getClass().getDeclaredMethod("exit", (Class[]) null));
-                MacOSAdapter.setAboutHandler(viewerController, viewerController.getClass().getDeclaredMethod("showAboutDialog", (Class[]) null));
+                MacOSAdapter.setQuitHandler(viewerController, viewerController.getClass().getDeclaredMethod("exit",
+                        (Class[]) null));
+                MacOSAdapter.setAboutHandler(viewerController, viewerController.getClass().getDeclaredMethod(
+                        "showAboutDialog", (Class[]) null));
             } catch (Exception e) {
                 logger.log(Level.FINE, "Error occurred while loading the MacOSAdapter:", e);
             }
@@ -577,7 +580,7 @@ public class SwingViewBuilder implements ViewBuilder {
         JMenuItem openURLMenuItem = buildOpenURLMenuItem();
         if (openFileMenuItem != null && openURLMenuItem != null) {
             JMenu openSubMenu = new JMenu(messageBundle.getString("viewer.menu.open.label"));
-            Images.applyIcons (openSubMenu, "open", Images.IconSize.SMALL);
+            Images.applyIcons(openSubMenu, "open", Images.IconSize.SMALL);
             addToMenu(openSubMenu, openFileMenuItem);
             addToMenu(openSubMenu, openURLMenuItem);
             addToMenu(fileMenu, openSubMenu);
@@ -680,7 +683,8 @@ public class SwingViewBuilder implements ViewBuilder {
     public JMenuItem buildExportDocumentFileMenuItem() {
         JMenuItem mi = makeMenuItem(
                 messageBundle.getString("viewer.menu.exportDocument.label"), null, null,
-                buildKeyStroke(KeyEventConstants.KEY_CODE_EXPORT_DOCUMENT, KeyEventConstants.MODIFIER_EXPORT_DOCUMENT, false));
+                buildKeyStroke(KeyEventConstants.KEY_CODE_EXPORT_DOCUMENT, KeyEventConstants.MODIFIER_EXPORT_DOCUMENT
+                        , false));
         if (viewerController != null && mi != null)
             viewerController.setExportDocumentFileMenuItem(mi);
         return mi;
@@ -1024,7 +1028,8 @@ public class SwingViewBuilder implements ViewBuilder {
     }
 
     public JMenuItem buildAdvancedSearchMenuItem() {
-        final JMenuItem mi = makeMenuItem(messageBundle.getString("viewer.toolbar.search.advanced.label"), buildKeyStroke(KeyEventConstants.KEY_CODE_SEARCH, KeyEventConstants.MODIFIER_ADVANCED_SEARCH));
+        final JMenuItem mi = makeMenuItem(messageBundle.getString("viewer.toolbar.search.advanced.label"),
+                buildKeyStroke(KeyEventConstants.KEY_CODE_SEARCH, KeyEventConstants.MODIFIER_ADVANCED_SEARCH));
         if (viewerController != null) {
             viewerController.setAdvancedSearchMenuItem(mi);
         }
@@ -1460,7 +1465,7 @@ public class SwingViewBuilder implements ViewBuilder {
 
         JComboBox<String> tmp = new JComboBox<>();
         tmp.setToolTipText(messageBundle.getString("viewer.toolbar.zoom.tooltip"));
-        tmp.setPreferredSize(new Dimension(90, Images.getHeightValueForIconSize (iconSize)));
+        tmp.setPreferredSize(new Dimension(90, Images.getHeightValueForIconSize(iconSize)));
         for (float zoomLevel : zoomLevels)
             tmp.addItem(NumberFormat.getPercentInstance().format(zoomLevel));
         tmp.setEditable(true);
@@ -1483,7 +1488,7 @@ public class SwingViewBuilder implements ViewBuilder {
         JComboBox<String> tmp = new JComboBox<>();
         tmp.setToolTipText(messageBundle.getString(
                 "viewer.utilityPane.markupAnnotation.view.publicToggleButton.tooltip.label"));
-        tmp.setPreferredSize(new Dimension(65, Images.getHeightValueForIconSize (iconSize)));
+        tmp.setPreferredSize(new Dimension(65, Images.getHeightValueForIconSize(iconSize)));
         tmp.addItem(messageBundle.getString("viewer.utilityPane.markupAnnotation.view.publicToggleButton.label"));
         tmp.addItem(messageBundle.getString("viewer.utilityPane.markupAnnotation.view.privateToggleButton.label"));
         tmp.setEditable(true);
@@ -2290,7 +2295,8 @@ public class SwingViewBuilder implements ViewBuilder {
     }
 
     public JToggleButton buildPageViewSinglePageConToggleButton() {
-        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.continuous.singlePage.label"),
+        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.continuous" +
+                        ".singlePage.label"),
                 messageBundle.getString("viewer.toolbar.pageView.continuous.singlePage.tooltip"),
                 "single_page_column", iconSize,
                 buttonFont);
@@ -2300,7 +2306,8 @@ public class SwingViewBuilder implements ViewBuilder {
     }
 
     public JToggleButton buildPageViewFacingPageConToggleButton() {
-        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.continuous.facingPage.label"),
+        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.continuous" +
+                        ".facingPage.label"),
                 messageBundle.getString("viewer.toolbar.pageView.continuous.facingPage.tooltip"),
                 "two_page_column", iconSize,
                 buttonFont);
@@ -2310,7 +2317,8 @@ public class SwingViewBuilder implements ViewBuilder {
     }
 
     public JToggleButton buildPageViewSinglePageNonConToggleButton() {
-        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.nonContinuous.singlePage.label"),
+        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.nonContinuous" +
+                        ".singlePage.label"),
                 messageBundle.getString("viewer.toolbar.pageView.nonContinuous.singlePage.tooltip"),
                 "single_page", iconSize, buttonFont);
         if (viewerController != null && btn != null)
@@ -2319,7 +2327,8 @@ public class SwingViewBuilder implements ViewBuilder {
     }
 
     public JToggleButton buildPageViewFacingPageNonConToggleButton() {
-        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.nonContinuous.facingPage.label"),
+        JToggleButton btn = makeToolbarToggleButton(messageBundle.getString("viewer.toolbar.pageView.nonContinuous" +
+                        ".facingPage.label"),
                 messageBundle.getString("viewer.toolbar.pageView.nonContinuous.facingPage.tooltip"),
                 "two_page", iconSize, buttonFont);
         if (viewerController != null && btn != null)
@@ -2336,7 +2345,6 @@ public class SwingViewBuilder implements ViewBuilder {
      * @param imageName display image name
      * @param iconSize  image size file extention constant
      * @param font      display font
-     *
      * @return a button with the specified characteristics.
      */
     protected JButton makeToolbarButton(
@@ -2345,7 +2353,7 @@ public class SwingViewBuilder implements ViewBuilder {
         JButton tmp = new JButton(showButtonText ? title : "");
         tmp.setFont(font);
         tmp.setToolTipText(toolTip);
-        Images.applyIcons (tmp, imageName, iconSize);
+        Images.applyIcons(tmp, imageName, iconSize);
         tmp.setRolloverEnabled(true);
         tmp.setBorderPainted(false);
         tmp.setContentAreaFilled(false);
@@ -2354,8 +2362,10 @@ public class SwingViewBuilder implements ViewBuilder {
         return tmp;
     }
 
-    protected AnnotationColorToggleButton makeAnnotationToggleButton(String title, String toolTip, String colorPreferenceKey,
-                                                                     String imageName, Images.IconSize imageSize, Font font, float alpha) {
+    protected AnnotationColorToggleButton makeAnnotationToggleButton(String title, String toolTip,
+                                                                     String colorPreferenceKey,
+                                                                     String imageName, Images.IconSize imageSize,
+                                                                     Font font, float alpha) {
         return new IconAnnotationColorToggleButton(viewerController, messageBundle, title, toolTip,
                 colorPreferenceKey, imageName, imageSize, font, alpha);
     }
@@ -2378,7 +2388,7 @@ public class SwingViewBuilder implements ViewBuilder {
         tmp.setToolTipText(toolTip);
         tmp.setRolloverEnabled(true);
 
-        Images.applyIcons (tmp, imageName, iconSize);
+        Images.applyIcons(tmp, imageName, iconSize);
         //tmp.setBorderPainted(false);
         tmp.setBorder(BorderFactory.createEmptyBorder());
         tmp.setContentAreaFilled(false);
@@ -2404,7 +2414,7 @@ public class SwingViewBuilder implements ViewBuilder {
         JToggleButton tmp = new JToggleButton(showButtonText ? title : "");
         tmp.setFont(font);
         tmp.setToolTipText(toolTip);
-        Images.applyIcons (tmp, imageName, iconSize);
+        Images.applyIcons(tmp, imageName, iconSize);
         //tmp.setBorderPainted(false);
         tmp.setBorder(BorderFactory.createEmptyBorder());
         tmp.setContentAreaFilled(false);
@@ -2441,9 +2451,9 @@ public class SwingViewBuilder implements ViewBuilder {
                                      final Images.IconSize imageSize, KeyStroke accel) {
         JMenuItem jmi = new JMenuItem(text);
         if (imageName != null) {
-            Images.applyIcons (jmi, imageName, imageSize);
+            Images.applyIcons(jmi, imageName, imageSize);
         } else {
-            Images.applyIcon (jmi, "menu_spacer", IconPack.Variant.NONE, Images.IconSize.SMALL);
+            Images.applyIcon(jmi, "menu_spacer", IconPack.Variant.NONE, Images.IconSize.SMALL);
         }
         jmi.setBorder(BorderFactory.createEmptyBorder());
         jmi.setContentAreaFilled(false);
@@ -2500,18 +2510,23 @@ public class SwingViewBuilder implements ViewBuilder {
         PageViewDecorator.pageColor = new Color(preferences.getInt(
                 ViewerPropertiesManager.PROPERTY_PAGE_VIEW_PAPER_COLOR, PageViewDecorator.pageColor.getRGB()));
         PageViewDecorator.pageBorderColor = new Color(preferences.getInt(
-                ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR, PageViewDecorator.pageBorderColor.getRGB()));
+                ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR,
+                PageViewDecorator.pageBorderColor.getRGB()));
         AbstractDocumentView.backgroundColour = new Color(preferences.getInt(
-                ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR, AbstractDocumentView.backgroundColour.getRGB()));
+                ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR,
+                AbstractDocumentView.backgroundColour.getRGB()));
 
         // image reference type.
         ImageReferenceFactory.imageReferenceType = ImageReferenceFactory.getImageReferenceType(
                 preferences.get(ViewerPropertiesManager.PROPERTY_IMAGING_REFERENCE_TYPE, "default"));
 
         // advanced reference types.
-        Library.commonPoolThreads = preferences.getInt(ViewerPropertiesManager.PROPERTY_COMMON_THREAD_COUNT, Library.commonPoolThreads);
-        Library.imagePoolThreads = preferences.getInt(ViewerPropertiesManager.PROPERTY_IMAGE_PROXY_THREAD_COUNT, Library.imagePoolThreads);
-        ImageReference.useProxy = preferences.getBoolean(ViewerPropertiesManager.PROPERTY_IMAGE_PROXY_ENABLED, ImageReference.useProxy);
+        Library.commonPoolThreads = preferences.getInt(ViewerPropertiesManager.PROPERTY_COMMON_THREAD_COUNT,
+                Library.commonPoolThreads);
+        Library.imagePoolThreads = preferences.getInt(ViewerPropertiesManager.PROPERTY_IMAGE_PROXY_THREAD_COUNT,
+                Library.imagePoolThreads);
+        ImageReference.useProxy = preferences.getBoolean(ViewerPropertiesManager.PROPERTY_IMAGE_PROXY_ENABLED,
+                ImageReference.useProxy);
 
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/fonts/FontCellRender.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/fonts/FontCellRender.java
@@ -40,8 +40,8 @@ public class FontCellRender extends DefaultTreeCellRenderer {
                 tree, value, sel,
                 expanded, leaf, row,
                 hasFocus);
-        Icon icon = Images.getSingleIcon ("page", IconPack.Variant.NONE, Images.IconSize.TINY);
-        setOpenIcon (icon);
+        Icon icon = Images.getSingleIcon("page", IconPack.Variant.NONE, Images.IconSize.TINY);
+        setOpenIcon(icon);
         setClosedIcon(icon);
         setLeafIcon(icon);
         return this;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/preferences/GeneralPreferencesPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/preferences/GeneralPreferencesPanel.java
@@ -90,14 +90,16 @@ public class GeneralPreferencesPanel extends JPanel implements PropertyChangeLis
         constraints.insets = new Insets(5, 5, 5, 5);
 
         addGB(generalPreferences, new JLabel(
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.textSelectionColor.label")),
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.textSelectionColor" +
+                                ".label")),
                 0, 0, 1, 1);
         constraints.anchor = GridBagConstraints.EAST;
         addGB(generalPreferences, selectionColorChooserButton, 1, 0, 1, 1);
 
         constraints.anchor = GridBagConstraints.WEST;
         addGB(generalPreferences, new JLabel(
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.searchHighlightColor.label")),
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.searchHighlightColor" +
+                                ".label")),
                 0, 1, 1, 1);
         constraints.anchor = GridBagConstraints.EAST;
         addGB(generalPreferences, highlightColorChooserButton, 1, 1, 1, 1);
@@ -116,7 +118,8 @@ public class GeneralPreferencesPanel extends JPanel implements PropertyChangeLis
         Color paperBorderColor = new Color(preferences.getInt(
                 ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BORDER_COLOR, PageViewDecorator.pageBorderColor.getRGB()));
         Color viewBackgroundColor = new Color(preferences.getInt(
-                ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR, AbstractDocumentView.backgroundColour.getRGB()));
+                ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR,
+                AbstractDocumentView.backgroundColour.getRGB()));
 
         paperShadowColorChooserButton = new ColorChooserButton(paperShadowColor);
         paperShadowColorChooserButton.addPropertyChangeListener("background", this);
@@ -143,28 +146,32 @@ public class GeneralPreferencesPanel extends JPanel implements PropertyChangeLis
 
         constraints.anchor = GridBagConstraints.WEST;
         addGB(pageViewPreferences, new JLabel(
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView.shadowColor.label")),
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView.shadowColor" +
+                                ".label")),
                 0, 0, 1, 1);
         constraints.anchor = GridBagConstraints.EAST;
         addGB(pageViewPreferences, paperShadowColorChooserButton, 1, 0, 1, 1);
 
         constraints.anchor = GridBagConstraints.WEST;
         addGB(pageViewPreferences, new JLabel(
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView.paperColor.label")),
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView.paperColor" +
+                                ".label")),
                 0, 1, 1, 1);
         constraints.anchor = GridBagConstraints.EAST;
         addGB(pageViewPreferences, paperColorChooserButton, 1, 1, 1, 1);
 
         constraints.anchor = GridBagConstraints.WEST;
         addGB(pageViewPreferences, new JLabel(
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView.borderColor.label")),
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView.borderColor" +
+                                ".label")),
                 0, 2, 1, 1);
         constraints.anchor = GridBagConstraints.EAST;
         addGB(pageViewPreferences, paperBorderColorChooserButton, 1, 2, 1, 1);
 
         constraints.anchor = GridBagConstraints.WEST;
         addGB(pageViewPreferences, new JLabel(
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView.backgroundColor.label")),
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.pageView" +
+                                ".backgroundColor.label")),
                 0, 3, 1, 1);
         constraints.anchor = GridBagConstraints.EAST;
         addGB(pageViewPreferences, viewBackgroundColorChooserButton, 1, 3, 1, 1);
@@ -184,12 +191,14 @@ public class GeneralPreferencesPanel extends JPanel implements PropertyChangeLis
 
         ValueLabelItem[] sizeList = new ValueLabelItem[]{
                 new ValueLabelItem(Boolean.TRUE,
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.iconSize.small.label")),
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.iconSize.small" +
+                                ".label")),
                 new ValueLabelItem(Boolean.FALSE,
-                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.iconSize.large.label"))};
+                        messageBundle.getString("viewer.dialog.viewerPreferences.section.general.iconSize.large" +
+                                ".label"))};
         iconSizeComboBox = new JComboBox<>(sizeList);
         iconSizeComboBox.setSelectedIndex(
-                Images.getDefaultIconSizeOr (preferences, Images.IconSize.SMALL) == Images.IconSize.SMALL
+                Images.getDefaultIconSizeOr(preferences, Images.IconSize.SMALL) == Images.IconSize.SMALL
                         ? 0 : 1);
         iconSizeComboBox.addItemListener(this);
         constraints.anchor = GridBagConstraints.WEST;
@@ -213,7 +222,8 @@ public class GeneralPreferencesPanel extends JPanel implements PropertyChangeLis
         Object source = e.getItemSelectable();
         if (source == iconSizeComboBox) {
             preferences.put(ViewerPropertiesManager.PROPERTY_ICON_DEFAULT_SIZE,
-                    iconSizeComboBox.getSelectedIndex() == 0 ? Images.IconSize.SMALL.toString () : Images.IconSize.LARGE.toString ());
+                    iconSizeComboBox.getSelectedIndex() == 0 ? Images.IconSize.SMALL.toString() :
+                            Images.IconSize.LARGE.toString());
         }
     }
 
@@ -228,16 +238,20 @@ public class GeneralPreferencesPanel extends JPanel implements PropertyChangeLis
             preferences.putInt(ViewerPropertiesManager.PROPERTY_TEXT_SELECTION_COLOR, Page.selectionColor.getRGB());
         } else if (source == paperShadowColorChooserButton) {
             PageViewDecorator.pageShadowColor = paperShadowColorChooserButton.getBackground();
-            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_SHADOW_COLOR, PageViewDecorator.pageShadowColor.getRGB());
+            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_SHADOW_COLOR,
+                    PageViewDecorator.pageShadowColor.getRGB());
         } else if (source == paperColorChooserButton) {
             PageViewDecorator.pageColor = paperColorChooserButton.getBackground();
-            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_PAPER_COLOR, PageViewDecorator.pageColor.getRGB());
+            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_PAPER_COLOR,
+                    PageViewDecorator.pageColor.getRGB());
         } else if (source == paperBorderColorChooserButton) {
             PageViewDecorator.pageBorderColor = paperBorderColorChooserButton.getBackground();
-            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR, PageViewDecorator.pageBorderColor.getRGB());
+            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR,
+                    PageViewDecorator.pageBorderColor.getRGB());
         } else if (source == viewBackgroundColorChooserButton) {
             AbstractDocumentView.backgroundColour = viewBackgroundColorChooserButton.getBackground();
-            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR, AbstractDocumentView.backgroundColour.getRGB());
+            preferences.putInt(ViewerPropertiesManager.PROPERTY_PAGE_VIEW_BACKGROUND_COLOR,
+                    AbstractDocumentView.backgroundColour.getRGB());
         }
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/AnnotationSelectionHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/AnnotationSelectionHandler.java
@@ -29,7 +29,7 @@ import java.util.ResourceBundle;
 
 /**
  * The AnnotationSelectionHandler is responsible for deselecting all annotations
- * when the a mouse click event has been fired.
+ * when a mouse click event has been fired.
  *
  * @since 5.0
  */
@@ -56,13 +56,13 @@ public class AnnotationSelectionHandler extends CommonToolHandler
         // create destination menu item
         addDestinationMenuItem = new JMenuItem(messageBundle.getString(
                 "viewer.utilityPane.view.selectionTool.contextMenu.addDestination.label"));
-        Images.applyIcon (addDestinationMenuItem, "destination", IconPack.Variant.NONE, Images.IconSize.MINI);
+        Images.applyIcon(addDestinationMenuItem, "destination", IconPack.Variant.NONE, Images.IconSize.MINI);
         addDestinationMenuItem.addActionListener(this);
         contextMenu.add(addDestinationMenuItem);
         // create free text menu item.
         freeTextMenuItem = new JMenuItem(messageBundle.getString(
                 "viewer.utilityPane.view.selectionTool.contextMenu.addFreeText.label"));
-        Images.applyIcon (freeTextMenuItem, "freetext_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
+        Images.applyIcon(freeTextMenuItem, "freetext_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
         freeTextMenuItem.addActionListener(this);
         contextMenu.add(freeTextMenuItem);
     }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelectionViewHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelectionViewHandler.java
@@ -35,7 +35,7 @@ import java.util.ResourceBundle;
 import java.util.logging.Logger;
 
 /**
- * TextSelectionViewHandler propagates text selection events into the the
+ * TextSelectionViewHandler propagates text selection events into the
  * views child page components.  This handle is required for multi-page text
  * selection.  On mouse click all text selection states are removed.
  *
@@ -135,7 +135,7 @@ public class TextSelectionViewHandler extends TextSelection
         JMenuItem addDestinationMenuItem = new JMenuItem(
                 messageBundle.getString("viewer.utilityPane.view.selectionTool.contextMenu.addDestination.label"));
         addDestinationMenuItem.setEnabled(modifyDocument);
-        Images.applyIcon (addDestinationMenuItem, "destination", IconPack.Variant.NONE, Images.IconSize.MINI);
+        Images.applyIcon(addDestinationMenuItem, "destination", IconPack.Variant.NONE, Images.IconSize.MINI);
         addDestinationMenuItem.addActionListener(e -> {
             // grab the start of the text selection
             Point point = getSelectionBounds(pageComponent).getLocation();
@@ -149,7 +149,7 @@ public class TextSelectionViewHandler extends TextSelection
         JMenuItem addHighlightMenuItem = new JMenuItem(
                 messageBundle.getString("viewer.annotation.popup.addAnnotation.hightlight.label"));
         addHighlightMenuItem.setEnabled(modifyDocument);
-        Images.applyIcon (addHighlightMenuItem, "highlight_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
+        Images.applyIcon(addHighlightMenuItem, "highlight_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
         addHighlightMenuItem.addActionListener(e ->
                 new HighLightAnnotationHandler(controller.getDocumentViewController(), pageComponent)
                         .createMarkupAnnotation(null));
@@ -158,7 +158,7 @@ public class TextSelectionViewHandler extends TextSelection
         JMenuItem addUnderlineMenuItem = new JMenuItem(
                 messageBundle.getString("viewer.annotation.popup.addAnnotation.underline.label"));
         addUnderlineMenuItem.setEnabled(modifyDocument);
-        Images.applyIcon (addUnderlineMenuItem, "underline", IconPack.Variant.NORMAL, Images.IconSize.MINI);
+        Images.applyIcon(addUnderlineMenuItem, "underline", IconPack.Variant.NORMAL, Images.IconSize.MINI);
         addUnderlineMenuItem.addActionListener(e -> new UnderLineAnnotationHandler(controller.getDocumentViewController(), pageComponent)
                 .createMarkupAnnotation(null));
         contextMenu.add(addUnderlineMenuItem);
@@ -166,7 +166,7 @@ public class TextSelectionViewHandler extends TextSelection
         JMenuItem addStrikeOutMenuItem = new JMenuItem(
                 messageBundle.getString("viewer.annotation.popup.addAnnotation.strikeout.label"));
         addStrikeOutMenuItem.setEnabled(modifyDocument);
-        Images.applyIcon (addStrikeOutMenuItem, "strikeout", IconPack.Variant.NORMAL, Images.IconSize.MINI);
+        Images.applyIcon(addStrikeOutMenuItem, "strikeout", IconPack.Variant.NORMAL, Images.IconSize.MINI);
         addStrikeOutMenuItem.addActionListener(e -> new StrikeOutAnnotationHandler(controller.getDocumentViewController(), pageComponent)
                 .createMarkupAnnotation(null));
         contextMenu.add(addStrikeOutMenuItem);
@@ -194,7 +194,7 @@ public class TextSelectionViewHandler extends TextSelection
                     selectedPages.size() > 0) {
                 PageViewComponentImpl pageComp;
                 for (AbstractPageViewComponent selectedPage : selectedPages) {
-                    pageComp = (PageViewComponentImpl)selectedPage;
+                    pageComp = (PageViewComponentImpl) selectedPage;
                     if (pageComp != null) {
                         pageComp.getTextSelectionPageHandler().selectionEnd(modeEvent.getPoint(), pageComp);
                     }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/AnnotationCellRender.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/AnnotationCellRender.java
@@ -42,52 +42,62 @@ public class AnnotationCellRender extends DefaultTreeCellRenderer {
     /**
      * Comment/text annotation icon.
      */
-    public static final Icon ANNOTATION_TEXT_ICON = Images.getSingleIcon ("annot_text_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_TEXT_ICON = Images.getSingleIcon("annot_text_tree", IconPack.Variant.NONE,
+            Images.IconSize.SMALL);
 
     /**
      * Markup highlight annotation icon.
      */
-    public static final Icon ANNOTATION_HIGHLIGHT_ICON = Images.getSingleIcon ("annot_highlight_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_HIGHLIGHT_ICON = Images.getSingleIcon("annot_highlight_tree",
+            IconPack.Variant.NONE, Images.IconSize.SMALL);
 
     /**
      * Markup cross out annotation icon.
      */
-    public static final Icon ANNOTATION_CROSS_OUT_ICON = Images.getSingleIcon ("annot_cross_out_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_CROSS_OUT_ICON = Images.getSingleIcon("annot_cross_out_tree",
+            IconPack.Variant.NONE, Images.IconSize.SMALL);
 
     /**
      * Markup underline annotation icon.
      */
-    public static final Icon ANNOTATION_UNDERLINE_ICON = Images.getSingleIcon ("annot_underline_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_UNDERLINE_ICON = Images.getSingleIcon("annot_underline_tree",
+            IconPack.Variant.NONE, Images.IconSize.SMALL);
 
     /**
      * Free text annotation icon.
      */
-    public static final Icon ANNOTATION_FREE_TEXT_ICON = Images.getSingleIcon ("annot_free_text_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_FREE_TEXT_ICON = Images.getSingleIcon("annot_free_text_tree",
+            IconPack.Variant.NONE, Images.IconSize.SMALL);
 
     /**
      * Line annotation icon.
      */
-    public static final Icon ANNOTATION_LINE_ICON = Images.getSingleIcon ("annot_line_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_LINE_ICON = Images.getSingleIcon("annot_line_tree", IconPack.Variant.NONE,
+            Images.IconSize.SMALL);
 
     /**
      * Circle annotation icon.
      */
-    public static final Icon ANNOTATION_CIRCLE_ICON = Images.getSingleIcon ("annot_circle_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_CIRCLE_ICON = Images.getSingleIcon("annot_circle_tree", IconPack.Variant.NONE
+            , Images.IconSize.SMALL);
 
     /**
      * Square annotation icon.
      */
-    public static final Icon ANNOTATION_SQUARE_ICON = Images.getSingleIcon ("annot_square_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_SQUARE_ICON = Images.getSingleIcon("annot_square_tree", IconPack.Variant.NONE
+            , Images.IconSize.SMALL);
 
     /**
      * Ink annotation icon.
      */
-    public static final Icon ANNOTATION_INK_ICON = Images.getSingleIcon ("annot_ink_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_INK_ICON = Images.getSingleIcon("annot_ink_tree", IconPack.Variant.NONE,
+            Images.IconSize.SMALL);
 
     /**
      * Link annotation icon.
      */
-    public static final Icon ANNOTATION_LINK_ICON = Images.getSingleIcon ("annot_link_tree", IconPack.Variant.NONE, Images.IconSize.SMALL);
+    public static final Icon ANNOTATION_LINK_ICON = Images.getSingleIcon("annot_link_tree", IconPack.Variant.NONE,
+            Images.IconSize.SMALL);
 
     public static final GeneralPath squareColorOutline;
     public static final GeneralPath circleColorOutline;
@@ -192,7 +202,8 @@ public class AnnotationCellRender extends DefaultTreeCellRenderer {
         }
         // dynamic as the validator status changes, so will the icon.
         if (annotation instanceof TextAnnotation) {
-            ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_text_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+            ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_text_c_tree",
+                    IconPack.Variant.NONE, Images.IconSize.SMALL));
             tmp.setColor(annotation.getColor());
             tmp.setColorBound(textColorOutline);
             setIcon(tmp);
@@ -201,23 +212,27 @@ public class AnnotationCellRender extends DefaultTreeCellRenderer {
         } else if (annotation instanceof FreeTextAnnotation) {
             setIcon(ANNOTATION_FREE_TEXT_ICON);
         } else if (annotation instanceof LineAnnotation) {
-            ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_line_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+            ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_line_c_tree",
+                    IconPack.Variant.NONE, Images.IconSize.SMALL));
             tmp.setColor(annotation.getColor(), 1f, false, false);
             tmp.setColorBound(lineColorOutline);
             setIcon(tmp);
         } else if (annotation instanceof SquareAnnotation) {
-            ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_square_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+            ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_square_c_tree",
+                    IconPack.Variant.NONE, Images.IconSize.SMALL));
             tmp.setColor(annotation.getColor(), 1f, false, false);
             tmp.setColorBound(squareColorOutline);
             setIcon(tmp);
         } else if (annotation instanceof CircleAnnotation) {
-            ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_circle_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+            ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_circle_c_tree",
+                    IconPack.Variant.NONE, Images.IconSize.SMALL));
             tmp.setColor(annotation.getColor(), 1f, false, false);
             tmp.setColorBound(circleColorOutline);
             setIcon(tmp);
         } else if (annotation instanceof TextMarkupAnnotation) {
             if (annotation.getSubType().equals(TextMarkupAnnotation.SUBTYPE_HIGHLIGHT)) {
-                ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_highlight_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+                ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_highlight_c_tree",
+                        IconPack.Variant.NONE, Images.IconSize.SMALL));
                 tmp.setColor(annotation.getColor());
                 tmp.setBack(false);
                 tmp.setColorBound(highlightColorOutline);
@@ -225,30 +240,33 @@ public class AnnotationCellRender extends DefaultTreeCellRenderer {
             } else if (annotation.getSubType().equals(TextMarkupAnnotation.SUBTYPE_SQUIGGLY)) {
                 setIcon(ANNOTATION_UNDERLINE_ICON);
             } else if (annotation.getSubType().equals(TextMarkupAnnotation.SUBTYPE_STRIKE_OUT)) {
-                ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_cross_out_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+                ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_cross_out_c_tree",
+                        IconPack.Variant.NONE, Images.IconSize.SMALL));
                 tmp.setColor(annotation.getColor(), 1f, true, true);
                 tmp.setColorBound(strikeOutColorOutline);
                 setIcon(tmp);
             } else if (annotation.getSubType().equals(TextMarkupAnnotation.SUBTYPE_UNDERLINE)) {
-                ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_underline_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+                ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_underline_c_tree",
+                        IconPack.Variant.NONE, Images.IconSize.SMALL));
                 tmp.setColor(annotation.getColor(), 1f, true, false);
                 tmp.setColorBound(underlineColorOutline);
                 setIcon(tmp);
             }
         } else if (annotation instanceof InkAnnotation) {
-            ColorOverlayIcon tmp = new ColorOverlayIcon (Images.getSingleIcon ("annot_ink_c_tree", IconPack.Variant.NONE, Images.IconSize.SMALL));
+            ColorOverlayIcon tmp = new ColorOverlayIcon(Images.getSingleIcon("annot_ink_c_tree",
+                    IconPack.Variant.NONE, Images.IconSize.SMALL));
             tmp.setColor(annotation.getColor());
             tmp.setColorBound(inkColorOutline);
             setIcon(tmp);
         } else if (annotation instanceof TextWidgetAnnotation) {
-            Icon tmp = Images.getSingleIcon ("form_highlight", IconPack.Variant.NORMAL, Images.IconSize.SMALL);
+            Icon tmp = Images.getSingleIcon("form_highlight", IconPack.Variant.NORMAL, Images.IconSize.SMALL);
             setIcon(tmp);
         } else if (annotation != null) {
             setLeafIcon(null);
             setOpenIcon(null);
             setClosedIcon(null);
         } else if (value instanceof DefaultMutableTreeNode) {
-            Icon icon = Images.getSingleIcon ("page", IconPack.Variant.NONE, Images.IconSize.TINY);
+            Icon icon = Images.getSingleIcon("page", IconPack.Variant.NONE, Images.IconSize.TINY);
             setOpenIcon(icon);
             setClosedIcon(icon);
             setLeafIcon(icon);
@@ -256,8 +274,8 @@ public class AnnotationCellRender extends DefaultTreeCellRenderer {
         if (PRIVATE_PROPERTY_ENABLED && annotation != null && !(annotation instanceof TextWidgetAnnotation)) {
             final Icon privateIcon;
             privateIcon = annotation.getFlagPrivateContents() ?
-                    Images.getSingleIcon ("lock", IconPack.Variant.NONE, Images.IconSize.TINY) :
-                    Images.getSingleIcon ("unlock", IconPack.Variant.NONE, Images.IconSize.TINY);
+                    Images.getSingleIcon("lock", IconPack.Variant.NONE, Images.IconSize.TINY) :
+                    Images.getSingleIcon("unlock", IconPack.Variant.NONE, Images.IconSize.TINY);
             final CompoundIcon icon = new CompoundIcon(getIcon(), privateIcon);
             setIcon(icon);
         }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/markup/MarkupAnnotationPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/markup/MarkupAnnotationPanel.java
@@ -74,6 +74,7 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
     public enum FilterSubTypeColumn {
         ALL, TEXT, HIGHLIGHT, STRIKEOUT, UNDERLINE, LINE, SQUARE, CIRCLE, INK, FREETEXT
     }
+
     public enum FilterVisibilityColumn {
         ALL, PRIVATE, PUBLIC
     }
@@ -139,41 +140,57 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
         // assemble filter by author
         filterAuthorActions = new ArrayList<>(3);
         filterAuthorActions.add(new FilterAuthorAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byAuthor.all.label"), FilterAuthorColumn.ALL));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byAuthor.all.label"),
+                FilterAuthorColumn.ALL));
         filterAuthorActions.add(new FilterAuthorAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byAuthor.current.label"), FilterAuthorColumn.AUTHOR_CURRENT));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byAuthor.current.label"),
+                FilterAuthorColumn.AUTHOR_CURRENT));
         filterAuthorActions.add(new FilterAuthorAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byAuthor.others.label"), FilterAuthorColumn.AUTHOR_OTHER));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byAuthor.others.label"),
+                FilterAuthorColumn.AUTHOR_OTHER));
         // assemble filter by visibility
         filterVisibilityActions = new ArrayList<>(3);
         filterVisibilityActions.add(new FilterVisibilityAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility.all.label"), FilterVisibilityColumn.ALL));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility.all.label"),
+                FilterVisibilityColumn.ALL));
         filterVisibilityActions.add(new FilterVisibilityAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility.public.label"), FilterVisibilityColumn.PUBLIC));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility.public.label"),
+                FilterVisibilityColumn.PUBLIC));
         filterVisibilityActions.add(new FilterVisibilityAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility.private.label"), FilterVisibilityColumn.PRIVATE));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility.private.label"),
+                FilterVisibilityColumn.PRIVATE));
         // assemble filter by type
         filterTypeActions = new ArrayList<>(10);
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.all.label"), FilterSubTypeColumn.ALL));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.all.label"),
+                FilterSubTypeColumn.ALL));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.text.label"), FilterSubTypeColumn.TEXT));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.text.label"),
+                FilterSubTypeColumn.TEXT));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.highlight.label"), FilterSubTypeColumn.HIGHLIGHT));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.highlight.label"),
+                FilterSubTypeColumn.HIGHLIGHT));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.underline.label"), FilterSubTypeColumn.UNDERLINE));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.underline.label"),
+                FilterSubTypeColumn.UNDERLINE));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.strikeout.label"), FilterSubTypeColumn.STRIKEOUT));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.strikeout.label"),
+                FilterSubTypeColumn.STRIKEOUT));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.line.label"), FilterSubTypeColumn.LINE));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.line.label"),
+                FilterSubTypeColumn.LINE));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.square.label"), FilterSubTypeColumn.SQUARE));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.square.label"),
+                FilterSubTypeColumn.SQUARE));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.circle.label"), FilterSubTypeColumn.CIRCLE));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.circle.label"),
+                FilterSubTypeColumn.CIRCLE));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.ink.label"), FilterSubTypeColumn.INK));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.ink.label"),
+                FilterSubTypeColumn.INK));
         filterTypeActions.add(new FilterTypeAction(messageBundle.getString(
-                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.freeText.label"), FilterSubTypeColumn.FREETEXT));
+                "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byType.freeText.label"),
+                FilterSubTypeColumn.FREETEXT));
 
         preferences = controller.getPropertiesManager().getPreferences();
         buildGUI();
@@ -305,9 +322,11 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
         // append private/public start.
         if (PRIVATE_PROPERTY_ENABLED) {
             if (annotation.getFlagPrivateContents()) {
-                statusLabel.append(messageBundle.getString("viewer.utilityPane.markupAnnotation.view.privateToggleButton.label"));
+                statusLabel.append(messageBundle.getString("viewer.utilityPane.markupAnnotation.view" +
+                        ".privateToggleButton.label"));
             } else {
-                statusLabel.append(messageBundle.getString("viewer.utilityPane.markupAnnotation.view.publicToggleButton.label"));
+                statusLabel.append(messageBundle.getString("viewer.utilityPane.markupAnnotation.view" +
+                        ".publicToggleButton.label"));
             }
         }
         if (colorLabelString != null) {
@@ -378,13 +397,14 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
     protected void buildSortFilterToolBar() {
         JPanel filterSortToolPanel = new JPanel(new GridBagLayout());
 
-        Images.IconSize iconSize = Images.getDefaultIconSizeOr (preferences, Images.IconSize.LARGE);
+        Images.IconSize iconSize = Images.getDefaultIconSizeOr(preferences, Images.IconSize.LARGE);
 
         DropDownButton sortDropDownButton = new DropDownButton(controller, "",
                 messageBundle.getString("viewer.utilityPane.markupAnnotation.toolbar.sort.sortButton.tooltip"),
                 "sort", iconSize, SwingViewBuilder.buildButtonFont());
 
-        String defaultColumn = preferences.get(ViewerPropertiesManager.PROPERTY_ANNOTATION_SORT_COLUMN, SortColumn.PAGE.toString());
+        String defaultColumn = preferences.get(ViewerPropertiesManager.PROPERTY_ANNOTATION_SORT_COLUMN,
+                SortColumn.PAGE.toString());
         ButtonGroup sortMenuGroup = new ButtonGroup();
         JCheckBoxMenuItem sortMenuItem;
         for (Action sortAction : sortActions) {
@@ -411,19 +431,24 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
                 "viewer.utilityPane.markupAnnotation.toolbar.filter.option.byColor.label"));
 
         // build out author submenu, all, current user, other users
-        defaultColumn = preferences.get(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_AUTHOR_COLUMN, FilterAuthorColumn.ALL.toString());
-        filterAuthorAction = buildMenuItemGroup(authorFilterMenuItem, filterAuthorActions, defaultColumn, filterAuthorAction);
+        defaultColumn = preferences.get(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_AUTHOR_COLUMN,
+                FilterAuthorColumn.ALL.toString());
+        filterAuthorAction = buildMenuItemGroup(authorFilterMenuItem, filterAuthorActions, defaultColumn,
+                filterAuthorAction);
 
         // build out visibility submenu, all, public, private
         JMenu visibilityMenuItem = new JMenu(
-                messageBundle.getString("viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility.label"));
+                messageBundle.getString("viewer.utilityPane.markupAnnotation.toolbar.filter.option.byVisibility" +
+                        ".label"));
         defaultColumn = preferences.get(
-                ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_VISIBILITY_COLUMN, FilterVisibilityColumn.ALL.toString());
+                ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_VISIBILITY_COLUMN,
+                FilterVisibilityColumn.ALL.toString());
         filterVisibilityAction = buildMenuItemGroup(
                 visibilityMenuItem, filterVisibilityActions, defaultColumn, filterVisibilityAction);
 
         // build out markup annotation types.
-        defaultColumn = preferences.get(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_TYPE_COLUMN, FilterSubTypeColumn.ALL.toString());
+        defaultColumn = preferences.get(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_TYPE_COLUMN,
+                FilterSubTypeColumn.ALL.toString());
         filterTypeAction = buildMenuItemGroup(typeFilterMenuItem, filterTypeActions, defaultColumn, filterTypeAction);
 
         refreshColorPanel();
@@ -531,7 +556,8 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
         }
     }
 
-    private Action buildMenuItemGroup(JMenuItem menuItem, ArrayList<Action> actions, String defaultColumn, Action currentAction) {
+    private Action buildMenuItemGroup(JMenuItem menuItem, ArrayList<Action> actions, String defaultColumn,
+                                      Action currentAction) {
         ButtonGroup filterTypeMenuGroup = new ButtonGroup();
         JCheckBoxMenuItem checkBoxMenuItem;
         for (Action action : actions) {
@@ -565,7 +591,8 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
     @Override
     public void disposeDocument() {
         markupAnnotationHandlerPanel.disposeDocument();
-        quickPaintAnnotationButton.removePropertyChangeListener(PropertyConstants.ANNOTATION_QUICK_COLOR_CHANGE, controller);
+        quickPaintAnnotationButton.removePropertyChangeListener(PropertyConstants.ANNOTATION_QUICK_COLOR_CHANGE,
+                controller);
     }
 
     protected void sortAndFilterAnnotationData() {
@@ -574,7 +601,8 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
         FilterSubTypeColumn filterType = (FilterSubTypeColumn) filterTypeAction.getValue(COLUMN_PROPERTY);
         FilterAuthorColumn filterAuthor = (FilterAuthorColumn) filterAuthorAction.getValue(COLUMN_PROPERTY);
         Color filterColor = (Color) filterColorAction.getValue(COLUMN_PROPERTY);
-        FilterVisibilityColumn filterVisibility = (FilterVisibilityColumn) filterVisibilityAction.getValue(COLUMN_PROPERTY);
+        FilterVisibilityColumn filterVisibility =
+                (FilterVisibilityColumn) filterVisibilityAction.getValue(COLUMN_PROPERTY);
         filterDropDownButton.setSelected(!filterAuthor.equals(FilterAuthorColumn.ALL) ||
                 !filterType.equals(FilterSubTypeColumn.ALL) ||
                 filterColor != null);
@@ -641,7 +669,8 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
             preferences.putBoolean(PROPERTY_SEARCH_MARKUP_PANEL_REGEX_ENABLED, regexMenuItem.isSelected());
         } else if (source == caseSensitiveMenutItem) {
             regexMenuItem.setEnabled(!caseSensitiveMenutItem.isSelected());
-            preferences.putBoolean(PROPERTY_SEARCH_MARKUP_PANEL_CASE_SENSITIVE_ENABLED, caseSensitiveMenutItem.isSelected());
+            preferences.putBoolean(PROPERTY_SEARCH_MARKUP_PANEL_CASE_SENSITIVE_ENABLED,
+                    caseSensitiveMenutItem.isSelected());
         }
     }
 
@@ -677,7 +706,8 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
 
         public void actionPerformed(ActionEvent ae) {
             filterTypeAction = this;
-            preferences.put(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_TYPE_COLUMN, getValue(COLUMN_PROPERTY).toString());
+            preferences.put(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_TYPE_COLUMN,
+                    getValue(COLUMN_PROPERTY).toString());
             sortAndFilterAnnotationData();
         }
     }
@@ -690,7 +720,8 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
 
         public void actionPerformed(ActionEvent ae) {
             filterAuthorAction = this;
-            preferences.put(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_AUTHOR_COLUMN, getValue(COLUMN_PROPERTY).toString());
+            preferences.put(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_AUTHOR_COLUMN,
+                    getValue(COLUMN_PROPERTY).toString());
             sortAndFilterAnnotationData();
         }
     }
@@ -704,7 +735,8 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
 
         public void actionPerformed(ActionEvent ae) {
             filterVisibilityAction = this;
-            preferences.put(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_VISIBILITY_COLUMN, getValue(COLUMN_PROPERTY).toString());
+            preferences.put(ViewerPropertiesManager.PROPERTY_ANNOTATION_FILTER_VISIBILITY_COLUMN,
+                    getValue(COLUMN_PROPERTY).toString());
             sortAndFilterAnnotationData();
         }
     }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/attachment/AttachmentPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/attachment/AttachmentPanel.java
@@ -30,8 +30,8 @@ import static org.icepdf.ri.common.utility.attachment.FileTableModel.*;
 /**
  * AttachmentPanel displays a PDF attachments as defined by the Catalogs names tree's EmbeddedFiles entry.
  * The view is pretty straight forward showing properties on all attached files but only allows the opening
- * of .pdf files via a double click of a row.  However it is possible to save any file by selecting a table
- * row and right clicking to expose the context menu for 'Save as..."
+ * of .pdf files via a double click of a row.  However, it is possible to save any file by selecting a table
+ * row and right-clicking to expose the context menu for 'Save as...'
  *
  * @since 6.2
  */
@@ -104,7 +104,7 @@ public class AttachmentPanel extends JPanel implements MouseListener, ActionList
         contextMenu = new JPopupMenu();
         saveAsMenuItem = new JMenuItem(messageBundle.getString(
                 "viewer.utilityPane.attachments.menu.saveAs.label"));
-        Images.applyIcon (saveAsMenuItem, "save", IconPack.Variant.NORMAL, Images.IconSize.SMALL);
+        Images.applyIcon(saveAsMenuItem, "save", IconPack.Variant.NORMAL, Images.IconSize.SMALL);
         saveAsMenuItem.addActionListener(this);
         contextMenu.add(saveAsMenuItem);
 
@@ -196,7 +196,7 @@ public class AttachmentPanel extends JPanel implements MouseListener, ActionList
                         WindowManager.getInstance().newWindow(embeddedDocument, fileName);
                     } catch (IOException e) {
                         logger.log(Level.WARNING, "Error opening PDF file stream " + fileName, e);
-                    } catch( PDFSecurityException e) {
+                    } catch (PDFSecurityException e) {
                         logger.log(Level.WARNING, "Error opening PDF security exception " + fileName, e);
                     }
                 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/outline/OutlinesTree.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/outline/OutlinesTree.java
@@ -40,7 +40,7 @@ public class OutlinesTree extends JTree {
                 TreeSelectionModel.SINGLE_TREE_SELECTION);
         // change the look & feel of the jtree
         DefaultTreeCellRenderer renderer = new DefaultTreeCellRenderer();
-        Icon icon = Images.getSingleIcon ("page", IconPack.Variant.NONE, Images.IconSize.TINY);
+        Icon icon = Images.getSingleIcon("page", IconPack.Variant.NONE, Images.IconSize.TINY);
         renderer.setOpenIcon(icon);
         renderer.setClosedIcon(icon);
         renderer.setLeafIcon(icon);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchFilterButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchFilterButton.java
@@ -32,7 +32,7 @@ public class SearchFilterButton extends DropDownButton {
                 "",
                 controller.getMessageBundle().getString(titleRes),
                 "filter",
-                Images.getDefaultIconSizeOr (controller.getPropertiesManager (), Images.IconSize.LARGE),
+                Images.getDefaultIconSizeOr(controller.getPropertiesManager(), Images.IconSize.LARGE),
                 SwingViewBuilder.buildButtonFont());
         final Preferences preferences = controller.getPropertiesManager().getPreferences();
         boolean isWholePage = preferences.getBoolean(PROPERTY_SEARCH_PANEL_WHOLE_PAGE_ENABLED, false);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureCertTreeNode.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureCertTreeNode.java
@@ -17,7 +17,6 @@ package org.icepdf.ri.common.utility.signatures;
 
 import javax.swing.*;
 import javax.swing.tree.DefaultMutableTreeNode;
-import java.awt.*;
 import java.security.cert.Certificate;
 import java.util.Collection;
 import java.util.logging.Logger;
@@ -43,7 +42,7 @@ public class SignatureCertTreeNode extends DefaultMutableTreeNode {
         return certificateChain;
     }
 
-    public Icon getIcon () {
+    public Icon getIcon() {
         return icon;
     }
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureTreeNode.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureTreeNode.java
@@ -170,11 +170,11 @@ public class SignatureTreeNode extends DefaultMutableTreeNode {
     protected Icon getRootNodeValidityIcon() {
         if (!signatureValidator.isSignedDataModified() && signatureValidator.isCertificateChainTrusted()
                 && signatureValidator.isSignaturesCoverDocumentLength()) {
-            return Images.getSingleIcon ("signature_valid", IconPack.Variant.NONE, Images.IconSize.MINI);
+            return Images.getSingleIcon("signature_valid", IconPack.Variant.NONE, Images.IconSize.MINI);
         } else if (!signatureValidator.isSignedDataModified() && signatureValidator.isSignaturesCoverDocumentLength()) {
-            return Images.getSingleIcon ("signature_caution", IconPack.Variant.NONE, Images.IconSize.MINI);
+            return Images.getSingleIcon("signature_caution", IconPack.Variant.NONE, Images.IconSize.MINI);
         } else {
-            return Images.getSingleIcon ("signature_invalid", IconPack.Variant.NONE, Images.IconSize.MINI);
+            return Images.getSingleIcon("signature_invalid", IconPack.Variant.NONE, Images.IconSize.MINI);
         }
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationPopupMenu.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationPopupMenu.java
@@ -129,16 +129,16 @@ public class MarkupAnnotationPopupMenu extends AnnotationPopup<MarkupAnnotationC
                     messageBundle.getString("viewer.utilityPane.view.selectionTool.contextMenu.addDestination.label"));
             addDestinationMenuItem.setEnabled(modifyDocument);
             addDestinationMenuItem.addActionListener(this);
-            Images.applyIcon (addDestinationMenuItem, "destination", IconPack.Variant.NONE, Images.IconSize.MINI);
+            Images.applyIcon(addDestinationMenuItem, "destination", IconPack.Variant.NONE, Images.IconSize.MINI);
             addFreeTextMenuItem1 = new JMenuItem(
                     messageBundle.getString("viewer.annotation.popup.addAnnotation.freeText.label"));
             addFreeTextMenuItem1.setEnabled(modifyDocument);
-            Images.applyIcon (addFreeTextMenuItem1, "freetext_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
+            Images.applyIcon(addFreeTextMenuItem1, "freetext_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
             addFreeTextMenuItem1.addActionListener(this);
             addFreeTextMenuItem2 = new JMenuItem(
                     messageBundle.getString("viewer.annotation.popup.addAnnotation.freeText.label"));
             addFreeTextMenuItem2.setEnabled(modifyDocument);
-            Images.applyIcon (addFreeTextMenuItem2, "freetext_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
+            Images.applyIcon(addFreeTextMenuItem2, "freetext_annot", IconPack.Variant.NORMAL, Images.IconSize.MINI);
             addFreeTextMenuItem2.addActionListener(this);
             // addition of set status menu
             JMenu submenu = new JMenu(
@@ -189,13 +189,16 @@ public class MarkupAnnotationPopupMenu extends AnnotationPopup<MarkupAnnotationC
 
         if (PRIVATE_PROPERTY_ENABLED) {
             final JMenu submenu = new JMenu(messageBundle.getString("viewer.annotation.popup.privacy.label"));
-            togglePrivacyMenuItem = new JMenuItem(messageBundle.getString("viewer.annotation.popup.privacy.toggle.label"));
+            togglePrivacyMenuItem = new JMenuItem(messageBundle.getString("viewer.annotation.popup.privacy.toggle" +
+                    ".label"));
             togglePrivacyMenuItem.addActionListener(this);
             submenu.add(togglePrivacyMenuItem);
-            setAllPrivateMenuItem = new JMenuItem(messageBundle.getString("viewer.annotation.popup.privacy.all.private.label"));
+            setAllPrivateMenuItem = new JMenuItem(messageBundle.getString("viewer.annotation.popup.privacy.all" +
+                    ".private.label"));
             setAllPrivateMenuItem.addActionListener(this);
             submenu.add(setAllPrivateMenuItem);
-            setAllPublicMenuItem = new JMenuItem(messageBundle.getString("viewer.annotation.popup.privacy.all.public.label"));
+            setAllPublicMenuItem = new JMenuItem(messageBundle.getString("viewer.annotation.popup.privacy.all.public" +
+                    ".label"));
             setAllPublicMenuItem.addActionListener(this);
             submenu.add(setAllPublicMenuItem);
             add(submenu);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/PopupAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/PopupAnnotationComponent.java
@@ -68,7 +68,7 @@ import static org.icepdf.core.util.SystemProperties.INTERACTIVE_ANNOTATIONS;
  * accepted, rejected, cancelled, completed, none. The component can also add
  * replyTo text annotations as well as delete comments.
  * <br>
- * The PopupAnnotationComponent is slightly more complex then the other
+ * The PopupAnnotationComponent is slightly more complex than the other
  * annotations components.  Most annotations let the page pain the annotation
  * but in this case PopupAnnotationComponent paints itself along with controls
  * for editing, replying and deleting TextAnnotation comments.
@@ -913,9 +913,11 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
                 final boolean hasChildren = tn.getChildCount() > 0;
                 if (node instanceof MarkupAnnotationTreeNode) {
                     final Annotation annot = (MarkupAnnotation) ((MarkupAnnotationTreeNode) node).getUserObject();
-                    return hasChildren ? Stream.concat(Stream.of(annot), Collections.list(tn.children()).stream().flatMap(PopupAnnotationComponent::getAllAnnotations)) : Stream.of(annot);
+                    return hasChildren ? Stream.concat(Stream.of(annot),
+                            Collections.list(tn.children()).stream().flatMap(PopupAnnotationComponent::getAllAnnotations)) : Stream.of(annot);
                 } else {
-                    return hasChildren ? Collections.list(tn.children()).stream().flatMap(PopupAnnotationComponent::getAllAnnotations) : Stream.empty();
+                    return hasChildren ?
+                            Collections.list(tn.children()).stream().flatMap(PopupAnnotationComponent::getAllAnnotations) : Stream.empty();
                 }
             } else {
                 return Stream.empty();
@@ -934,7 +936,8 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
             MarkupAnnotation markupAnnotation = selectedMarkupAnnotation;
             if (markupAnnotation != null) {
                 // find the popup component
-                ArrayList<AbstractAnnotationComponent> annotationComponents = pageViewComponent.getAnnotationComponents();
+                ArrayList<AbstractAnnotationComponent> annotationComponents =
+                        pageViewComponent.getAnnotationComponents();
                 Reference compReference;
                 Reference markupReference = markupAnnotation.getPObjectReference();
                 for (AnnotationComponent annotationComponent : annotationComponents) {
@@ -1086,8 +1089,8 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
         minimizeButton.setBackground(popupBackgroundColor);
         privateToggleButton.setBackground(popupBackgroundColor);
         // lock icons.
-        Icon lockedIcon = Images.getSingleIcon ("lock", IconPack.Variant.NONE, Images.IconSize.TINY);
-        Icon unlockedIcon = Images.getSingleIcon ("unlock", IconPack.Variant.NONE, Images.IconSize.TINY);
+        Icon lockedIcon = Images.getSingleIcon("lock", IconPack.Variant.NONE, Images.IconSize.TINY);
+        Icon unlockedIcon = Images.getSingleIcon("unlock", IconPack.Variant.NONE, Images.IconSize.TINY);
         privateToggleButton.setIcon(unlockedIcon);
         privateToggleButton.setPressedIcon(null);
         privateToggleButton.setSelectedIcon(lockedIcon);
@@ -1247,7 +1250,7 @@ public class PopupAnnotationComponent extends AbstractAnnotationComponent<PopupA
         return textArea.getFont().getSize();
     }
 
-    public int getHeaderFontSize(){
+    public int getHeaderFontSize() {
         return titleLabel.getFont().getSize();
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/CertificatePropertiesDialog.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/CertificatePropertiesDialog.java
@@ -51,14 +51,16 @@ public class CertificatePropertiesDialog extends EscapeJDialog {
     protected static ResourceBundle messageBundle;
     private final Collection<? extends Certificate> certs;
 
-    public CertificatePropertiesDialog(Frame parent, ResourceBundle messageBundle, Collection<? extends Certificate> certs) {
+    public CertificatePropertiesDialog(Frame parent, ResourceBundle messageBundle,
+                                       Collection<? extends Certificate> certs) {
         super(parent, true);
         CertificatePropertiesDialog.messageBundle = messageBundle;
         this.certs = certs;
         buildUI();
     }
 
-    public CertificatePropertiesDialog(JDialog parent, ResourceBundle messageBundle, Collection<? extends Certificate> certs) {
+    public CertificatePropertiesDialog(JDialog parent, ResourceBundle messageBundle,
+                                       Collection<? extends Certificate> certs) {
         super(parent, true);
         CertificatePropertiesDialog.messageBundle = messageBundle;
         this.certs = certs;
@@ -80,7 +82,8 @@ public class CertificatePropertiesDialog extends EscapeJDialog {
 
         JPanel buttonPanel = new JPanel();
         buttonPanel.setLayout(new FlowLayout(FlowLayout.TRAILING));
-        JButton closeButton = new JButton(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.closeButton.label"));
+        JButton closeButton = new JButton(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog" +
+                ".closeButton.label"));
         closeButton.setMnemonic("viewer.utilityPane.signatures.cert.dialog.closeButton.mnemonic".charAt(0));
         closeButton.addActionListener(e -> setVisible(false));
         buttonPanel.add(closeButton);
@@ -158,7 +161,8 @@ public class CertificatePropertiesDialog extends EscapeJDialog {
 
     /**
      * Break down DN string into an array used for message format.
-     * Organization: {0}\n Organization Unit :{1}\n Common Name: {2}\n Local: {3}\n State: {4}\n Country:{5}\n Email: {6}
+     * Organization: {0}\n Organization Unit :{1}\n Common Name: {2}\n Local: {3}\n State: {4}\n Country:{5}\n Email:
+     * {6}
      */
     private Object[] formatDNString(X500Name rdName) {
         Object[] output = new Object[7];
@@ -201,7 +205,7 @@ public class CertificatePropertiesDialog extends EscapeJDialog {
         DefaultTreeCellRenderer customCellRenderer = new DefaultTreeCellRenderer();
         customCellRenderer.putClientProperty("html.disable", Boolean.TRUE);
 
-        Icon icon = Images.getSingleIcon ("page", IconPack.Variant.NONE, Images.IconSize.TINY);
+        Icon icon = Images.getSingleIcon("page", IconPack.Variant.NONE, Images.IconSize.TINY);
         customCellRenderer.setOpenIcon(icon);
         customCellRenderer.setClosedIcon(icon);
         customCellRenderer.setLeafIcon(icon);
@@ -264,16 +268,19 @@ public class CertificatePropertiesDialog extends EscapeJDialog {
                 "viewer.utilityPane.signatures.cert.dialog.info.version.value"));
         String certVersion = formatter.format(new Object[]{String.valueOf(cert.getVersion())});
 
-        formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.serialNumber.value"));
+        formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.serialNumber" +
+                ".value"));
         String serialNumber = formatter.format(new Object[]{String.valueOf(cert.getSerialNumber())});
 
-        formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.signatureAlgorithm.value"));
+        formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info" +
+                ".signatureAlgorithm.value"));
         String signatureAlgorithm = formatter.format(new Object[]{cert.getSigAlgName()});
 
         formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.issuer.value"));
         String issuer = formatter.format(formatDNString(new X500Name(cert.getIssuerDN().toString())));
 
-        formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.validity.value"));
+        formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.validity" +
+                ".value"));
         String validity = formatter.format(new Object[]{cert.getNotBefore(), cert.getNotAfter()});
 
         formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.subject.value"));
@@ -285,15 +292,18 @@ public class CertificatePropertiesDialog extends EscapeJDialog {
         try {
             formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.md5.value"));
             md5 = formatter.format(new Object[]{getCertFingerPrint("MD5", cert)});
-            formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.sha1.value"));
+            formatter.applyPattern(messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.sha1" +
+                    ".value"));
             sha1 = formatter.format(new Object[]{getCertFingerPrint("SHA1", cert)});
         } catch (Exception e) {
             logger.log(Level.WARNING, "Failed to get cert fingerprint", e);
         }
         Object[][] data = {
                 {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.version.label"), certVersion},
-                {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.serialNumber.label"), serialNumber},
-                {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.signatureAlgorithm.label"), signatureAlgorithm},
+                {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.serialNumber.label"),
+                        serialNumber},
+                {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.signatureAlgorithm.label"),
+                        signatureAlgorithm},
                 {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.issuer.label"), issuer},
                 {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.validity.label"), validity},
                 {messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.subject.label"), subject},
@@ -338,8 +348,10 @@ class CertificateInfo {
      * @return CN
      */
     private String extractAliasName(X509Certificate cert) {
-        String subjectName = messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.unknownSubject.label");
-        String issuerName = messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.unknownIssuer.label");
+        String subjectName = messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.unknownSubject" +
+                ".label");
+        String issuerName = messageBundle.getString("viewer.utilityPane.signatures.cert.dialog.info.unknownIssuer" +
+                ".label");
         // Extract CN from the DN for each certificate
         try {
             X500Name principal = new X500Name(cert.getSubjectDN().toString());

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignatureValidationPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignatureValidationPanel.java
@@ -25,7 +25,7 @@ import java.awt.*;
 import java.util.ResourceBundle;
 
 /**
- * SignatureValidationPanel shows a summary of the the validation results.
+ * SignatureValidationPanel shows a summary of the validation results.
  */
 public class SignatureValidationPanel extends JPanel {
     // layouts constraint
@@ -33,7 +33,8 @@ public class SignatureValidationPanel extends JPanel {
 
 
     public SignatureValidationPanel(SignatureValidationStatus signatureValidationStatus, ResourceBundle messageBundle,
-                                    SignatureWidgetAnnotation signatureWidgetAnnotation, SignatureValidator signatureValidator,
+                                    SignatureWidgetAnnotation signatureWidgetAnnotation,
+                                    SignatureValidator signatureValidator,
                                     boolean showIcon, boolean showBorder) {
         if (showBorder) {
             setBorder(new TitledBorder(new EtchedBorder(EtchedBorder.LOWERED),
@@ -43,7 +44,7 @@ public class SignatureValidationPanel extends JPanel {
         }
 
         // get the respective image.
-        JLabel validityIconLabel = new JLabel(signatureValidationStatus.getValidityIcon ());
+        JLabel validityIconLabel = new JLabel(signatureValidationStatus.getValidityIcon());
 
         // put it all together.
         setAlignmentY(JPanel.TOP_ALIGNMENT);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignatureValidationStatus.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignatureValidationStatus.java
@@ -27,7 +27,6 @@ import org.icepdf.ri.images.Images;
 
 import javax.security.auth.x500.X500Principal;
 import javax.swing.*;
-import java.net.URL;
 import java.security.cert.X509Certificate;
 import java.text.MessageFormat;
 import java.util.ResourceBundle;
@@ -54,7 +53,8 @@ public class SignatureValidationStatus {
     private final String dictionaryDate;
 
     public SignatureValidationStatus(ResourceBundle messageBundle,
-                                     SignatureWidgetAnnotation signatureWidgetAnnotation, SignatureValidator signatureValidator) {
+                                     SignatureWidgetAnnotation signatureWidgetAnnotation,
+                                     SignatureValidator signatureValidator) {
 
         // build out the string that we need to display
         validity = "viewer.annotation.signature.validation.common.invalid.label";
@@ -114,7 +114,8 @@ public class SignatureValidationStatus {
         dictionaryDate = signatureDictionary.getDate();
     }
 
-    private void validateSignatureNode(SignatureWidgetAnnotation signatureWidgetAnnotation, SignatureValidator signatureValidator) {
+    private void validateSignatureNode(SignatureWidgetAnnotation signatureWidgetAnnotation,
+                                       SignatureValidator signatureValidator) {
         SignatureFieldDictionary fieldDictionary = signatureWidgetAnnotation.getFieldDictionary();
 
         if (fieldDictionary != null) {
@@ -134,11 +135,11 @@ public class SignatureValidationStatus {
     protected Icon getLargeValidityIcon(SignatureValidator signatureValidator) {
         if (!signatureValidator.isSignedDataModified() && signatureValidator.isCertificateChainTrusted()
                 && signatureValidator.isSignaturesCoverDocumentLength()) {
-            return Images.getSingleIcon ("signature_valid", IconPack.Variant.NONE, Images.IconSize.HUGE);
+            return Images.getSingleIcon("signature_valid", IconPack.Variant.NONE, Images.IconSize.HUGE);
         } else if (!signatureValidator.isSignedDataModified() && signatureValidator.isSignaturesCoverDocumentLength()) {
-            return Images.getSingleIcon ("signature_cation", IconPack.Variant.NONE, Images.IconSize.HUGE);
+            return Images.getSingleIcon("signature_cation", IconPack.Variant.NONE, Images.IconSize.HUGE);
         } else {
-            return Images.getSingleIcon ("signature_invalid", IconPack.Variant.NONE, Images.IconSize.HUGE);
+            return Images.getSingleIcon("signature_invalid", IconPack.Variant.NONE, Images.IconSize.HUGE);
         }
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignerSummaryPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignerSummaryPanel.java
@@ -32,7 +32,8 @@ public class SignerSummaryPanel extends JPanel {
     private final GridBagConstraints constraints;
 
     public SignerSummaryPanel(SignatureValidationStatus signatureValidationStatus, ResourceBundle messageBundle,
-                              SignatureWidgetAnnotation signatureWidgetAnnotation, SignatureValidator signatureValidator,
+                              SignatureWidgetAnnotation signatureWidgetAnnotation,
+                              SignatureValidator signatureValidator,
                               boolean showIcon) {
 
         String validity = signatureValidationStatus.getValidity();
@@ -47,7 +48,7 @@ public class SignerSummaryPanel extends JPanel {
         String location = formatter.format(new Object[]{signatureValidationStatus.getDictionaryLocation()});
 
         // get the respective image.
-        JLabel validityIconLabel = new JLabel(signatureValidationStatus.getValidityIcon ());
+        JLabel validityIconLabel = new JLabel(signatureValidationStatus.getValidityIcon());
 
         // put it all together.
         setAlignmentY(JPanel.TOP_ALIGNMENT);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/AbstractColorButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/AbstractColorButton.java
@@ -17,8 +17,6 @@ package org.icepdf.ri.common.widgets;
 
 import org.icepdf.ri.common.views.Controller;
 import org.icepdf.ri.common.widgets.annotations.AnnotationColorPropertyPanel;
-import org.icepdf.ri.images.Images;
-import org.icepdf.ri.util.ViewerPropertiesManager;
 
 import javax.swing.*;
 import javax.swing.event.AncestorEvent;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/ColorOverlayIcon.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/ColorOverlayIcon.java
@@ -29,14 +29,14 @@ public class ColorOverlayIcon implements Icon {
     protected final PaintButtonBase paintButtonBase;
     protected final Icon baseIcon;
 
-    public ColorOverlayIcon (URL location) {
-        baseIcon = new ImageIcon (location);
+    public ColorOverlayIcon(URL location) {
+        baseIcon = new ImageIcon(location);
         paintButtonBase = new PaintButtonBase(null);
     }
 
-    public ColorOverlayIcon (Icon icon) {
+    public ColorOverlayIcon(Icon icon) {
         baseIcon = icon;
-        paintButtonBase = new PaintButtonBase (null);
+        paintButtonBase = new PaintButtonBase(null);
     }
 
     public void setColor(Color color, float alpha) {
@@ -75,9 +75,13 @@ public class ColorOverlayIcon implements Icon {
     }
 
     @Override
-    public int getIconWidth () { return baseIcon.getIconWidth (); }
+    public int getIconWidth() {
+        return baseIcon.getIconWidth();
+    }
 
     @Override
-    public int getIconHeight () { return baseIcon.getIconHeight (); }
+    public int getIconHeight() {
+        return baseIcon.getIconHeight();
+    }
 
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorButton.java
@@ -46,7 +46,7 @@ public abstract class AnnotationColorButton extends AbstractColorButton {
         colorButton.setToolTipText(toolTip);
         colorButton.setRolloverEnabled(true);
 
-        Images.applyIcons (colorButton, imageName, imageSize);
+        Images.applyIcons(colorButton, imageName, imageSize);
         colorButton.setBorder(BorderFactory.createEmptyBorder());
         colorButton.setContentAreaFilled(false);
         colorButton.setFocusPainted(true);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorToggleButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorToggleButton.java
@@ -49,7 +49,7 @@ public abstract class AnnotationColorToggleButton extends AbstractColorButton {
         colorButton.setToolTipText(toolTip);
         colorButton.setRolloverEnabled(true);
 
-        Images.applyIcons (colorButton, imageName, imageSize);
+        Images.applyIcons(colorButton, imageName, imageSize);
         colorButton.setBorder(BorderFactory.createEmptyBorder());
         colorButton.setContentAreaFilled(false);
         colorButton.setFocusPainted(true);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/IconAnnotationColorToggleButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/IconAnnotationColorToggleButton.java
@@ -20,7 +20,8 @@ public class IconAnnotationColorToggleButton extends AnnotationColorToggleButton
 
     public IconAnnotationColorToggleButton(final Controller controller, final ResourceBundle messageBundle,
                                            final String title, final String toolTip, final String colorProperty,
-                                           final String imageName, final Images.IconSize imageSize, final Font font, final float alpha) {
+                                           final String imageName, final Images.IconSize imageSize, final Font font,
+                                           final float alpha) {
         this(controller, messageBundle, title, toolTip, colorProperty, imageName, imageSize, font, alpha, Color.YELLOW);
     }
 
@@ -45,20 +46,22 @@ public class IconAnnotationColorToggleButton extends AnnotationColorToggleButton
         super(controller, messageBundle, title, toolTip, colorProperty, imageName, imageSize, font);
         this.alpha = alpha;
         //final ImageIcon icon = new ImageIcon(Images.get(imageName + "_a" + imageSize + ".png"));
-        final Icon icon = Images.getSingleIcon (imageName, IconPack.Variant.NORMAL, imageSize);
+        final Icon icon = Images.getSingleIcon(imageName, IconPack.Variant.NORMAL, imageSize);
         baseImage = new BufferedImage(icon.getIconWidth(), icon.getIconHeight(), BufferedImage.TYPE_INT_ARGB);
         final Graphics2D g = baseImage.createGraphics();
         g.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
         icon.paintIcon(null, g, 0, 0);
         g.dispose();
         setupLayout();
-        final Color defColor = new Color(ViewerPropertiesManager.getInstance().checkAndStoreIntProperty(colorProperty, defaultColor.getRGB()));
+        final Color defColor = new Color(ViewerPropertiesManager.getInstance().checkAndStoreIntProperty(colorProperty
+                , defaultColor.getRGB()));
         setColor(defColor, false);
     }
 
     @Override
     public void setColor(final Color newColor, final boolean fireChangeEvent) {
-        final BufferedImage newImage = new BufferedImage(baseImage.getWidth(), baseImage.getHeight(), BufferedImage.TYPE_INT_ARGB);
+        final BufferedImage newImage = new BufferedImage(baseImage.getWidth(), baseImage.getHeight(),
+                BufferedImage.TYPE_INT_ARGB);
         for (int x = 0; x < baseImage.getWidth(); ++x) {
             for (int y = 0; y < baseImage.getHeight(); ++y) {
                 final Color orig = new Color(baseImage.getRGB(x, y), true);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/DefaultIconPack.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/DefaultIconPack.java
@@ -20,70 +20,75 @@ import java.net.URL;
  */
 public class DefaultIconPack extends IconPack {
 
-	@Override
-	public VariantPool getProvidedVariants () {
-		return new VariantPool (Variant.DISABLED, Variant.ROLLOVER, Variant.PRESSED, Variant.SELECTED);
-	}
+    @Override
+    public VariantPool getProvidedVariants() {
+        return new VariantPool(Variant.DISABLED, Variant.ROLLOVER, Variant.PRESSED, Variant.SELECTED);
+    }
 
-	@Override
-	public Icon getIcon (String name, Variant variant, Images.IconSize size) throws RuntimeException {
-		String iconSize;
-		switch (size) {
-			case HUGE:
-				iconSize = "_lg";
-				break;
-			case LARGE:
-				iconSize = "_32";
-				break;
-			case SMALL:
-				iconSize = "_24";
-				break;
-			case MINI:
-				iconSize = "_20";
-				break;
-			default:
-				iconSize = "_16";
-				break;
-		}
+    @Override
+    public Icon getIcon(String name, Variant variant, Images.IconSize size) throws RuntimeException {
+        String iconSize;
+        switch (size) {
+            case HUGE:
+                iconSize = "_lg";
+                break;
+            case LARGE:
+                iconSize = "_32";
+                break;
+            case SMALL:
+                iconSize = "_24";
+                break;
+            case MINI:
+                iconSize = "_20";
+                break;
+            default:
+                iconSize = "_16";
+                break;
+        }
 
-		String iconVariant;
-		switch (variant) {
-			case NORMAL:
-				iconVariant = "_a";
-				break;
-			case PRESSED:
-			case DISABLED:
-				iconVariant = "_i";
-				break;
-			case ROLLOVER:
-				iconVariant = "_r";
-				break;
-			case SELECTED:
-				iconVariant = "_selected_a";
-				break;
-			case NONE:
-			default:
-				iconVariant = "";
-				break;
-		}
+        String iconVariant;
+        switch (variant) {
+            case NORMAL:
+                iconVariant = "_a";
+                break;
+            case PRESSED:
+            case DISABLED:
+                iconVariant = "_i";
+                break;
+            case ROLLOVER:
+                iconVariant = "_r";
+                break;
+            case SELECTED:
+                iconVariant = "_selected_a";
+                break;
+            case NONE:
+            default:
+                iconVariant = "";
+                break;
+        }
 
-		URL url = Images.class.getResource (name + iconVariant + iconSize + ".png");
-		if (url == null) {
-			throw new NullPointerException ("Icon " + name + " not found with variant " + variant + ", size " + size + " on classpath; NULL URL returned");
-		}
+        URL url = Images.class.getResource(name + iconVariant + iconSize + ".png");
+        if (url == null) {
+            throw new NullPointerException("Icon " + name + " not found with variant " + variant + ", size " + size + " on classpath; NULL URL returned");
+        }
 
-		return new ImageIcon (url);
-	}
+        return new ImageIcon(url);
+    }
 
-	@Override
-	public int getHeightValueForSize (Images.IconSize size) {
-		switch (size) {
-			case HUGE: return 57;
-			case LARGE: return 32;
-			case SMALL: return 24;
-			case MINI: return 20;
-			default: return 16;
-		}
-	}
+    @Override
+    public int getHeightValueForSize(Images.IconSize size) {
+        switch (size) {
+            case HUGE:
+                return 57;
+            case LARGE:
+                return 32;
+            case SMALL:
+                return 24;
+            case MINI:
+                return 20;
+            default:
+                return 16;
+        }
+    }
 
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/IconPack.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/IconPack.java
@@ -13,135 +13,155 @@ import static org.icepdf.ri.images.Images.IconSize;
  */
 public abstract class IconPack {
 
-	/**
-	 * Enum describing the different available variants of any icon
-	 */
-	public enum Variant {
-		/**
-		 * "None" variant, i.e. either no variant is preferred or the source icon is known not to have variants.
-		 * <p/>
-		 * An icon pack may choose to load a different variant than "none" if it deems it appropriate to do so.
-		 */
-		NONE,
+    /**
+     * Enum describing the different available variants of any icon
+     */
+    public enum Variant {
+        /**
+         * "None" variant, i.e. either no variant is preferred or the source icon is known not to have variants.
+         * <p/>
+         * An icon pack may choose to load a different variant than "none" if it deems it appropriate to do so.
+         */
+        NONE,
 
-		/**
-		 * "Normal" variant, i.e. the icon which should be displayed in a button's default state.
-		 */
-		NORMAL,
+        /**
+         * "Normal" variant, i.e. the icon which should be displayed in a button's default state.
+         */
+        NORMAL,
 
-		/**
-		 * "Disabled" variant to be displayed whenever a button/component is marked as disabled.
-		 */
-		DISABLED,
+        /**
+         * "Disabled" variant to be displayed whenever a button/component is marked as disabled.
+         */
+        DISABLED,
 
-		/**
-		 * "Rollover" variant to be displayed when the mouse cursors hovers a component/button.
-		 */
-		ROLLOVER,
+        /**
+         * "Rollover" variant to be displayed when the mouse cursors hovers a component/button.
+         */
+        ROLLOVER,
 
-		/**
-		 * "Pressed" variant to be displayed when a button is pressed.
-		 */
-		PRESSED,
+        /**
+         * "Pressed" variant to be displayed when a button is pressed.
+         */
+        PRESSED,
 
-		/**
-		 * "Selected" variant to be displayed when a toggleable component is marked as selected.
-		 */
-		SELECTED
-	}
+        /**
+         * "Selected" variant to be displayed when a toggleable component is marked as selected.
+         */
+        SELECTED
+    }
 
-	/**
-	 * Data class advertising the different (optional) variants an icon pack provides
-	 */
-	public static class VariantPool {
+    /**
+     * Data class advertising the different (optional) variants an icon pack provides
+     */
+    public static class VariantPool {
 
-		private final boolean providesDisabled;
-		private final boolean providesRollover;
-		private final boolean providesPressed;
-		private final boolean providesSelected;
+        private final boolean providesDisabled;
+        private final boolean providesRollover;
+        private final boolean providesPressed;
+        private final boolean providesSelected;
 
-		protected VariantPool (Variant... variants) {
-			boolean providesDisabled = false;
-			boolean providesRollover = false;
-			boolean providesPressed = false;
-			boolean providesSelected = false;
-			for (Variant variant : variants) {
-				switch (variant) {
-					case DISABLED: providesDisabled = true; break;
-					case ROLLOVER: providesRollover = true; break;
-					case PRESSED: providesPressed = true; break;
-					case SELECTED: providesSelected = true; break;
-				}
-			}
+        protected VariantPool(Variant... variants) {
+            boolean providesDisabled = false;
+            boolean providesRollover = false;
+            boolean providesPressed = false;
+            boolean providesSelected = false;
+            for (Variant variant : variants) {
+                switch (variant) {
+                    case DISABLED:
+                        providesDisabled = true;
+                        break;
+                    case ROLLOVER:
+                        providesRollover = true;
+                        break;
+                    case PRESSED:
+                        providesPressed = true;
+                        break;
+                    case SELECTED:
+                        providesSelected = true;
+                        break;
+                }
+            }
 
-			this.providesDisabled = providesDisabled;
-			this.providesRollover = providesRollover;
-			this.providesPressed = providesPressed;
-			this.providesSelected = providesSelected;
-		}
+            this.providesDisabled = providesDisabled;
+            this.providesRollover = providesRollover;
+            this.providesPressed = providesPressed;
+            this.providesSelected = providesSelected;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#DISABLED} variant.
-		 * @return If {@link Variant#DISABLED} is available
-		 */
-		public boolean disabledProvided () { return this.providesDisabled; }
+        /**
+         * Whether this icon pack provides the {@link Variant#DISABLED} variant.
+         *
+         * @return If {@link Variant#DISABLED} is available
+         */
+        public boolean disabledProvided() {
+            return this.providesDisabled;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#ROLLOVER} variant.
-		 * @return If {@link Variant#ROLLOVER} is available
-		 */
-		public boolean rolloverProvided () { return this.providesRollover; }
+        /**
+         * Whether this icon pack provides the {@link Variant#ROLLOVER} variant.
+         *
+         * @return If {@link Variant#ROLLOVER} is available
+         */
+        public boolean rolloverProvided() {
+            return this.providesRollover;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#PRESSED} variant.
-		 * @return If {@link Variant#PRESSED} is available
-		 */
-		public boolean pressedProvided () { return this.providesPressed; }
+        /**
+         * Whether this icon pack provides the {@link Variant#PRESSED} variant.
+         *
+         * @return If {@link Variant#PRESSED} is available
+         */
+        public boolean pressedProvided() {
+            return this.providesPressed;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#SELECTED} variant.
-		 * @return If {@link Variant#SELECTED} is available
-		 */
-		public boolean selectedProvided () { return this.providesSelected; }
+        /**
+         * Whether this icon pack provides the {@link Variant#SELECTED} variant.
+         *
+         * @return If {@link Variant#SELECTED} is available
+         */
+        public boolean selectedProvided() {
+            return this.providesSelected;
+        }
 
-	}
+    }
 
-	/**
-	 * Gets all variants this icon pack provides for at least one icon.
-	 * <p/>
-	 * This method is called by the {@link Images} utility class when deciding what icons to register to a given
-	 * component. No guarantee regarding further usage is made.
-	 *
-	 * @return Information about what variant this icon pack provides.
-	 */
-	public abstract VariantPool getProvidedVariants ();
+    /**
+     * Gets all variants this icon pack provides for at least one icon.
+     * <p/>
+     * This method is called by the {@link Images} utility class when deciding what icons to register to a given
+     * component. No guarantee regarding further usage is made.
+     *
+     * @return Information about what variant this icon pack provides.
+     */
+    public abstract VariantPool getProvidedVariants();
 
-	/**
-	 * Gets a single icon with the given name in the given variant and size from the classpath.
-	 * <p/>
-	 * Note that the {@code size} parameter is to be regarded as a hint. If the icon pack deems it necessary to return
-	 * another size for any given icon, the icon will be returned in this size instead. No guarantee is made that any
-	 * icon return by this method is square nor that all icons will have the height value returned by
-	 * {@link #getHeightValueForSize(IconSize)} for the given {@code size}.
-	 *
-	 * @param name    The name of the icon to retrieve
-	 * @param variant The variant to retrieve
-	 * @param size    The size to retrieve
-	 * @return		  The icon requested in the given variant, either in the wanted size or a similar size
-	 * @throws RuntimeException If the icon could not be retrieved from the classpath or any other error occurs
-	 */
-	public abstract Icon getIcon (String name, Variant variant, IconSize size) throws RuntimeException;
+    /**
+     * Gets a single icon with the given name in the given variant and size from the classpath.
+     * <p/>
+     * Note that the {@code size} parameter is to be regarded as a hint. If the icon pack deems it necessary to return
+     * another size for any given icon, the icon will be returned in this size instead. No guarantee is made that any
+     * icon return by this method is square nor that all icons will have the height value returned by
+     * {@link #getHeightValueForSize(IconSize)} for the given {@code size}.
+     *
+     * @param name    The name of the icon to retrieve
+     * @param variant The variant to retrieve
+     * @param size    The size to retrieve
+     * @return The icon requested in the given variant, either in the wanted size or a similar size
+     * @throws RuntimeException If the icon could not be retrieved from the classpath or any other error occurs
+     */
+    public abstract Icon getIcon(String name, Variant variant, IconSize size) throws RuntimeException;
 
-	/**
-	 * Returns the expected height of an icon requested with the given icon size.
-	 * <p/>
-	 * Note that there is no guarantee that an icon requested with the given size actually has the returned value
-	 * for the size as its height, nor that the returned value of this method is equal to the width of any icon
-	 * requested with the given size.
-	 *
-	 * @param size The icon size to get the expected height for
-	 * @return     The height value (in pixels) of a typical icon of the given size
-	 */
-	public abstract int getHeightValueForSize (IconSize size);
+    /**
+     * Returns the expected height of an icon requested with the given icon size.
+     * <p/>
+     * Note that there is no guarantee that an icon requested with the given size actually has the returned value
+     * for the size as its height, nor that the returned value of this method is equal to the width of any icon
+     * requested with the given size.
+     *
+     * @param size The icon size to get the expected height for
+     * @return The height value (in pixels) of a typical icon of the given size
+     */
+    public abstract int getHeightValueForSize(IconSize size);
 
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/IconPack.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/IconPack.java
@@ -13,52 +13,52 @@ import static org.icepdf.ri.images.Images.IconSize;
  */
 public abstract class IconPack {
 
-	/**
-	 * Enum describing the different available variants of any icon
-	 */
-	public enum Variant {
-		/**
-		 * "None" variant, i.e. either no variant is preferred or the source icon is known not to have variants.
-		 * <p/>
-		 * An icon pack may choose to load a different variant than "none" if it deems it appropriate to do so.
-		 */
-		NONE,
+    /**
+     * Enum describing the different available variants of any icon
+     */
+    public enum Variant {
+        /**
+         * "None" variant, i.e. either no variant is preferred or the source icon is known not to have variants.
+         * <p/>
+         * An icon pack may choose to load a different variant than "none" if it deems it appropriate to do so.
+         */
+        NONE,
 
-		/**
-		 * "Normal" variant, i.e. the icon which should be displayed in a button's default state.
-		 */
-		NORMAL,
+        /**
+         * "Normal" variant, i.e. the icon which should be displayed in a button's default state.
+         */
+        NORMAL,
 
-		/**
-		 * "Disabled" variant to be displayed whenever a button/component is marked as disabled.
-		 */
-		DISABLED,
+        /**
+         * "Disabled" variant to be displayed whenever a button/component is marked as disabled.
+         */
+        DISABLED,
 
-		/**
-		 * "Rollover" variant to be displayed when the mouse cursors hovers a component/button.
-		 */
-		ROLLOVER,
+        /**
+         * "Rollover" variant to be displayed when the mouse cursors hovers a component/button.
+         */
+        ROLLOVER,
 
-		/**
-		 * "Pressed" variant to be displayed when a button is pressed.
-		 */
-		PRESSED,
+        /**
+         * "Pressed" variant to be displayed when a button is pressed.
+         */
+        PRESSED,
 
-		/**
-		 * "Selected" variant to be displayed when a toggleable component is marked as selected.
-		 */
-		SELECTED
-	}
+        /**
+         * "Selected" variant to be displayed when a toggleable component is marked as selected.
+         */
+        SELECTED
+    }
 
-	/**
-	 * Data class advertising the different (optional) variants an icon pack provides
-	 */
-	public static class VariantPool {
+    /**
+     * Data class advertising the different (optional) variants an icon pack provides
+     */
+    public static class VariantPool {
 
-		private final boolean providesDisabled;
-		private final boolean providesRollover;
-		private final boolean providesPressed;
-		private final boolean providesSelected;
+        private final boolean providesDisabled;
+        private final boolean providesRollover;
+        private final boolean providesPressed;
+        private final boolean providesSelected;
 
         protected VariantPool(Variant... variants) {
             boolean providesDisabled = false;
@@ -67,64 +67,88 @@ public abstract class IconPack {
             boolean providesSelected = false;
             for (Variant variant : variants) {
                 switch (variant) {
+                    case DISABLED:
+                        providesDisabled = true;
+                        break;
+                    case ROLLOVER:
+                        providesRollover = true;
+                        break;
+                    case PRESSED:
+                        providesPressed = true;
+                        break;
+                    case SELECTED:
+                        providesSelected = true;
+                        break;
                 }
             }
 
-			this.providesDisabled = providesDisabled;
-			this.providesRollover = providesRollover;
-			this.providesPressed = providesPressed;
-			this.providesSelected = providesSelected;
-		}
+            this.providesDisabled = providesDisabled;
+            this.providesRollover = providesRollover;
+            this.providesPressed = providesPressed;
+            this.providesSelected = providesSelected;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#DISABLED} variant.
-		 * @return If {@link Variant#DISABLED} is available
-		 */
-		public boolean disabledProvided () { return this.providesDisabled; }
+        /**
+         * Whether this icon pack provides the {@link Variant#DISABLED} variant.
+         *
+         * @return If {@link Variant#DISABLED} is available
+         */
+        public boolean disabledProvided() {
+            return this.providesDisabled;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#ROLLOVER} variant.
-		 * @return If {@link Variant#ROLLOVER} is available
-		 */
-		public boolean rolloverProvided () { return this.providesRollover; }
+        /**
+         * Whether this icon pack provides the {@link Variant#ROLLOVER} variant.
+         *
+         * @return If {@link Variant#ROLLOVER} is available
+         */
+        public boolean rolloverProvided() {
+            return this.providesRollover;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#PRESSED} variant.
-		 * @return If {@link Variant#PRESSED} is available
-		 */
-		public boolean pressedProvided () { return this.providesPressed; }
+        /**
+         * Whether this icon pack provides the {@link Variant#PRESSED} variant.
+         *
+         * @return If {@link Variant#PRESSED} is available
+         */
+        public boolean pressedProvided() {
+            return this.providesPressed;
+        }
 
-		/**
-		 * Whether this icon pack provides the {@link Variant#SELECTED} variant.
-		 * @return If {@link Variant#SELECTED} is available
-		 */
-		public boolean selectedProvided () { return this.providesSelected; }
+        /**
+         * Whether this icon pack provides the {@link Variant#SELECTED} variant.
+         *
+         * @return If {@link Variant#SELECTED} is available
+         */
+        public boolean selectedProvided() {
+            return this.providesSelected;
+        }
 
-	}
+    }
 
-	/**
-	 * Gets all variants this icon pack provides for at least one icon.
-	 * <p/>
-	 * This method is called by the {@link Images} utility class when deciding what icons to register to a given
-	 * component. No guarantee regarding further usage is made.
-	 *
-	 * @return Information about what variant this icon pack provides.
-	 */
-	public abstract VariantPool getProvidedVariants ();
+    /**
+     * Gets all variants this icon pack provides for at least one icon.
+     * <p/>
+     * This method is called by the {@link Images} utility class when deciding what icons to register to a given
+     * component. No guarantee regarding further usage is made.
+     *
+     * @return Information about what variant this icon pack provides.
+     */
+    public abstract VariantPool getProvidedVariants();
 
-	/**
-	 * Gets a single icon with the given name in the given variant and size from the classpath.
-	 * <p/>
-	 * Note that the {@code size} parameter is to be regarded as a hint. If the icon pack deems it necessary to return
-	 * another size for any given icon, the icon will be returned in this size instead. No guarantee is made that any
-	 * icon return by this method is square
-	 *
-	 * @param name    The name of the icon to retrieve
-	 * @param variant The variant to retrieve
-	 * @param size    The size to retrieve
-	 * @return		  The icon requested in the given variant, either in the wanted size or a similar size
-	 * @throws RuntimeException If the icon could not be retrieved from the classpath or any other error occurs
-	 */
-	public abstract Icon getIcon (String name, Variant variant, IconSize size) throws RuntimeException;
+    /**
+     * Gets a single icon with the given name in the given variant and size from the classpath.
+     * <p/>
+     * Note that the {@code size} parameter is to be regarded as a hint. If the icon pack deems it necessary to return
+     * another size for any given icon, the icon will be returned in this size instead. No guarantee is made that any
+     * icon return by this method is square
+     *
+     * @param name    The name of the icon to retrieve
+     * @param variant The variant to retrieve
+     * @param size    The size to retrieve
+     * @return The icon requested in the given variant, either in the wanted size or a similar size
+     * @throws RuntimeException If the icon could not be retrieved from the classpath or any other error occurs
+     */
+    public abstract Icon getIcon(String name, Variant variant, IconSize size) throws RuntimeException;
 
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/Images.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/images/Images.java
@@ -33,12 +33,14 @@ import static org.icepdf.ri.images.IconPack.Variant;
  * are meant to be customizable by applications embedding ICEpdf, call:
  * <ul>
  *     <li>for a single icon {@link #getSingleIcon(String, Variant, IconSize)}</li>
- *     <li>for a button without different styles for its states, {@link #applyIcon(AbstractButton, String, Variant, IconSize)}</li>
+ *     <li>for a button without different styles for its states,
+ *     {@link #applyIcon(AbstractButton, String, Variant, IconSize)}</li>
  *     <li>for a button with different styles per state, {@link #applyIcons(AbstractButton, String, IconSize)}</li>
  * </ul>
  * Icons for the different states will be loaded and registered on the button if the current icon pack provides
  * these styles. Note that all types of buttons, including {@code JMenu}s and {@code JMenuItem}s are supported
- * by {@link #applyIcons(AbstractButton, String, IconSize)} and {@link #applyIcon(AbstractButton, String, Variant, IconSize)}.
+ * by {@link #applyIcons(AbstractButton, String, IconSize)} and
+ * {@link #applyIcon(AbstractButton, String, Variant, IconSize)}.
  *
  * @author Mark Collette
  * @author Alexander Leithner
@@ -74,21 +76,22 @@ public class Images {
         TINY
     }
 
-    private static final Logger LOGGER = Logger.getLogger (Images.class.getName ());
+    private static final Logger LOGGER = Logger.getLogger(Images.class.getName());
 
     private static final IconPack ICON_PACK;
     private static final IconPack.VariantPool AVAILABLE_VARIANTS;
 
     static {
-        Object defaultIconPackProp = UIManager.get ("org.icepdf.ri.iconpack");
+        Object defaultIconPackProp = UIManager.get("org.icepdf.ri.iconpack");
         if (!(defaultIconPackProp instanceof IconPack)) {
-            LOGGER.fine ("No user-defined icon pack was registered or registered one was invalid; using default icon pack");
-            ICON_PACK = new DefaultIconPack ();
+            LOGGER.fine("No user-defined icon pack was registered or registered one was invalid; using default icon " +
+                    "pack");
+            ICON_PACK = new DefaultIconPack();
         } else {
             ICON_PACK = (IconPack) defaultIconPackProp;
         }
 
-        AVAILABLE_VARIANTS = ICON_PACK.getProvidedVariants ();
+        AVAILABLE_VARIANTS = ICON_PACK.getProvidedVariants();
     }
 
     /**
@@ -108,8 +111,8 @@ public class Images {
     /**
      * Get a single icon from the classpath (must be PNG or GIF); no icon packs involved
      *
-     * @param name  The file to retrieve
-     * @return      A URL referring to the requested icon on the classpath.
+     * @param name The file to retrieve
+     * @return A URL referring to the requested icon on the classpath.
      */
     public static URL get(String name) {
         return Images.class.getResource(name);
@@ -122,30 +125,30 @@ public class Images {
      *
      * @param propertiesManager The Properties Manager to retrieve the preferences from
      * @param elseValue         The value to return if preference is unset or is invalid
-     * @return                  The current preference for the icon size or the given default value
+     * @return The current preference for the icon size or the given default value
      */
-    public static IconSize getDefaultIconSizeOr (ViewerPropertiesManager propertiesManager, IconSize elseValue) {
-        return getDefaultIconSizeOr (propertiesManager.getPreferences (), elseValue);
+    public static IconSize getDefaultIconSizeOr(ViewerPropertiesManager propertiesManager, IconSize elseValue) {
+        return getDefaultIconSizeOr(propertiesManager.getPreferences(), elseValue);
     }
 
     /**
      * Get the current setting for the icon size or the given "else" value if preference is unset or is invalid
      *
-     * @param preferences   The preference store to retrieve the preference from
-     * @param elseValue     The value to return if preference is unset or is invalid
-     * @return              The current preference for the icon size or the given default value
+     * @param preferences The preference store to retrieve the preference from
+     * @param elseValue   The value to return if preference is unset or is invalid
+     * @return The current preference for the icon size or the given default value
      */
-    public static IconSize getDefaultIconSizeOr (Preferences preferences, IconSize elseValue) {
+    public static IconSize getDefaultIconSizeOr(Preferences preferences, IconSize elseValue) {
         IconSize iconSize;
 
         String defaultSizeStr = preferences.get(ViewerPropertiesManager.PROPERTY_ICON_DEFAULT_SIZE, Images.SIZE_LARGE);
-        if (defaultSizeStr == null || !(defaultSizeStr.equals (Images.SIZE_SMALL) || defaultSizeStr.equals (Images.SIZE_LARGE))) {
+        if (defaultSizeStr == null || !(defaultSizeStr.equals(Images.SIZE_SMALL) || defaultSizeStr.equals(Images.SIZE_LARGE))) {
             try {
-                iconSize = IconSize.valueOf (defaultSizeStr);
+                iconSize = IconSize.valueOf(defaultSizeStr);
             } catch (IllegalArgumentException e) {
                 iconSize = elseValue;
             }
-        } else if (defaultSizeStr.equals (Images.SIZE_SMALL)) iconSize = Images.IconSize.SMALL;
+        } else if (defaultSizeStr.equals(Images.SIZE_SMALL)) iconSize = Images.IconSize.SMALL;
         else iconSize = Images.IconSize.LARGE;
 
         return iconSize;
@@ -154,11 +157,11 @@ public class Images {
     /**
      * Ask the current icon pack what its default height value (in pixels) is for the given icon size
      *
-     * @param iconSize  The icon size to query
-     * @return          The height value for the given icon size of the current icon pack
+     * @param iconSize The icon size to query
+     * @return The height value for the given icon size of the current icon pack
      */
-    public static int getHeightValueForIconSize (IconSize iconSize) {
-        return ICON_PACK.getHeightValueForSize (iconSize);
+    public static int getHeightValueForIconSize(IconSize iconSize) {
+        return ICON_PACK.getHeightValueForSize(iconSize);
     }
 
     /**
@@ -170,11 +173,11 @@ public class Images {
      * @param iconName The icon to register
      * @param size     The size of the icon to register
      */
-    public static void applyIcons (AbstractButton button, String iconName, IconSize size) {
-        applyIcon (button::setIcon, iconName, Variant.NORMAL, size);
-        if (AVAILABLE_VARIANTS.pressedProvided ()) applyIcon (button::setPressedIcon, iconName, Variant.PRESSED, size);
-        if (AVAILABLE_VARIANTS.rolloverProvided ()) applyIcon (button::setRolloverIcon, iconName, Variant.ROLLOVER, size);
-        if (AVAILABLE_VARIANTS.disabledProvided ()) applyIcon (button::setDisabledIcon, iconName, Variant.DISABLED, size);
+    public static void applyIcons(AbstractButton button, String iconName, IconSize size) {
+        applyIcon(button::setIcon, iconName, Variant.NORMAL, size);
+        if (AVAILABLE_VARIANTS.pressedProvided()) applyIcon(button::setPressedIcon, iconName, Variant.PRESSED, size);
+        if (AVAILABLE_VARIANTS.rolloverProvided()) applyIcon(button::setRolloverIcon, iconName, Variant.ROLLOVER, size);
+        if (AVAILABLE_VARIANTS.disabledProvided()) applyIcon(button::setDisabledIcon, iconName, Variant.DISABLED, size);
     }
 
     /**
@@ -188,8 +191,8 @@ public class Images {
      * @param variant  The wanted variant of the given icon
      * @param size     The wanted size
      */
-    public static void applyIcon (AbstractButton button, String iconName, Variant variant, IconSize size) {
-        applyIcon (button::setIcon, iconName, variant, size);
+    public static void applyIcon(AbstractButton button, String iconName, Variant variant, IconSize size) {
+        applyIcon(button::setIcon, iconName, variant, size);
     }
 
     /**
@@ -201,11 +204,11 @@ public class Images {
      * @param iconName The icon to retrieve from the current icon pack
      * @param variant  The variant of the icon to retrieve
      * @param size     The size in which to retrieve the icon
-     * @return         The icon as fetched by the icon pack
+     * @return The icon as fetched by the icon pack
      * @throws RuntimeException If the icon pack could not find or could not load the requested icon
      */
-    public static Icon getSingleIcon (String iconName, Variant variant, IconSize size) throws RuntimeException {
-        return ICON_PACK.getIcon (iconName, variant, size);
+    public static Icon getSingleIcon(String iconName, Variant variant, IconSize size) throws RuntimeException {
+        return ICON_PACK.getIcon(iconName, variant, size);
     }
 
     /**
@@ -216,11 +219,12 @@ public class Images {
      * @param variant       The variant of the icon to fetch
      * @param size          The wanted size of the icon
      */
-    private static void applyIcon (Consumer <Icon> applyFunction, String name, Variant variant, IconSize size) {
+    private static void applyIcon(Consumer<Icon> applyFunction, String name, Variant variant, IconSize size) {
         try {
-            applyFunction.accept (ICON_PACK.getIcon (name, variant, size));
+            applyFunction.accept(ICON_PACK.getIcon(name, variant, size));
         } catch (RuntimeException e) {
-            LOGGER.log (Level.WARNING, "Couldn't get icon " + name + ", size " + size + ", variant " + variant + " from icon pack", e);
+            LOGGER.log(Level.WARNING, "Couldn't get icon " + name + ", size " + size + ", variant " + variant + " " +
+                    "from icon pack", e);
         }
     }
 


### PR DESCRIPTION
- bring code formatting inline with project defaults. 
- few layout tweak to make layout less dependent on width height. Removed the getHeightValueForIconSize() call. 
- set toolbar buttons to to an empty boarder to make the toolbar a little closer to the original layout.  Height is a little higher then before but I think this is more in line with swing defaults. 