### PR TITLE
Gh-263 page rotatoin compensation when sorting text

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -34,8 +34,8 @@ import java.awt.*;
 import java.awt.geom.*;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -1259,7 +1259,7 @@ public class Page extends Dictionary {
         return totalRotation;
     }
 
-    private float getPageRotation() {
+    public float getPageRotation() {
         // Get the pages default orientation if available, if not defined
         // then it is zero.
         Object tmpRotation = library.getObject(entries, ROTATE_KEY);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
@@ -456,7 +456,7 @@ public class FreeTextAnnotation extends MarkupAnnotation {
                 textSprites.addText(
                         currentChar, // cid
                         String.valueOf(currentChar), // unicode value
-                        currentX, currentY, newAdvanceX, 0);
+                        currentX, currentY, newAdvanceX, 0, 0);
             } else {
                 // move back to start of next line
                 currentY += lineHeight;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
@@ -57,6 +57,8 @@ public class Shapes {
     private int rule;
     private float alpha;
 
+    private float pageRotation;
+
     // Graphics stack for a page's content.
     protected final ArrayList<DrawCmd> shapes = new ArrayList<>(shapesInitialCapacity);
 
@@ -203,5 +205,14 @@ public class Shapes {
 
     public void setAlpha(float alpha) {
         this.alpha = alpha;
+    }
+
+    public float getRotation() {
+        return pageRotation;
+    }
+
+    public void setRotation(float pageRotation) {
+        pageText.setPageRotation(pageRotation);
+        this.pageRotation = pageRotation;
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TextSprite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TextSprite.java
@@ -107,7 +107,8 @@ public class TextSprite {
      * @param height  height of cid from font.
      * @return new GlyphText object containing the text data.
      */
-    public GlyphText addText(char cid, String unicode, float x, float y, float width, float height) {
+    public GlyphText addText(char cid, String unicode, float x, float y, float width, float height,
+                             float pageRotation) {
         // x,y must not change as it will affect painting of the glyph,
         // we can change the bounds of glyphBounds as this is what needs to be normalized
         // to page space
@@ -149,7 +150,7 @@ public class TextSprite {
 
         // create glyph and normalize bounds.
         GlyphText glyphText =
-                new GlyphText(x, y, width, height, glyphBounds, cid, unicode);
+                new GlyphText(x, y, width, height, glyphBounds, pageRotation, cid, unicode);
         glyphText.normalizeToUserSpace(graphicStateTransform, tmTransform);
         glyphText.setFontSubTypeFormat(subTypeFormat);
         glyphTexts.add(glyphText);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/AbstractText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/AbstractText.java
@@ -218,7 +218,7 @@ public abstract class AbstractText implements Text {
      * Gets the original bounds of the text unit, this value is not normalized
      * to page space and represents the raw layout coordinates of the text as
      * defined in the Post Script notation. This is primarily used for text
-     * extraction line and word break calculations.
+     * selection contains calculations.
      *
      * @return text bounds.
      */
@@ -228,9 +228,9 @@ public abstract class AbstractText implements Text {
 
     /**
      * Gets the bounds of the text unit, this value is normalized to page space and removes any page
-     * level rotations.  This is primarily used for text searching and text extraction formating.
-     * Where the textExtractionBounds represent the raw layout coordinates of the text as defined in the document
-     * which is good for text selection calculations but breaks down when trying to do text extraction formatting.
+     * level rotations.  This is primarily used text coordinate sorting for extraction and searching.
+     * Where the getTextSelectionBounds represent the raw layout coordinates of the text as defined in the document
+     * which is good for text selection calculations but breaks down when trying to do text extraction sorting.
      *
      * @return text bounds.
      */
@@ -238,6 +238,7 @@ public abstract class AbstractText implements Text {
         if (textExtractionBounds == null) {
             if (pageRotation != 0) {
                 AffineTransform transform = new AffineTransform();
+                // rotation without centering as we want the margin to be the same
                 transform.rotate(Math.toRadians(pageRotation));
                 textExtractionBounds =
                         (Rectangle2D.Double) transform.createTransformedShape(textSelectionBounds).getBounds2D();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/AbstractText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/AbstractText.java
@@ -18,6 +18,7 @@ package org.icepdf.core.pobjects.graphics.text;
 import org.icepdf.core.pobjects.Page;
 
 import java.awt.*;
+import java.awt.geom.AffineTransform;
 import java.awt.geom.GeneralPath;
 import java.awt.geom.Point2D;
 import java.awt.geom.Rectangle2D;
@@ -38,10 +39,9 @@ public abstract class AbstractText implements Text {
     // Bounds of text converted to page space.
     protected Rectangle2D.Double bounds;
 
-    // original bounds as plotted by the PDF,  can be used for space and
-    // line break detection.  Once normalized to page space (bounds instance var)
-    // it may not be possible to make the formatting detection.  However, normalized
-    // bounds are used for text selection.
+    // original bounds as plotted by the PDF, this is used for painting selection as calculating mouse interactions
+    protected Rectangle2D.Double textSelectionBounds;
+    // Can be used for space and line break detection.
     protected Rectangle2D.Double textExtractionBounds;
 
     // selected states
@@ -57,6 +57,8 @@ public abstract class AbstractText implements Text {
     protected boolean hasHighlight;
     // highlight cursor hint for quicker painting
     protected boolean hasHighlightCursor;
+
+    protected float pageRotation;
 
     /**
      * Gets the bounds of the respective text object normalized to page
@@ -220,7 +222,29 @@ public abstract class AbstractText implements Text {
      *
      * @return text bounds.
      */
+    public Rectangle2D.Double getTextSelectionBounds() {
+        return textSelectionBounds;
+    }
+
+    /**
+     * Gets the bounds of the text unit, this value is normalized to page space and removes any page
+     * level rotations.  This is primarily used for text searching and text extraction formating.
+     * Where the textExtractionBounds represent the raw layout coordinates of the text as defined in the document
+     * which is good for text selection calculations but breaks down when trying to do text extraction formatting.
+     *
+     * @return text bounds.
+     */
     public Rectangle2D.Double getTextExtractionBounds() {
+        if (textExtractionBounds == null) {
+            if (pageRotation != 0) {
+                AffineTransform transform = new AffineTransform();
+                transform.rotate(Math.toRadians(pageRotation));
+                textExtractionBounds =
+                        (Rectangle2D.Double) transform.createTransformedShape(textSelectionBounds).getBounds2D();
+            } else {
+                textExtractionBounds = textSelectionBounds;
+            }
+        }
         return textExtractionBounds;
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/GlyphText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/GlyphText.java
@@ -50,13 +50,14 @@ public class GlyphText extends AbstractText {
     private int fontSubTypeFormat;
 
     public GlyphText(float x, float y, float advanceX, float advanceY, Rectangle2D.Double bounds,
-                     char cid, String unicode) {
+                     float pageRotation, char cid, String unicode) {
         this.x = x;
         this.y = y;
         this.advanceX = advanceX;
         this.advanceY = advanceY;
+        this.pageRotation = pageRotation;
         this.bounds = bounds;
-        this.textExtractionBounds = new Rectangle2D.Double(bounds.x, bounds.y, bounds.width, bounds.height);
+        this.textSelectionBounds = new Rectangle2D.Double(bounds.x, bounds.y, bounds.width, bounds.height);
         this.cid = cid;
         this.unicode = unicode;
     }
@@ -72,23 +73,7 @@ public class GlyphText extends AbstractText {
         // map the coordinates from glyph space to user space.
         Path2D.Double generalPath = new Path2D.Double(bounds, af);
         bounds = (Rectangle2D.Double) generalPath.getBounds2D();
-        // we have some portrait type layouts where the text is actually
-        // running on the y-axis.  The reason for this is Tm that specifies
-        // a -1 shear which is basically a 90 degree rotation.  Which breaks
-        // our left to right top down text extraction logic (PDF-854).
-        if (af1 != null && af1.getShearX() < -1) {
-            // adjust of the rotation, move the text back to a normal layout.
-            generalPath = new Path2D.Double(bounds, new AffineTransform(0, -1, 1, 0, 0, 0));
-            textExtractionBounds = (Rectangle2D.Double) generalPath.getBounds2D();
-        } else if (af1 != null && af1.getShearY() < -1) {
-            // adjust of the rotation, move the text back to a normal layout.
-            generalPath = new Path2D.Double(bounds, new AffineTransform(0, 1, -1, 0, 0, 0));
-            textExtractionBounds = (Rectangle2D.Double) generalPath.getBounds2D();
-        } else {
-            // 99% of the time we just use the bounds.
-            textExtractionBounds = bounds;
-        }
-
+        textSelectionBounds = bounds;
     }
 
     public boolean isRedacted() {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/LineText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/LineText.java
@@ -31,8 +31,14 @@ public class LineText extends AbstractText implements TextSelect {
 
     private List<WordText> words;
 
+
     public LineText() {
+        this(0f);
+    }
+
+    public LineText(float pageRotation) {
         words = new ArrayList<>(16);
+        this.pageRotation = pageRotation;
     }
 
     public Rectangle2D.Double getBounds() {
@@ -67,14 +73,14 @@ public class LineText extends AbstractText implements TextSelect {
         if (WordText.detectWhiteSpace(sprite) ||
                 WordText.detectPunctuation(sprite, currentWord)) {
             // add as a new word, nothing special otherwise
-            WordText newWord = new WordText();
+            WordText newWord = new WordText(this.pageRotation);
             newWord.setWhiteSpace(true);
             newWord.addText(sprite);
             addWord(newWord);
             // ready new word
             currentWord = null;
         }
-        // we just a a new work sorting later will add the line breaks
+        // we just a new work sorting later will add the line breaks
         else if (getCurrentWord().detectNewLine(sprite)) {
             // add the break
             WordText spaceWord = currentWord.buildSpaceWord(sprite, false);
@@ -84,7 +90,7 @@ public class LineText extends AbstractText implements TextSelect {
             // ready a new word
             currentWord = null;
             // add as a new word, nothing special otherwise
-            WordText newWord = new WordText();
+            WordText newWord = new WordText(this.pageRotation);
             newWord.setWhiteSpace(true);
             newWord.addText(sprite);
             addWord(newWord);
@@ -148,7 +154,7 @@ public class LineText extends AbstractText implements TextSelect {
      */
     private WordText getCurrentWord() {
         if (currentWord == null) {
-            currentWord = new WordText();
+            currentWord = new WordText(this.pageRotation);
             words.add(currentWord);
         }
         return currentWord;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/PageText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/PageText.java
@@ -58,6 +58,7 @@ public class PageText implements TextSelect {
 
     // pointer to current line during document parse, no other use.
     private LineText currentLine;
+    private float pageRotation;
 
     private final ArrayList<LineText> pageLines;
     private ArrayList<LineText> sortedPageLines;
@@ -68,7 +69,16 @@ public class PageText implements TextSelect {
     private LinkedHashMap<OptionalContents, PageText> optionalPageLines;
 
     public PageText() {
+        this(0f);
+    }
+
+    public PageText(float pageRotation) {
         pageLines = new ArrayList<>(64);
+        this.pageRotation = pageRotation;
+    }
+
+    public void setPageRotation(float pageRotation) {
+        this.pageRotation = pageRotation;
     }
 
     public void newLine(LinkedList<OptionalContents> oCGs) {
@@ -80,7 +90,7 @@ public class PageText implements TextSelect {
             PageText pageText = optionalPageLines.get(optionalContent);
             if (pageText == null) {
                 // create a text object add the glyph.
-                pageText = new PageText();
+                pageText = new PageText(pageRotation);
                 pageText.newLine();
                 optionalPageLines.put(optionalContent, pageText);
             } else {
@@ -95,7 +105,7 @@ public class PageText implements TextSelect {
                 currentLine.getWords().size() == 0) {
             return;
         }
-        currentLine = new LineText();
+        currentLine = new LineText(pageRotation);
         pageLines.add(currentLine);
     }
 
@@ -114,7 +124,7 @@ public class PageText implements TextSelect {
      * {@link #sortAndFormatText}.
      * <br>
      * During the extraction process extra space will automatically be added
-     * between words.  However depending on how the PDF is encoded can result
+     * between words.  However, depending on how the PDF is encoded can result
      * in too many extra spaces.  So as a result this feature can be turned off
      * with the system property org.icepdf.core.views.page.text.autoSpace which
      * is set to True by default.
@@ -145,7 +155,7 @@ public class PageText implements TextSelect {
             for (OptionalContents key : keys) {
                 if (key != null && key.isVisible()) {
                     ArrayList<LineText> pageLines = optionalPageLines.get(key).getVisiblePageLines(false);
-                    LineText currentLine = new LineText();
+                    LineText currentLine = new LineText(pageRotation);
                     visiblePageLines.add(currentLine);
                     for (LineText lineText : pageLines) {
                         currentLine.addAll(lineText.getWords());
@@ -165,7 +175,7 @@ public class PageText implements TextSelect {
         if (optionalPageLines != null) {
             // iterate over optional content keys and extract text from visible groups
             Set<OptionalContents> keys = optionalPageLines.keySet();
-            LineText currentLine = new LineText();
+            LineText currentLine = new LineText(pageRotation);
             visiblePageLines.add(currentLine);
             for (OptionalContents key : keys) {
                 if (key != null) {
@@ -226,7 +236,7 @@ public class PageText implements TextSelect {
         PageText pageText = optionalPageLines.get(optionalContent);
         if (pageText == null) {
             // create a text object add the glyph.
-            pageText = new PageText();
+            pageText = new PageText(pageRotation);
             pageText.addGlyph(sprite);
             optionalPageLines.put(optionalContent, pageText);
         } else {
@@ -442,7 +452,7 @@ public class PageText implements TextSelect {
                     // on table base text.
                     diff = Math.abs(currentY - lastY);
                     if (diff != 0 && diff > word.getTextExtractionBounds().getHeight() / 2) {
-                        LineText lineText = new LineText();
+                        LineText lineText = new LineText(pageRotation);
                         lineText.addAll(words.subList(start, end));
                         sortedPageLines.add(lineText);
                         start = end;
@@ -451,7 +461,7 @@ public class PageText implements TextSelect {
                     lastY = currentY;
                 }
                 if (start < end) {
-                    LineText lineText = new LineText();
+                    LineText lineText = new LineText(pageRotation);
                     lineText.addAll(words.subList(start, end));
                     sortedPageLines.add(lineText);
                 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/WordText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/WordText.java
@@ -78,9 +78,10 @@ public class WordText extends AbstractText implements TextSelect {
     // reference to last added text.
     private int previousGlyphText;
 
-    public WordText() {
+    public WordText(float pageRotation) {
         text = new StringBuilder();
         glyphs = new ArrayList<>(4);
+        this.pageRotation = pageRotation;
     }
 
     public int size(){
@@ -97,14 +98,13 @@ public class WordText extends AbstractText implements TextSelect {
 
     protected boolean detectNewLine(GlyphText sprite) {
         if (currentGlyph != null && autoSpaceInsertion) {
-            // last added glyph
-            Rectangle2D.Double bounds1 = currentGlyph.getTextExtractionBounds();
-            double currentYCoord = sprite.getTextExtractionBounds().y;
-            double previousYCoord = currentGlyph.getTextExtractionBounds().y;
+            Rectangle2D previousBounds = currentGlyph.getTextExtractionBounds();
+            Rectangle2D currentBounds = sprite.getTextExtractionBounds();
+
             // half previous glyph width will be used to determine a space
-            double tolerance = bounds1.height / spaceFraction;
+            double tolerance = previousBounds.getHeight() / spaceFraction;
             // checking the y coordinate as well as any shift normall means a new work, this might need to get fuzzy later.
-            double ydiff = Math.abs(currentYCoord - previousYCoord);
+            double ydiff = Math.abs(currentBounds.getY() - previousBounds.getY());
             return ydiff > tolerance;
         } else {
             return false;
@@ -113,18 +113,15 @@ public class WordText extends AbstractText implements TextSelect {
 
     protected boolean detectSpace(GlyphText sprite) {
         if (currentGlyph != null && autoSpaceInsertion) {
-            // last added glyph
-            Rectangle2D.Double bounds1 = currentGlyph.getTextExtractionBounds();
-            double currentXCoord = sprite.getTextExtractionBounds().x;
-            double currentYCoord = sprite.getTextExtractionBounds().y;
-            double previousXCoord = currentGlyph.getTextExtractionBounds().x;
-            double previousYCoord = currentGlyph.getTextExtractionBounds().y;
+            Rectangle2D previousBounds = currentGlyph.getTextExtractionBounds();
+            Rectangle2D currentBounds = sprite.getTextExtractionBounds();
+
             // spaces can be negative if we have a LTR layout.
-            double space = Math.abs(currentXCoord - (previousXCoord + bounds1.width));
+            double space = Math.abs(currentBounds.getX() - (previousBounds.getX() + previousBounds.getWidth()));
             // half previous glyph width will be used to determine a space
-            double tolerance = bounds1.width / spaceFraction;
+            double tolerance = previousBounds.getWidth() / spaceFraction;
             // checking the y coordinate as well as any shift normall means a new work, this might need to get fuzzy later.
-            double ydiff = Math.abs(currentYCoord - previousYCoord);
+            double ydiff = Math.abs(currentBounds.getY() - previousBounds.getY());
             return space > tolerance || ydiff > tolerance;
         } else {
             return false;
@@ -191,7 +188,7 @@ public class WordText extends AbstractText implements TextSelect {
             spaces = 1;
         }
         // add extra spaces
-        WordText whiteSpace = new WordText();
+        WordText whiteSpace = new WordText(this.pageRotation);
         double offset;
         GlyphText spaceText = null;
         Rectangle2D.Double spaceBounds;
@@ -246,7 +243,9 @@ public class WordText extends AbstractText implements TextSelect {
                         spaceBounds.y,
                         spaceBounds.width,
                         spaceBounds.height),
-                (char) 32, String.valueOf((char) 32));
+                0,
+                (char) 32,
+                String.valueOf((char) 32));
         whiteSpace.addText(spaceText);
         whiteSpace.setWhiteSpace(true);
         return whiteSpace;
@@ -275,11 +274,11 @@ public class WordText extends AbstractText implements TextSelect {
             }
             bounds.add(sprite.getBounds());
         }
-        if (textExtractionBounds == null) {
-            rect = sprite.getTextExtractionBounds();
-            textExtractionBounds = new Rectangle2D.Double(rect.x, rect.y, rect.width, rect.height);
+        if (textSelectionBounds == null) {
+            rect = sprite.getTextSelectionBounds();
+            textSelectionBounds = new Rectangle2D.Double(rect.x, rect.y, rect.width, rect.height);
         } else {
-            textExtractionBounds.add(sprite.getTextExtractionBounds());
+            textSelectionBounds.add(sprite.getTextSelectionBounds());
         }
 
         // append the text that maps up the sprite
@@ -299,11 +298,11 @@ public class WordText extends AbstractText implements TextSelect {
                 } else {
                     bounds.add(glyph.getBounds());
                 }
-                if (textExtractionBounds == null) {
-                    Rectangle2D.Double rect = glyph.getTextExtractionBounds();
-                    textExtractionBounds = new Rectangle2D.Double(rect.x, rect.y, rect.width, rect.height);
+                if (textSelectionBounds == null) {
+                    Rectangle2D.Double rect = glyph.getTextSelectionBounds();
+                    textSelectionBounds = new Rectangle2D.Double(rect.x, rect.y, rect.width, rect.height);
                 } else {
-                    textExtractionBounds.add(glyph.getTextExtractionBounds());
+                    textSelectionBounds.add(glyph.getTextSelectionBounds());
                 }
             }
         }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
@@ -43,12 +43,7 @@ public class Indexer {
         DictionaryEntries xRefDictionary = null;
         Lexer lexer = new Lexer(library);
         Parser parser = new Parser(library);
-        int previousPos = -1;
         while (pos > 0) {
-            if (previousPos == pos) {
-                throw new IOException("Failed to index objects (infinite loop)");
-            }
-            previousPos = pos;
             if (xRefDictionary == null) {
                 int end = 0;
                 int trailerPosition = pos = ByteBufferUtil.findReverseString(byteBuffer, byteBuffer.limit(), end, Parser.TRAILER_MARKER);

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
@@ -1559,7 +1559,7 @@ public abstract class AbstractContentParser {
             GlyphText glyphText = textSprites.addText(
                     currentChar, // cid
                     textState.currentfont.toUnicode(currentChar), // unicode value
-                    currentX, currentY, newAdvanceX, newAdvanceY);
+                    currentX, currentY, newAdvanceX, newAdvanceY, shapes.getRotation());
             shapes.getPageText().addGlyph(glyphText, oCGs);
 
             if (contentStreamRedactorCallback != null) {

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
@@ -45,6 +45,7 @@ public class ContentParser extends AbstractContentParser {
             throws InterruptedException, IOException {
         if (shapes == null) {
             shapes = new Shapes();
+            shapes.setRotation(page != null ? page.getPageRotation() : 0f);
             if (graphicState == null) {
                 graphicState = new GraphicsState(shapes);
             }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
@@ -160,7 +160,7 @@ public class DocumentSearchControllerImpl implements DocumentSearchController {
      * <br>
      * This class differences from {@link #searchHighlightPage(int)} in that
      * is returns a list of lineText fragments for each hit but the LinText
-     * is padded by pre and post words that surround the hit in the page
+     * is padded by pre- and post-words that surround the hit in the page
      * context.
      * <br>
      * This method represent the org.icepdf.core search algorithm for this
@@ -962,7 +962,8 @@ public class DocumentSearchControllerImpl implements DocumentSearchController {
         try {
             if (viewerController != null) {
                 // get access to currently open document instance.
-
+                // this has been getPageText in the past when the search cursor was introduced, but I can't see
+                // a good reason for not using the view text in this circumatstance
                 pageText = viewerController.getDocument().getPageViewText(pageIndex);
             } else if (document != null) {
                 pageText = document.getPageViewText(pageIndex);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
@@ -962,9 +962,10 @@ public class DocumentSearchControllerImpl implements DocumentSearchController {
         try {
             if (viewerController != null) {
                 // get access to currently open document instance.
-                pageText = viewerController.getDocument().getPageText(pageIndex);
+
+                pageText = viewerController.getDocument().getPageViewText(pageIndex);
             } else if (document != null) {
-                pageText = document.getPageText(pageIndex);
+                pageText = document.getPageViewText(pageIndex);
             }
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
@@ -34,8 +34,8 @@ import org.icepdf.ri.common.views.PageViewComponentImpl;
 
 import java.awt.*;
 import java.awt.geom.Rectangle2D;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -267,8 +267,8 @@ public class DocumentSearchControllerImpl implements DocumentSearchController {
                                     // add word to potentials
                                     searchPhraseHitCount++;
                                 }
-                                // reset the counters.
                                 else {
+                                    // reset the counters.
                                     searchPhraseHitCount = 0;
                                 }
                             } else {


### PR DESCRIPTION
- long standing bug where text selection and searching can act wonky when a Page has a non zero rotation.   
- In such a case text is generally not layed out  int a left to right top down way and the text sorting code ends up putting in a whole bunch more line breaks and spaces then actually needed. 