### PR TITLE
GH-439 add some protection and early exit of the PageImageCaptureTask…

### DIFF
--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractPageViewComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractPageViewComponent.java
@@ -427,6 +427,9 @@ public abstract class AbstractPageViewComponent
                     documentViewController);
             boolean isFirstProgressivePaint = false;
             try {
+                // be careful that the document hasn't been closed on awt thread.
+                if (documentViewController != null && documentViewController.getDocumentViewModel() == null)
+                    return null;
                 if (documentViewController != null) page.addPageProcessingListener(pageLoadingListener);
                 // page init, interruptible
                 page.init();


### PR DESCRIPTION
- @volkerwahh called out that they are seeing some extra memory on disposing a document and the occasional exception.  
- the problem is related the the pageImageCaptureTask/thread/process not being canceled  on dispose. 
- in theory a page parse and paint can happen even as a page is disposed and previously there was no attempt to clean the process up.   Not a pig deal normally but in a memory constricted jvm, it can cause problems.
- this pr adds some protection for a null documentViewModel and cancels the task on dispose.  
- this should keep the memory footprint pretty small on dispose. 