### PR TITLE
GH-440 font factory cache for loaded system fonts

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontDescriptor.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontDescriptor.java
@@ -311,7 +311,7 @@ public class FontDescriptor extends Dictionary {
         // catch everything, we can fall back to font substitution if a failure
         // occurs.
         catch (Exception e) {
-            logger.log(Level.WARNING, "Error Reading Embedded Font ", e);
+            logger.log(Level.WARNING, "Error Reading Embedded Font, falling back to substitution ", e);
             embeddedFontDamaged = true;
         }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontFactory.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontFactory.java
@@ -111,26 +111,22 @@ public class FontFactory {
         return font;
     }
 
-    public FontFile createFontFile(Stream fontStream, int fontType, Name fontSubType) {
+    public FontFile createFontFile(Stream fontStream, int fontType, Name fontSubType) throws Exception {
         FontFile fontFile = null;
-        try {
-            if (FONT_OPEN_TYPE == fontType) {
-                fontFile = new ZFontOpenType(fontStream);
-            } else if (FONT_TRUE_TYPE == fontType) {
-                fontFile = new ZFontTrueType(fontStream);
-            } else if (FONT_TYPE_1 == fontType) {
-                fontFile = new ZFontType1(fontStream);
-            } else if (FONT_TYPE_1C == fontType) {
-                fontFile = new ZFontType1C(fontStream);
-            } else if (FONT_CID_TYPE_0 == fontType) {
-                fontFile = new ZFontType0(fontStream);
-            } else if (FONT_CID_TYPE_0C == fontType || FONT_CID_TYPE_1C == fontType) {
-                fontFile = new ZFontType0(fontStream);
-            } else if (FONT_CID_TYPE_2 == fontType) {
-                fontFile = new ZFontType2(fontStream);
-            }
-        } catch (Exception e) {
-            logger.log(Level.WARNING, "Error reading font file type " + FONT_OPEN_TYPE, e);
+        if (FONT_OPEN_TYPE == fontType) {
+            fontFile = new ZFontOpenType(fontStream);
+        } else if (FONT_TRUE_TYPE == fontType) {
+            fontFile = new ZFontTrueType(fontStream);
+        } else if (FONT_TYPE_1 == fontType) {
+            fontFile = new ZFontType1(fontStream);
+        } else if (FONT_TYPE_1C == fontType) {
+            fontFile = new ZFontType1C(fontStream);
+        } else if (FONT_CID_TYPE_0 == fontType) {
+            fontFile = new ZFontType0(fontStream);
+        } else if (FONT_CID_TYPE_0C == fontType || FONT_CID_TYPE_1C == fontType) {
+            fontFile = new ZFontType0(fontStream);
+        } else if (FONT_CID_TYPE_2 == fontType) {
+            fontFile = new ZFontType2(fontStream);
         }
         return fontFile;
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1.java
@@ -167,7 +167,7 @@ public class ZFontType1 extends ZSimpleFont {
 
     @Override
     public String getName() {
-        return type1Font.getName();
+        return type1Font != null ? type1Font.getName() : null;
     }
 
     private void calculateFontBbox() throws IOException {


### PR DESCRIPTION
- adds a cache for system fonts as per the suggestion of @volkerwahh 
- when a page(s) have a lot of fonts that fallback on font substitution then the cache kicks in. 
- this is particularly useful with acroforms where there could be 60 fields on a page and 60 instances of the same font. 
- anyways nice memory optimization