### PR TITLE
GH-444 add a configurable for user node for the preference api

### DIFF
--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/FontPropertiesManager.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/FontPropertiesManager.java
@@ -16,6 +16,7 @@
 package org.icepdf.ri.util;
 
 import org.icepdf.core.pobjects.fonts.FontManager;
+import org.icepdf.core.util.Defs;
 import org.icepdf.ri.util.font.FontCache;
 
 import java.util.Properties;
@@ -44,7 +45,21 @@ public class FontPropertiesManager {
     private static final Logger logger = Logger.getLogger(FontPropertiesManager.class.toString());
 
     // can't use system level cache on window as of JDK 1.8_14, but should work in 9.
-    private static final Preferences prefs = Preferences.userNodeForPackage(FontCache.class);
+    private static final Preferences prefs = Preferences.userNodeForPackage(getPreferencesClass());
+
+    public static final String PREFERENCES_KEY_CLASS = "org.icepdf.ri.util.FontPreferencesKey";
+
+    private static Class<?> getPreferencesClass() {
+        String fontPreferencesKey = Defs.sysProperty(PREFERENCES_KEY_CLASS);
+        if (fontPreferencesKey != null) {
+            try {
+                return Class.forName(fontPreferencesKey);
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return FontCache.class;
+    }
 
     private static FontPropertiesManager fontPropertiesManager;
 


### PR DESCRIPTION
Adds a new system property org.icepdf.ri.util.FontPreferencesKey that allows the specification of the class path  that should be used for the user node when writing the preference file.  By default nothing changes but the system property can be used to specify a new class path where the preferences will be written. 