### PR TITLE
GH-445 allow list for fontManager

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.prefs.Preferences;
+import java.util.regex.Pattern;
 
 /**
  * <p>The <code>FontManager</code> class is responsible for finding available
@@ -48,6 +49,31 @@ public class FontManager {
 
     private static final Logger logger =
             Logger.getLogger(FontManager.class.toString());
+
+    /**
+     * You can set an allowListPattern by Setting the System Property "org.icepdf.core.pobjects.fonts
+     * .fontFileAllowListPattern":
+     * <pre><code>
+     * System.getProperties().put(FONT_FILE_ALLOW_LIST_PATTERN_PROPERTY, MOST_COMMON_FONTS_PATTERN);
+     * </code></pre>
+     */
+    public static final String FONT_FILE_ALLOW_LIST_PATTERN_PROPERTY =
+            "org.icepdf.core.pobjects.fonts.fontFileAllowListPattern";
+
+    /**
+     * Target of this Pattern is to get some system fonts, but not too much, if memory is a topic. This
+     * Pattern has a positive list in the beginning as well as a negative list with the Unicode, to exclude
+     * some "huge" Unicode-Fonts.
+     * But of course this is just an example to get started with an allowList.
+     */
+    public static final String MOST_COMMON_FONTS_PATTERN =
+            "(?i)^.*?(Times New Roman|arial|Courier New|Helvetica)(?!.*?Unicode).*?";
+
+    /**
+     * Allow list pattern for font file names.  If the pattern is empty no filtering takes place.  The default
+     * is an empty string which means all fonts are loaded.
+     */
+    public static final String DEFAULT_FONT_FILE_ALLOW_LIST_PATTERN = "";
 
     // stores all font data
     private static List<Object[]> fontList;
