### PR TITLE
GH-381 Exit indexing loop if previous position == position

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
@@ -43,7 +43,12 @@ public class Indexer {
         DictionaryEntries xRefDictionary = null;
         Lexer lexer = new Lexer(library);
         Parser parser = new Parser(library);
+        int previousPos = -1;
         while (pos > 0) {
+            if (previousPos == pos) {
+                throw new IOException("Failed to index objects (infinite loop)");
+            }
+            previousPos = pos;
             if (xRefDictionary == null) {
                 int end = 0;
                 int trailerPosition = pos = ByteBufferUtil.findReverseString(byteBuffer, byteBuffer.limit(), end, Parser.TRAILER_MARKER);


### PR DESCRIPTION
Fixes #381 
This tries to exit the indexing loop if the position doesn't move.     
I'm not really sure it's the correct way to do it given my non-expertise in PDF indexing, so don't hesitate to tell me or modify the exit condition if needed.