### PR TITLE
GH-414 make sure we have a CompositeFont before proceeding

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
@@ -73,8 +73,10 @@ public class Type0Font extends SimpleFont {
                 Object descendantFontObject = descendantFonts.get(0);
                 if (descendantFontObject instanceof Reference) {
                     Reference descendantFontReference = (Reference) descendantFontObject;
-                    descendantFont = (CompositeFont) library.getObject(descendantFontReference);
-                } else if (descendantFontObject instanceof CompositeFont) {
+                    descendantFontObject = library.getObject(descendantFontReference);
+                }
+
+                if (descendantFontObject instanceof CompositeFont) {
                     descendantFont = (CompositeFont) descendantFontObject;
                 }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
@@ -4,6 +4,7 @@ import org.icepdf.core.pobjects.DictionaryEntries;
 import org.icepdf.core.pobjects.Name;
 import org.icepdf.core.pobjects.Reference;
 import org.icepdf.core.pobjects.Stream;
+import org.icepdf.core.pobjects.fonts.FontDescriptor;
 import org.icepdf.core.pobjects.fonts.zfont.cmap.CMap;
 import org.icepdf.core.util.Library;
 
@@ -78,6 +79,11 @@ public class Type0Font extends SimpleFont {
 
                 if (descendantFontObject instanceof CompositeFont) {
                     descendantFont = (CompositeFont) descendantFontObject;
+                }
+                // strange malformed PDFe where the descendant font is a font descriptor,
+                else if (descendantFontObject instanceof FontDescriptor) {
+                    fontDescriptor = (FontDescriptor) descendantFontObject;
+                    parseFontDescriptor();
                 }
 
                 if (descendantFont != null) {


### PR DESCRIPTION
- add some protection to make sure we are dealing with a CompositeFont before casting.  
- user has reported a malformed file but no sample as of yet. 
- if I can get the sample file,  might be able to check if the returned FontDescriptor has a workable font.  
