### PR TITLE
GH-436 fix cert signer path in test.

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/handlers/Pkcs11SignerHandler.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/handlers/Pkcs11SignerHandler.java
@@ -67,6 +67,17 @@ public class Pkcs11SignerHandler extends SignerHandler {
     }
 
     @Override
+    public X509Certificate getCertificate() throws KeyStoreException {
+        if (keystore == null) {
+            buildKeyStore();
+        }
+        if (certAlias == null) {
+            certAlias = getAliasByCertificateSerialNumber(keystore, certSerial);
+        }
+        return super.getCertificate();
+    }
+
+    @Override
     protected PrivateKey getPrivateKey() throws KeyStoreException, UnrecoverableKeyException,
             NoSuchAlgorithmException {
         logger.log(Level.INFO, "search for");

--- a/viewer/viewer-awt/src/test/java/org/icepdf/signing/SigningTests.java
+++ b/viewer/viewer-awt/src/test/java/org/icepdf/signing/SigningTests.java
@@ -45,7 +45,7 @@ public class SigningTests {
     public void testXrefTableFullUpdate() {
 
         try {
-            String keystorePath = "/home/pcorless/dev/cert-test/openssl-keypair/certificate.pfx";
+            String keystorePath = "/signing/certificate.pfx";
             String password = "changeit";
             String certAlias = "senderKeyPair";
 


### PR DESCRIPTION
- SigningTest referenced a local cert which breaks the viewer build. 
- created cert specifically for test and added to test resources. 
