### PR TITLE
GH-410 fix word being flagged as whitespace

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/LineText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/LineText.java
@@ -91,7 +91,6 @@ public class LineText extends AbstractText implements TextSelect {
             currentWord = null;
             // add as a new word, nothing special otherwise
             WordText newWord = new WordText(this.pageRotation);
-            newWord.setWhiteSpace(true);
             newWord.addText(sprite);
             addWord(newWord);
         }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchFilterButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchFilterButton.java
@@ -80,7 +80,7 @@ public class SearchFilterButton extends DropDownButton {
         });
         if (isRegex || isWholeWord) {
             regexCheckbox.setEnabled(isRegex);
-            wholePageCheckbox.setEnabled(isWholeWord());
+            wholePageCheckbox.setEnabled(!isRegex);
             wholeWordCheckbox.setEnabled(isWholeWord);
         }
         cumulativeCheckbox = new PersistentJCheckBoxMenuItem(messageBundle.getString(

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchFilterButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchFilterButton.java
@@ -70,6 +70,7 @@ public class SearchFilterButton extends DropDownButton {
             wholePageCheckbox.setSelected(isWholePage() || isRegex());
             component.notifySearchFiltersChanged();
             preferences.putBoolean(PROPERTY_SEARCH_PANEL_REGEX_ENABLED, isRegex());
+            preferences.putBoolean(PROPERTY_SEARCH_PANEL_WHOLE_PAGE_ENABLED, isWholePage());
         });
         caseSensitiveCheckbox = new PersistentJCheckBoxMenuItem(messageBundle.getString(
                 "viewer.utilityPane.search.caseSenstiveCheckbox.label"), isCaseSensitive);
@@ -79,6 +80,7 @@ public class SearchFilterButton extends DropDownButton {
         });
         if (isRegex || isWholeWord) {
             regexCheckbox.setEnabled(isRegex);
+            wholePageCheckbox.setEnabled(isWholeWord());
             wholeWordCheckbox.setEnabled(isWholeWord);
         }
         cumulativeCheckbox = new PersistentJCheckBoxMenuItem(messageBundle.getString(
@@ -94,7 +96,7 @@ public class SearchFilterButton extends DropDownButton {
             preferences.putBoolean(PROPERTY_SEARCH_PANEL_SEARCH_TEXT_ENABLED, isText());
         });
         formsCheckbox = new PersistentJCheckBoxMenuItem(messageBundle.getString(
-                "viewer.utilityPane.search.forms.label"), isText);
+                "viewer.utilityPane.search.forms.label"), isForms);
         formsCheckbox.addActionListener(actionEvent -> {
             component.notifySearchFiltersChanged();
             preferences.putBoolean(PROPERTY_SEARCH_PANEL_SEARCH_FORMS_ENABLED, isForms());

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
@@ -311,6 +311,7 @@ public class DocumentViewControllerImpl
     }
 
     public String getSelectedText() {
+        if (documentViewModel == null) return null;
         StringBuilder selectedText = new StringBuilder();
         try {
             // regular page selected by user mouse, keyboard or api


### PR DESCRIPTION
- addresses a really old but where text could be marked as white space when autospaces were inserted before the word. 
- this fixes a corner case where the word in question won't show up in a regex search. 
- fix a few UI state issues with the search filter button menuItems. 