@@ -230,13 +256,19 @@ public class FontManager {
      */
     private static final String baseFontName;
 
+    private static final Pattern fontAllowListPattern;
+
     static {
         baseFontName = Defs.property("org.icepdf.core.font.basefont", "lucidasans");
+
+        fontAllowListPattern = getFontAllowListPattern();
     }
 
     // Singleton instance of class
     private static FontManager fontManager;
 
+    private FontManager() {
+    }
 
     /**
      * <p>Returns a static instance of the FontManager class.</p>
@@ -447,7 +479,7 @@ public class FontManager {
                     if (files != null) {
                         List<String> dirPaths = new ArrayList<>();
                         for (File file : files) {
-                            if (file.isFile()) {
+                            if (isFontFileAllowed(file)) {
                                 // load the font.
                                 evaluateFontForInsertion(file.getAbsolutePath());
                             } else if (file.isDirectory()) {
@@ -1257,6 +1289,31 @@ public class FontManager {
             }
         }
         return false;
+    }
+
+    private static Pattern getFontAllowListPattern() {
+        final Pattern fileAllowListPattern;
+        String patternString =
+                Defs.sysProperty(FONT_FILE_ALLOW_LIST_PATTERN_PROPERTY, DEFAULT_FONT_FILE_ALLOW_LIST_PATTERN);
+        fileAllowListPattern = Pattern.compile(patternString);
+        return fileAllowListPattern;
+    }
+
+    /**
+     * Check to see if the given file is allowed based on the current
+     * fontAllowListPattern.  If the pattern is empty all files are allowed.
+     *
+     * @param file file to check
+     * @return true if the file is allowed, false otherwise.
+     */
+    private boolean isFontFileAllowed(File file) {
+        if (!file.isFile()) {
+            return false;
+        }
+        if (fontAllowListPattern.pattern().isEmpty()) {
+            return true;
+        }
+        return fontAllowListPattern.matcher(file.getName()).matches();
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
@@ -256,18 +256,17 @@ public class FontManager {
      */
     private static final String baseFontName;
 
-    private static final Pattern fontAllowListPattern;
+    private Pattern fontAllowListPattern;
 
     static {
         baseFontName = Defs.property("org.icepdf.core.font.basefont", "lucidasans");
-
-        fontAllowListPattern = getFontAllowListPattern();
     }
 
     // Singleton instance of class
     private static FontManager fontManager;
 
     private FontManager() {
+        fontAllowListPattern = getFontAllowListPattern();
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
@@ -61,7 +61,7 @@ public class FontManager {
             "org.icepdf.core.pobjects.fonts.fontFileAllowListPattern";
 
     /**
-     * Target of this Pattern is to get some system fonts, but not too much, if memory is a topic. This
+     * Target of this Pattern is to get some system fonts, but not too many if memory is a topic. This
      * Pattern has a positive list in the beginning as well as a negative list with the Unicode, to exclude
      * some "huge" Unicode-Fonts.
      * But of course this is just an example to get started with an allowList.
@@ -265,7 +265,10 @@ public class FontManager {
     // Singleton instance of class
     private static FontManager fontManager;
 
-    private FontManager() {
+    /**
+     * VisibilityForTesting
+     */
+    FontManager() {
         fontAllowListPattern = getFontAllowListPattern();
     }
 
@@ -1302,10 +1305,12 @@ public class FontManager {
      * Check to see if the given file is allowed based on the current
      * fontAllowListPattern.  If the pattern is empty all files are allowed.
      *
+     * VisibilityForTesting
+     *
      * @param file file to check
      * @return true if the file is allowed, false otherwise.
      */
-    private boolean isFontFileAllowed(File file) {
+    boolean isFontFileAllowed(File file) {
         if (!file.isFile()) {
             return false;
         }

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/fonts/FontManagerTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/fonts/FontManagerTest.java
@@ -1,0 +1,62 @@
+package org.icepdf.core.pobjects.fonts;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.icepdf.core.pobjects.fonts.FontManager.FONT_FILE_ALLOW_LIST_PATTERN_PROPERTY;
+import static org.icepdf.core.pobjects.fonts.FontManager.MOST_COMMON_FONTS_PATTERN;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class FontManagerTest {
+    private static final Set<String> SAMPLE_FILENAMES = Set.of("foo.ttf", "Arial Bold.ttf", "Arial Unicode.ttf",
+            "Arial Narrow.ttf", "Foo Bold.ttf", "Foo Unicode.ttf", "Foo Narrow.ttf", "Times New Roman.ttf", "Apple " +
+                    "Symbols.ttf");
+    private static final Set<String> EXPECTED_FILTERED_FILES = Set.of("Arial Bold.ttf", "Arial Narrow.ttf", "Times " +
+            "New Roman.ttf");
+    private static final boolean EXPECTED_FALSE_AS_NO_FILE = false;
+
+    private static Stream<Arguments> paramProvider() {
+        return Stream.of(
+                arguments(
+                        null,
+                        SAMPLE_FILENAMES),
+                arguments(
+                        MOST_COMMON_FONTS_PATTERN,
+                        EXPECTED_FILTERED_FILES));
+    }
+
+    @ParameterizedTest
+    @MethodSource("paramProvider")
+    void testIsFontFileAllowedPattern(String patternString, Set<String> expectedFiles) throws IOException {
+        // Given
+        if (patternString != null) {
+            System.setProperty(FONT_FILE_ALLOW_LIST_PATTERN_PROPERTY, patternString);
+        }
+        FontManager instance = new FontManager();
+        Path tempDirectory = Files.createTempDirectory(FontManager.class.getSimpleName());
+        for (String sampleFilename : SAMPLE_FILENAMES) {
+            // Given
+            File sampleFile = tempDirectory.resolve(sampleFilename).toFile();
+            // When
+            boolean actualAllowed = instance.isFontFileAllowed(sampleFile);
+            // Then
+            Assertions.assertEquals(EXPECTED_FALSE_AS_NO_FILE, actualAllowed);
+            // Given
+            sampleFile.createNewFile();
+            // When
+            actualAllowed = instance.isFontFileAllowed(sampleFile);
+            // Then
+            boolean expectedAllowed = expectedFiles.contains(sampleFilename);
+            Assertions.assertEquals(expectedAllowed, actualAllowed);
+        }
+    }
+}


### PR DESCRIPTION
Adds a new system property to specify regex to filter out system fonts that will be read by the font manager.   