### PR TITLE
GH-480 add method for registering a new ImageReference.

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReferenceFactory.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReferenceFactory.java
@@ -22,19 +22,30 @@ import org.icepdf.core.pobjects.graphics.GraphicsState;
 import org.icepdf.core.pobjects.graphics.images.ImageStream;
 import org.icepdf.core.util.Defs;
 
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Logger;
+
 /**
  * The ImageReferenceFactory determines which implementation of the
  * Image Reference should be created.  The ImageReference type can be specified
- * by the following system properties or alternatively by the enum type.
+ * by the following system properties or alternatively by the registered type key.
  * <ul>
  * <li>org.icepdf.core.imageReference = default</li>
  * <li>org.icepdf.core.imageReference = scaled</li>
  * <li>org.icepdf.core.imageReference = mipmap</li>
  * <li>org.icepdf.core.imageReference = smoothScaled</li>
+ * <li>org.icepdf.core.imageReference = blurred</li>
  * </ul>
- * The default value returns an unaltered image,  scaled returns a scaled
- * image instance and there MIP mapped returns/picks a scaled image that
- * best fits the current zoom level for a balance of render speed and quality.
+ * The default value returns an unaltered image, scaled returns a scaled
+ * image instance and MIP mapped returns/picks a scaled image that best fits
+ * the current zoom level for a balance of render speed and quality.
+ * <p>
+ * New ImageReference implementations can be registered at runtime via
+ * {@link #register(String, String, ImageReferenceCreator)}, allowing third-party
+ * or application-level image reference types to be added without modifying this class.
  *
  * @see MipMappedImageReference
  * @see ImageStreamReference
@@ -43,87 +54,184 @@ import org.icepdf.core.util.Defs;
  */
 public class ImageReferenceFactory {
 
-    // allow scaling of large images to improve clarity on screen
+    private static final Logger logger = Logger.getLogger(ImageReferenceFactory.class.getName());
 
-    public enum ImageReference {
-        DEFAULT, SCALED, MIP_MAP, SMOOTH_SCALED, BLURRED
-
-
+    /**
+     * Functional interface for creating an {@link ImageReference} instance.
+     * Implement this to register a custom image reference type.
+     */
+    @FunctionalInterface
+    public interface ImageReferenceCreator {
+        ImageReference create(ImageStream imageStream, Name xobjectName, GraphicsState graphicsState,
+                              Resources resources, int imageIndex, Page page);
     }
 
-    public static ImageReference imageReferenceType;
+    // Built-in type key constants
+    public static final String TYPE_DEFAULT = "default";
+    public static final String TYPE_SCALED = "scaled";
+    public static final String TYPE_MIP_MAP = "mipmap";
+    public static final String TYPE_SMOOTH_SCALED = "smoothScaled";
+    public static final String TYPE_BLURRED = "blurred";
+
+    /**
+     * Registry entry pairing a display label with a creator.
+     */
+    public static final class RegistryEntry {
+        private final String displayName;
+        private final ImageReferenceCreator creator;
+
+        public RegistryEntry(String displayName, ImageReferenceCreator creator) {
+            this.displayName = displayName;
+            this.creator = creator;
+        }
+
+        public String getDisplayName() {
+            return displayName;
+        }
+
+        public ImageReferenceCreator getCreator() {
+            return creator;
+        }
+    }
+
+    /**
+     * Thread-safe registry of all known image reference types. Insertion order
+     * is preserved via the LinkedHashMap delegate so UI combo-boxes are stable.
+     */
+    private static final Map<String, RegistryEntry> orderedRegistry =
+            Collections.synchronizedMap(new LinkedHashMap<>());
+
+    /**
+     * Currently active image reference type key.
+     */
+    public static String imageReferenceType;
 
     static {
-        // decide if large images will be scaled
-        String imageReferenceType =
-                Defs.sysProperty("org.icepdf.core.imageReference",
-                        "default");
-        ImageReferenceFactory.imageReferenceType = getImageReferenceType(imageReferenceType);
+        // Register the five built-in types
+        registerBuiltin(TYPE_DEFAULT, "Default", ImageStreamReference::new);
+        registerBuiltin(TYPE_SCALED, "Scaled", ScaledImageReference::new);
+        registerBuiltin(TYPE_MIP_MAP, "MIP Map", MipMappedImageReference::new);
+        registerBuiltin(TYPE_SMOOTH_SCALED, "Smooth Scaled", SmoothScaledImageReference::new);
+        registerBuiltin(TYPE_BLURRED, "Blurred", BlurredImageReference::new);
+
+        // Resolve active type from system property
+        imageReferenceType = Defs.sysProperty("org.icepdf.core.imageReference", TYPE_DEFAULT);
+        if (!orderedRegistry.containsKey(imageReferenceType)) {
+            logger.warning("Unknown imageReference type '" + imageReferenceType + "', falling back to default.");
+            imageReferenceType = TYPE_DEFAULT;
+        }
     }
 
     private ImageReferenceFactory() {
     }
 
-    public static ImageReference getImageReferenceType() {
+    /**
+     * Registers a new image reference type.  Call this before the first page
+     * is rendered, typically at application startup.
+     *
+     * @param key         unique, case-sensitive identifier (e.g. {@code "myCustomType"})
+     * @param displayName human-readable label used in preference UIs
+     * @param creator     factory lambda that constructs the ImageReference
+     * @throws IllegalArgumentException if {@code key} is null or empty
+     */
+    public static void register(String key, String displayName, ImageReferenceCreator creator) {
+        if (key == null || key.isEmpty()) {
+            throw new IllegalArgumentException("ImageReference key must not be null or empty.");
+        }
+        orderedRegistry.put(key, new RegistryEntry(displayName != null ? displayName : key, creator));
+    }
+
+    /**
+     * Returns an unmodifiable ordered view of all registered type keys and their entries.
+     */
+    public static Map<String, RegistryEntry> getRegisteredTypes() {
+        synchronized (orderedRegistry) {
+            return Collections.unmodifiableMap(new LinkedHashMap<>(orderedRegistry));
+        }
+    }
+
+    /**
+     * Returns an ordered set of all registered type keys.
+     */
+    public static Set<String> getRegisteredTypeKeys() {
+        return getRegisteredTypes().keySet();
+    }
+
+
+    /**
+     * Returns the currently active image reference type key.
+     */
+    public static String getImageReferenceType() {
         return imageReferenceType;
     }
 
-    public static void setImageReferenceType(ImageReference imageReferenceType) {
-        ImageReferenceFactory.imageReferenceType = imageReferenceType;
+    /**
+     * Sets the active image reference type by key.
+     *
+     * @param key a registered type key; if unknown, falls back to {@link #TYPE_DEFAULT}.
+     */
+    public static void setImageReferenceType(String key) {
+        if (orderedRegistry.containsKey(key)) {
+            imageReferenceType = key;
+        } else {
+            logger.warning("Unknown imageReference type '" + key + "', falling back to default.");
+            imageReferenceType = TYPE_DEFAULT;
+        }
     }
 
     /**
-     * Takes a given imageReferenceType name and returns the associated enum type.
+     * Normalizes a property-string or legacy enum-name to a registered key.
+     * Handles both the canonical keys ({@code "default"}, {@code "mipmap"}, …) and
+     * the old enum names ({@code "DEFAULT"}, {@code "MIP_MAP"}, …) for backward
+     * compatibility with stored preferences.
      *
-     * @param imageReferenceType image type to get enum for.
-     * @return associated ImageReference enum or ImageReference.DEFAULT if no mapping can be found.
+     * @param name the raw string from a system property or preference store.
+     * @return the matching registered key, or {@link #TYPE_DEFAULT} if not found.
      */
-    public static ImageReference getImageReferenceType(String imageReferenceType) {
-        ImageReference scaleType;
-        if ("scaled".equals(imageReferenceType) || "SCALED".equals(imageReferenceType)) {
-            scaleType = ImageReference.SCALED;
-        } else if ("mipmap".equals(imageReferenceType) || "MIP_MAP".equals(imageReferenceType)) {
-            scaleType = ImageReference.MIP_MAP;
-        } else if ("smoothScaled".equals(imageReferenceType) || "SMOOTH_SCALED".equals(imageReferenceType)) {
-            scaleType = ImageReference.SMOOTH_SCALED;
-        } else if ("blurred".equals(imageReferenceType) || "BLURRED".equals(imageReferenceType)) {
-            scaleType = ImageReference.BLURRED;
-        } else {
-            scaleType = ImageReference.DEFAULT;
+    public static String getImageReferenceType(String name) {
+        if (name == null) return TYPE_DEFAULT;
+        // Direct registry hit (handles canonical keys and any custom keys)
+        if (orderedRegistry.containsKey(name)) return name;
+        // Legacy enum-name aliases for backward compatibility
+        switch (name.toUpperCase()) {
+            case "SCALED":
+                return TYPE_SCALED;
+            case "MIP_MAP":
+                return TYPE_MIP_MAP;
+            case "SMOOTH_SCALED":
+                return TYPE_SMOOTH_SCALED;
+            case "BLURRED":
+                return TYPE_BLURRED;
+            default:
+                return TYPE_DEFAULT;
         }
-        return scaleType;
     }
+
 
     /**
      * Gets an instance of an ImageReference object for the given image data.
-     * The ImageReference is specified by the system property org.icepdf.core.imageReference
-     * or by the static instance variable scale type.
+     * The ImageReference type is determined by {@link #imageReferenceType}.
      *
      * @param imageStream   image data
-     * @param xobjectName   image name if specified via do xobject reference, can be null
-     * @param resources     parent resource object.
-     * @param graphicsState image graphic state.
-     * @param page          page that image belongs to .
-     * @param imageIndex    image index number of total images for the page.
-     * @return newly create ImageReference.
+     * @param xobjectName   image name if specified via xObject reference, can be null
+     * @param resources     parent resource object
+     * @param graphicsState image graphic state
+     * @param page          page that the image belongs to
+     * @param imageIndex    image index number of total images for the page
+     * @return newly created ImageReference
      */
-    public static org.icepdf.core.pobjects.graphics.images.references.ImageReference getImageReference(
+    public static ImageReference getImageReference(
             ImageStream imageStream, Name xobjectName, Resources resources, GraphicsState graphicsState,
             Integer imageIndex, Page page) {
-        switch (imageReferenceType) {
-            case SCALED:
-                return new ScaledImageReference(imageStream, xobjectName, graphicsState, resources, imageIndex, page);
-            case SMOOTH_SCALED:
-                return new SmoothScaledImageReference(imageStream, xobjectName, graphicsState, resources, imageIndex,
-                        page);
-            case MIP_MAP:
-                return new MipMappedImageReference(imageStream, xobjectName, graphicsState, resources, imageIndex,
-                        page);
-            case BLURRED:
-                return new BlurredImageReference(imageStream, xobjectName, graphicsState, resources, imageIndex, page);
-            default:
-                return new ImageStreamReference(imageStream, xobjectName, graphicsState, resources, imageIndex, page);
+        RegistryEntry entry = orderedRegistry.get(imageReferenceType);
+        if (entry == null) {
+            entry = orderedRegistry.get(TYPE_DEFAULT);
         }
+        return entry.getCreator().create(imageStream, xobjectName, graphicsState, resources, imageIndex, page);
     }
 
+
+    private static void registerBuiltin(String key, String displayName, ImageReferenceCreator creator) {
+        orderedRegistry.put(key, new RegistryEntry(displayName, creator));
+    }
 }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
@@ -412,7 +412,7 @@ public class SwingViewBuilder implements ViewBuilder {
         viewerController.setPropertiesManager(propertiesManager);
 
         // Apply viewer preferences settings to various core system properties.
-        overrideHighlightColor(propertiesManager);
+        applyPropertyManagerSettings(propertiesManager);
 
         // update View Controller with previewer document page fit and view type info
         DocumentViewControllerImpl documentViewController =
@@ -2540,7 +2540,7 @@ public class SwingViewBuilder implements ViewBuilder {
      *
      * @param propertiesManager current properties manager.
      */
-    protected void overrideHighlightColor(ViewerPropertiesManager propertiesManager) {
+    protected void applyPropertyManagerSettings(ViewerPropertiesManager propertiesManager) {
 
         Preferences preferences = propertiesManager.getPreferences();
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/preferences/ImagingPreferencesPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/preferences/ImagingPreferencesPanel.java
@@ -23,6 +23,9 @@ import javax.swing.*;
 import javax.swing.border.EtchedBorder;
 import javax.swing.border.TitledBorder;
 import java.awt.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.prefs.Preferences;
 
@@ -46,23 +49,15 @@ public class ImagingPreferencesPanel extends JPanel {
 
         preferences = propertiesManager.getPreferences();
 
-        ImageReferenceItem[] imageReferenceItems = new ImageReferenceItem[]{
-                new ImageReferenceItem(messageBundle.getString(
-                        "viewer.dialog.viewerPreferences.section.imaging.imageReference.default.label"),
-                        ImageReferenceFactory.ImageReference.DEFAULT),
-                new ImageReferenceItem(messageBundle.getString(
-                        "viewer.dialog.viewerPreferences.section.imaging.imageReference.scaled.label"),
-                        ImageReferenceFactory.ImageReference.SCALED),
-                new ImageReferenceItem(messageBundle.getString(
-                        "viewer.dialog.viewerPreferences.section.imaging.imageReference.mipMap.label"),
-                        ImageReferenceFactory.ImageReference.MIP_MAP),
-                new ImageReferenceItem(messageBundle.getString(
-                        "viewer.dialog.viewerPreferences.section.imaging.imageReference.smothScaled.label"),
-                        ImageReferenceFactory.ImageReference.SMOOTH_SCALED),
-                new ImageReferenceItem(messageBundle.getString(
-                        "viewer.dialog.viewerPreferences.section.imaging.imageReference.blurred.label"),
-                        ImageReferenceFactory.ImageReference.BLURRED)
-        };
+        // Build combo items dynamically from the registry so custom types appear automatically
+        List<ImageReferenceItem> itemList = new ArrayList<>();
+        for (Map.Entry<String, ImageReferenceFactory.RegistryEntry> e :
+                ImageReferenceFactory.getRegisteredTypes().entrySet()) {
+            String key = e.getKey();
+            String label = localizedLabel(messageBundle, key, e.getValue().getDisplayName());
+            itemList.add(new ImageReferenceItem(label, key));
+        }
+        ImageReferenceItem[] imageReferenceItems = itemList.toArray(new ImageReferenceItem[0]);
 
         JComboBox<ImageReferenceItem> imageReferenceComboBox = new JComboBox<>(imageReferenceItems);
         imageReferenceComboBox.setSelectedItem(new ImageReferenceItem("", ImageReferenceFactory.imageReferenceType));
@@ -70,7 +65,7 @@ public class ImagingPreferencesPanel extends JPanel {
             JComboBox cb = (JComboBox) e.getSource();
             ImageReferenceItem selectedItem = (ImageReferenceItem) cb.getSelectedItem();
             ImageReferenceFactory.imageReferenceType = selectedItem.getValue();
-            preferences.put(ViewerPropertiesManager.PROPERTY_IMAGING_REFERENCE_TYPE, selectedItem.getValue().toString());
+            preferences.put(ViewerPropertiesManager.PROPERTY_IMAGING_REFERENCE_TYPE, selectedItem.getValue());
         });
 
         JPanel imagingPreferencesPanel = new JPanel(new GridBagLayout());
@@ -112,11 +107,43 @@ public class ImagingPreferencesPanel extends JPanel {
         layout.add(component, constraints);
     }
 
+    /**
+     * Returns a localized label for a built-in type key, falling back to the registry display name
+     * for any custom type that has no bundle entry.
+     */
+    private static String localizedLabel(ResourceBundle bundle, String key, String fallback) {
+        String bundleKey;
+        switch (key) {
+            case ImageReferenceFactory.TYPE_DEFAULT:
+                bundleKey = "viewer.dialog.viewerPreferences.section.imaging.imageReference.default.label";
+                break;
+            case ImageReferenceFactory.TYPE_SCALED:
+                bundleKey = "viewer.dialog.viewerPreferences.section.imaging.imageReference.scaled.label";
+                break;
+            case ImageReferenceFactory.TYPE_MIP_MAP:
+                bundleKey = "viewer.dialog.viewerPreferences.section.imaging.imageReference.mipMap.label";
+                break;
+            case ImageReferenceFactory.TYPE_SMOOTH_SCALED:
+                bundleKey = "viewer.dialog.viewerPreferences.section.imaging.imageReference.smothScaled.label";
+                break;
+            case ImageReferenceFactory.TYPE_BLURRED:
+                bundleKey = "viewer.dialog.viewerPreferences.section.imaging.imageReference.blurred.label";
+                break;
+            default:
+                return fallback;
+        }
+        try {
+            return bundle.getString(bundleKey);
+        } catch (java.util.MissingResourceException e) {
+            return fallback;
+        }
+    }
+
     static class ImageReferenceItem {
         final String label;
-        final ImageReferenceFactory.ImageReference value;
+        final String value;
 
-        public ImageReferenceItem(String label, ImageReferenceFactory.ImageReference value) {
+        public ImageReferenceItem(String label, String value) {
             this.label = label;
             this.value = value;
         }
@@ -125,7 +152,7 @@ public class ImagingPreferencesPanel extends JPanel {
             return label;
         }
 
-        public ImageReferenceFactory.ImageReference getValue() {
+        public String getValue() {
             return value;
         }
 
@@ -138,7 +165,7 @@ public class ImagingPreferencesPanel extends JPanel {
         public boolean equals(Object imageReferenceItem) {
             if (imageReferenceItem instanceof ImageReferenceItem)
                 return value.equals(((ImageReferenceItem) imageReferenceItem).getValue());
-            else if (imageReferenceItem instanceof ImageReferenceFactory.ImageReference) {
+            else if (imageReferenceItem instanceof String) {
                 return value.equals(imageReferenceItem);
             }
             return false;


### PR DESCRIPTION
- minor refactor to that allows a ImageReferenceType to be registered with the ImageReferenceFactory.  
- first time I've use the @FunctionalInterface which is pretty slick
``` java
public class MyApplication {

    public static void main(String[] args) {
        // Register the custom type with a key and display name
        ImageReferenceFactory.register(
                "inverted",                     // key used in preferences / system property
                "Inverted Colours",             // label shown in the UI combo-box
                InvertedImageReference::new     // constructor reference matching ImageReferenceCreator, which is the same for all the reference types
        );

        // Activate it as the current type...
        ImageReferenceFactory.setImageReferenceType("inverted");

        // ...or it will appear automatically in the ImagingPreferencesPanel combo-box

        // launch the rest of the application
    }
}

```