### PR TITLE
GH-386 fix two glyph selection issues

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
@@ -164,7 +164,8 @@ public class ZFontTrueType extends ZSimpleFont {
     }
 
     @Override
-    public FontFile deriveFont(float[] widths, int firstCh, float missingWidth, float ascent, float descent, Rectangle2D bbox, char[] diff) {
+    public FontFile deriveFont(float[] widths, int firstCh, float missingWidth, float ascent, float descent,
+                               Rectangle2D bbox, char[] diff) {
         ZFontTrueType font = new ZFontTrueType(this);
         font.firstCh = firstCh;
         font.ascent = ascent;
@@ -182,7 +183,8 @@ public class ZFontTrueType extends ZSimpleFont {
     }
 
     @Override
-    public FontFile deriveFont(Map<Integer, Float> widths, int firstCh, float missingWidth, float ascent, float descent, Rectangle2D bbox, char[] diff) {
+    public FontFile deriveFont(Map<Integer, Float> widths, int firstCh, float missingWidth, float ascent,
+                               float descent, Rectangle2D bbox, char[] diff) {
         ZFontTrueType font = new ZFontTrueType(this);
         font.firstCh = firstCh;
         font.ascent = ascent;
@@ -259,7 +261,8 @@ public class ZFontTrueType extends ZSimpleFont {
                     }
                     // (1, 0) - (Macintosh, Roman)
                     if (gid == 0 && cmapMacRoman != null && name != null) {
-                        Character macCode = org.icepdf.core.pobjects.fonts.zfont.Encoding.macRomanEncoding.getChar(name);
+                        Character macCode =
+                                org.icepdf.core.pobjects.fonts.zfont.Encoding.macRomanEncoding.getChar(name);
                         if (macCode != null) {
                             gid = cmapMacRoman.getGlyphId(macCode);
                         }
@@ -277,6 +280,17 @@ public class ZFontTrueType extends ZSimpleFont {
                             gid = cmapWinUnicode.getGlyphId(code);
                         } else if (encoding.getName().startsWith("Mac") && cmapMacRoman != null) {
                             gid = cmapMacRoman.getGlyphId(code);
+                        } else if (trueTypeFont.getPostScript() != null &&
+                                trueTypeFont.getPostScript().getGlyphNames() != null) {
+                            String[] glyphNames = trueTypeFont.getPostScript().getGlyphNames();
+                            // find in index of the glyph name, a cache might be nice have here
+                            for (int i = 0; i < glyphNames.length; i++) {
+                                if (glyphNames[i].equals(name)) {
+                                    gid = i;
+                                    return gid;
+                                }
+                            }
+                            gid = code;
                         } else {
                             gid = code;
                         }
@@ -341,7 +355,7 @@ public class ZFontTrueType extends ZSimpleFont {
         calculateFontBbox();
     }
 
-    private void calculateFontBbox(){
+    private void calculateFontBbox() {
         if (headerTable != null) {
             Rectangle2D bbox = new Rectangle2D.Float(
                     headerTable.getXMin(), headerTable.getYMin(), headerTable.getXMax(), headerTable.getYMax());

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
@@ -242,7 +242,7 @@ public class ZFontTrueType extends ZSimpleFont {
     }
 
     public int codeToGID(int code) {
-        int gid = 0;
+        int gid = 0; // worried about this, 0 is a valid glyph id for some CID fonts.
         try {
             if (cmapWinSymbol == null) {
                 if (encoding == null) {
@@ -270,28 +270,25 @@ public class ZFontTrueType extends ZSimpleFont {
                 }
                 // still not happy with this, lots of mystery and deception that needs to be figured out.
                 if (gid == 0) {
-                    if (encoding != null) {
-                        if (cmapWinUnicode != null &&
-                                (encoding.getName().equals(org.icepdf.core.pobjects.fonts.zfont.Encoding.WIN_ANSI_ENCODING_NAME)
-                                        || encoding.getName().equals("diff"))) {
-                            gid = cmapWinUnicode.getGlyphId(code);
-                        } else if (encoding.getName().startsWith("Mac") && cmapMacRoman != null) {
-                            gid = cmapMacRoman.getGlyphId(code);
-                        } else if (trueTypeFont.getPostScript() != null &&
-                                trueTypeFont.getPostScript().getGlyphNames() != null) {
-                            // fall back on the 'post' table
-                            String[] glyphNames = trueTypeFont.getPostScript().getGlyphNames();
-                            // find in index of the glyph name, a cache might be nice have here
-                            for (int i = 0; i < glyphNames.length; i++) {
-                                if (glyphNames[i].equals(name)) {
-                                    gid = i;
-                                    return gid;
-                                }
+                    if (encoding != null && cmapWinUnicode != null &&
+                            (encoding.getName().equals(org.icepdf.core.pobjects.fonts.zfont.Encoding.WIN_ANSI_ENCODING_NAME)
+                                    || encoding.getName().equals("diff"))) {
+                        gid = cmapWinUnicode.getGlyphId(code);
+                    } else if (encoding != null && encoding.getName().startsWith("Mac") && cmapMacRoman != null) {
+                        gid = cmapMacRoman.getGlyphId(code);
+                    } else if (trueTypeFont.getPostScript() != null &&
+                            trueTypeFont.getPostScript().getGlyphNames() != null) {
+                        // fall back on the 'post' table
+                        String[] glyphNames = trueTypeFont.getPostScript().getGlyphNames();
+                        // find in index of the glyph name, a cache might be nice have here
+                        for (int i = 0; i < glyphNames.length; i++) {
+                            if (glyphNames[i].equals(name)) {
+                                gid = i;
+                                // hard break out, we found it.
+                                return gid;
                             }
-                            gid = code;
-                        } else {
-                            gid = code;
                         }
+                        gid = code;
                     } else {
                         gid = code;
                     }
@@ -340,7 +337,6 @@ public class ZFontTrueType extends ZSimpleFont {
         } catch (Exception e) {
             logger.log(Level.WARNING, "Error deriving codeToGID", e);
         }
-
         return gid;
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
@@ -268,11 +268,8 @@ public class ZFontTrueType extends ZSimpleFont {
                         }
                     }
                 }
-                // 'post' table - comment is incorrect but keeping it for now as the post table is an encoding
-                // that we can use. With this little hack we still have issue showing some glyphs correctly.
-                // likely looking at font substitutions corner cases.
+                // still not happy with this, lots of mystery and deception that needs to be figured out.
                 if (gid == 0) {
-                    // still not happy with this, lots of mystery and deception that needs to be figured out.
                     if (encoding != null) {
                         if (cmapWinUnicode != null &&
                                 (encoding.getName().equals(org.icepdf.core.pobjects.fonts.zfont.Encoding.WIN_ANSI_ENCODING_NAME)
@@ -282,6 +279,7 @@ public class ZFontTrueType extends ZSimpleFont {
                             gid = cmapMacRoman.getGlyphId(code);
                         } else if (trueTypeFont.getPostScript() != null &&
                                 trueTypeFont.getPostScript().getGlyphNames() != null) {
+                            // fall back on the 'post' table
                             String[] glyphNames = trueTypeFont.getPostScript().getGlyphNames();
                             // find in index of the glyph name, a cache might be nice have here
                             for (int i = 0; i < glyphNames.length; i++) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1C.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1C.java
@@ -56,6 +56,8 @@ public class ZFontType1C extends ZSimpleFont {
         // use the font's internal encoding.
         if (org.icepdf.core.pobjects.fonts.zfont.Encoding.STANDARD_ENCODING_NAME.equals(encoding.getName())) {
             return cffType1Font.getEncoding().getName(estr);
+        } else if (encoding != null && "diff".equals(encoding.getName())) {
+            return encoding.getName(estr);
         } else {
             return String.valueOf(estr);
         }
@@ -89,7 +91,8 @@ public class ZFontType1C extends ZSimpleFont {
     }
 
     @Override
-    public FontFile deriveFont(float[] widths, int firstCh, float missingWidth, float ascent, float descent, Rectangle2D bbox, char[] diff) {
+    public FontFile deriveFont(float[] widths, int firstCh, float missingWidth, float ascent, float descent,
+                               Rectangle2D bbox, char[] diff) {
         ZFontType1C font = new ZFontType1C(this);
         font.missingWidth = this.missingWidth;
         font.firstCh = firstCh;
@@ -105,7 +108,8 @@ public class ZFontType1C extends ZSimpleFont {
     }
 
     @Override
-    public FontFile deriveFont(Map<Integer, Float> widths, int firstCh, float missingWidth, float ascent, float descent, Rectangle2D bbox, char[] diff) {
+    public FontFile deriveFont(Map<Integer, Float> widths, int firstCh, float missingWidth, float ascent,
+                               float descent, Rectangle2D bbox, char[] diff) {
         ZFontType1C font = new ZFontType1C(this);
         font.missingWidth = this.missingWidth;
         font.firstCh = firstCh;


### PR DESCRIPTION
- fix a encoding issue which was preventing some FontType1c fonts from finding the correct glyph mapping
- Similarly for TrueType, added code to fall back on the fonts post script table if no other encoding find a mapping. 