### PR TITLE
GH-417 remove hard code tree sizes and spacing, fallback on swing defaults

### DIFF
--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/AbstractWorkerPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/AbstractWorkerPanel.java
@@ -136,8 +136,6 @@ public abstract class AbstractWorkerPanel extends JPanel implements MutableDocum
         tree.setScrollsOnExpand(true);
         // setup a custom cell render
         if (cellRenderer != null) tree.setCellRenderer(cellRenderer);
-        tree.setFont(new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 13));
-        tree.setRowHeight(18);
         tree.setRootVisible(false);
         tree.setExpandsSelectedPaths(true);
         tree.setShowsRootHandles(true);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/NameJTree.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/NameJTree.java
@@ -34,8 +34,5 @@ public class NameJTree extends JTree {
         setModel(null);
         setRootVisible(true);
         setScrollsOnExpand(true);
-        // old font was Arial with is no go for linux.
-        setFont(new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 13));
-        setRowHeight(18);
     }
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/layers/LayersTree.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/layers/LayersTree.java
@@ -39,9 +39,6 @@ public class LayersTree extends JTree {
                 TreeSelectionModel.SINGLE_TREE_SELECTION);
         setRootVisible(true);
         setScrollsOnExpand(true);
-        // old font was Arial with is no go for linux.
-        setFont(new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 13));
-        setRowHeight(18);
     }
 }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/outline/OutlinesTree.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/outline/OutlinesTree.java
@@ -56,10 +56,6 @@ public class OutlinesTree extends JTree {
 
         setDragEnabled(true);
         setDropMode(DropMode.ON_OR_INSERT);
-
-        // old font was Arial with is no go for linux.
-        setFont(new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 13));
-        setRowHeight(18);
     }
 
     public TreePath getNextMatch(String prefix, int startingRow, Position.Bias bias) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignaturesTree.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignaturesTree.java
@@ -42,9 +42,5 @@ public class SignaturesTree extends JTree {
 
         // setup a custom cell render
         setCellRenderer(new SignatureCellRender());
-
-        // old font was Arial with is no go for linux.
-        setFont(new java.awt.Font("SansSerif", java.awt.Font.PLAIN, 13));
-        setRowHeight(18);
     }
 }


### PR DESCRIPTION
- remove some jtree font size settings. 
- no default to default swing look and feel. 