### PR TITLE
GH-345 Restores original spacing between button and dropdown arrow in toolbar

### DIFF
--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
@@ -205,8 +205,8 @@ public class SwingController extends ComponentAdapter
     private JLabel numberOfPagesLabel;
     private JButton zoomInButton;
     private JButton zoomOutButton;
-    private JComboBox zoomComboBox;
-    private JComboBox annotationPrivacyComboBox;
+    private JComboBox<String> zoomComboBox;
+    private JComboBox<String> annotationPrivacyComboBox;
     private JToggleButton fitActualSizeButton;
     private JToggleButton fitHeightButton;
     private JToggleButton fitWidthButton;
@@ -1017,7 +1017,7 @@ public class SwingController extends ComponentAdapter
      * @param zcb zoom level combo box values.
      * @param zl  default zoom level.
      */
-    public void setZoomComboBox(JComboBox zcb, float[] zl) {
+    public void setZoomComboBox(JComboBox<String> zcb, float[] zl) {
         zoomComboBox = zcb;
         documentViewController.setZoomLevels(zl);
         zoomComboBox.setSelectedItem(NumberFormat.getPercentInstance().format(1.0));
@@ -1034,7 +1034,7 @@ public class SwingController extends ComponentAdapter
         btn.addActionListener(this);
     }
 
-    public void setAnnotationPermissionComboBox(JComboBox zcb) {
+    public void setAnnotationPermissionComboBox(JComboBox<String> zcb) {
         annotationPrivacyComboBox = zcb;
         zcb.addItemListener(this);
     }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
@@ -1454,7 +1454,7 @@ public class SwingViewBuilder implements ViewBuilder {
         return btn;
     }
 
-    public JComboBox buildZoomCombBox() {
+    public JComboBox<String> buildZoomCombBox() {
         // Get the properties manager in preparation for trying to get the zoom levels
         doubleCheckPropertiesManager();
 
@@ -1465,7 +1465,7 @@ public class SwingViewBuilder implements ViewBuilder {
 
         JComboBox<String> tmp = new JComboBox<>();
         tmp.setToolTipText(messageBundle.getString("viewer.toolbar.zoom.tooltip"));
-        tmp.setPreferredSize(new Dimension(90, tmp.getPreferredSize().height));
+        tmp.setPreferredSize(new Dimension(115, tmp.getPreferredSize().height));
         for (float zoomLevel : zoomLevels)
             tmp.addItem(NumberFormat.getPercentInstance().format(zoomLevel));
         tmp.setEditable(true);
@@ -1484,11 +1484,11 @@ public class SwingViewBuilder implements ViewBuilder {
         return btn;
     }
 
-    public JComboBox buildAnnotationPermissionCombBox() {
+    public JComboBox<String> buildAnnotationPermissionCombBox() {
         JComboBox<String> tmp = new JComboBox<>();
         tmp.setToolTipText(messageBundle.getString(
                 "viewer.utilityPane.markupAnnotation.view.publicToggleButton.tooltip.label"));
-        tmp.setPreferredSize(new Dimension(65, tmp.getPreferredSize().height));
+        tmp.setPreferredSize(new Dimension(105, tmp.getPreferredSize().height));
         tmp.addItem(messageBundle.getString("viewer.utilityPane.markupAnnotation.view.publicToggleButton.label"));
         tmp.addItem(messageBundle.getString("viewer.utilityPane.markupAnnotation.view.privateToggleButton.label"));
         tmp.setEditable(true);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/AbstractColorButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/AbstractColorButton.java
@@ -47,10 +47,9 @@ public abstract class AbstractColorButton extends AbstractButton
 
     public AbstractColorButton(Controller controller,
                                ResourceBundle messageBundle) {
-        super();
         this.controller = controller;
-
         dropDownArrowButton = new JButton(new MetalComboBoxIcon());
+        dropDownArrowButton.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 5));
         dropDownArrowButton.setContentAreaFilled(false);
         dropDownArrowButton.setRolloverEnabled(false);
         dropDownArrowButton.setFocusPainted(false);


### PR DESCRIPTION
The spacing was increased with the original PR. I don't know if that was intentional, but if it wasn't, here is a quick fix to restore the more original look.

Also increases the width of the zoom and privacy comboboxes because the text was cut (at least on my machine).