### PR TITLE
GH-451 break out of reindexing file if no xref is found

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
@@ -83,7 +83,9 @@ public class Indexer {
                                 (CrossReferenceStream) parser.getCrossReference(byteBuffer, xRefPosition);
                         xRefDictionary = crossReferenceStream.getDictionaryEntries();
                     } catch (ObjectStateException e) {
-                        logger.finer("Failed to get cross reference for offset: " + xRefPosition);
+                        logger.finer("Failed to get cross reference for offset, likely not a PDF File: " + xRefPosition);
+                        throw new IllegalStateException("Failed to get cross reference for offset, likely not a PDF " +
+                                "File: " + xRefPosition, e);
                     }
                 }
 
@@ -111,7 +113,7 @@ public class Indexer {
                 pos = objectStart;
             }
         }
-        // add entries to the cross reference.
+        // add entries to the cross-reference.
         return crossReferenceRoot;
     }
 


### PR DESCRIPTION
- reindexing a corrupted PDF file is tricky work.  
- the new indexer code has a bug in that it will get caught in a infinite loop if the xref table isn't found. 
- The indexer was designed for cases where we have a more or less valid PDF file with valid objects but there was drift in the object offset values in the xref table.  
- This fix will kill the indexer if an /xref table or stream can't be found.  