### PR TITLE
GH-383 Using defaultWidth in ZFontType2.getAdvance

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType0.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType0.java
@@ -74,7 +74,12 @@ public class ZFontType0 extends ZSimpleFont {
             advance = widths[ech];
         }
         if (advance == 0) {
-            advance = 1.0f;
+            if (defaultWidth > 0.0f) {
+                advance = defaultWidth;
+            }
+            else {
+                advance = 1.0f;
+            }
         }
         float x = advance * size;//* (float) gsTransform.getScaleX();
         float y = advance * size;//* (float) gsTransform.getShearY();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
@@ -69,7 +69,7 @@ public class ZFontType2 extends ZSimpleFont { //extends ZFontTrueType {
             advance = widths[ech];
         }
         if (advance == 0) {
-           if (defaultWidth > 0.0f) {
+            if (defaultWidth > 0.0f) {
                 advance = defaultWidth;
             }
             else {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
@@ -69,7 +69,12 @@ public class ZFontType2 extends ZSimpleFont { //extends ZFontTrueType {
             advance = widths[ech];
         }
         if (advance == 0) {
-            advance = 1.0f;
+           if (defaultWidth > 0.0f) {
+                advance = defaultWidth;
+            }
+            else {
+                advance = 1.0f;
+            }
         }
         float x = advance * size * (float) gsTransform.getScaleX();
         float y = advance * size * (float) gsTransform.getShearY();


### PR DESCRIPTION
Embedded Type2 fonts may have a default width for characters. These characters are not mentioned in the W-Tag and currently stored with a zero-width. When a string gets rendered, the characters are spaced by the stored width. If this is zero the current implementation assumes a width of 1.000. This leads to strange inter-word-spaces. Using the default width renderes the text correctly