### PR TITLE
GH-488 migration logger setup to use class.getName()

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/io/RandomAccessFileInputStream.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/io/RandomAccessFileInputStream.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 public class RandomAccessFileInputStream extends InputStream implements SeekableInput {
 
     private static final Logger logger =
-            Logger.getLogger(RandomAccessFileInputStream.class.toString());
+            Logger.getLogger(RandomAccessFileInputStream.class.getName());
 
     private long m_lMarkPosition;
     private final RandomAccessFile m_RandomAccessFile;

--- a/core/core-awt/src/main/java/org/icepdf/core/io/SeekableByteArrayInputStream.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/io/SeekableByteArrayInputStream.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 public class SeekableByteArrayInputStream extends ByteArrayInputStream implements SeekableInput {
 
     private static final Logger log =
-            Logger.getLogger(SeekableByteArrayInputStream.class.toString());
+            Logger.getLogger(SeekableByteArrayInputStream.class.getName());
 
     private final int m_iBeginningOffset;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Catalog.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Catalog.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
 public class Catalog extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(Catalog.class.toString());
+            Logger.getLogger(Catalog.class.getName());
 
     public static final Name TYPE = new Name("Catalog");
     public static final Name DESTS_KEY = new Name("Dests");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Destination.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Destination.java
@@ -58,7 +58,7 @@ import java.util.logging.Logger;
 public class Destination extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(Destination.class.toString());
+            Logger.getLogger(Destination.class.getName());
 
     public static final Name D_KEY = new Name("D");
     // Vector destination type formats.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Document.java
@@ -73,7 +73,7 @@ import java.util.logging.Logger;
 public class Document {
 
     private static final Logger logger =
-            Logger.getLogger(Document.class.toString());
+            Logger.getLogger(Document.class.getName());
 
     /**
      * Gets the version number of ICEpdf rendering core.  This is not the version

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Form.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Form.java
@@ -44,7 +44,7 @@ import static org.icepdf.core.pobjects.annotations.utils.ContentWriterUtils.EMBE
  */
 public class Form extends Stream {
 
-    private static final Logger logger = Logger.getLogger(Form.class.toString());
+    private static final Logger logger = Logger.getLogger(Form.class.getName());
 
     public static final Name TYPE_VALUE = new Name("XObject");
     public static final Name SUB_TYPE_VALUE = new Name("Form");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/HexStringObject.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/HexStringObject.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 public class HexStringObject extends AbstractStringObject {
 
     private static final Logger logger =
-            Logger.getLogger(HexStringObject.class.toString());
+            Logger.getLogger(HexStringObject.class.getName());
 
     /**
      * <p>Creates a new hexadecimal string object so that it represents the same

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Name.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Name.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 public class Name {
 
     private static final Logger logger =
-            Logger.getLogger(Name.class.toString());
+            Logger.getLogger(Name.class.getName());
 
     private static final int HEX_CHAR = 0X23;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Names.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Names.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class Names extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(Names.class.toString());
+            Logger.getLogger(Names.class.getName());
 
     /**
      * A name tree mapping name strings to destinations.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/ObjectStream.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/ObjectStream.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class ObjectStream extends Stream {
 
     private static final Logger logger =
-            Logger.getLogger(ObjectStream.class.toString());
+            Logger.getLogger(ObjectStream.class.getName());
 
     public static final Name TYPE = new Name("ObjStm");
     public static final Name N_KEY = new Name("N");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -67,7 +67,7 @@ import java.util.stream.Collectors;
  */
 public class Page extends Dictionary {
 
-    private static final Logger logger = Logger.getLogger(Page.class.toString());
+    private static final Logger logger = Logger.getLogger(Page.class.getName());
 
     /**
      * Transparency value used to simulate text highlighting.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Resources.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Resources.java
@@ -49,7 +49,7 @@ public class Resources extends Dictionary {
     }
 
     private static final Logger logger =
-            Logger.getLogger(Resources.class.toString());
+            Logger.getLogger(Resources.class.getName());
 
     DictionaryEntries fonts;
     DictionaryEntries xobjects;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Stream.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Stream.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
  */
 public class Stream extends Dictionary {
 
-    private static final Logger logger = Logger.getLogger(Stream.class.toString());
+    private static final Logger logger = Logger.getLogger(Stream.class.getName());
 
     public static final Name FILTER_KEY = new Name("Filter");
     public static final Name DECODEPARAM_KEY = new Name("DecodeParms");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/FieldDictionary.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/FieldDictionary.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
 public class FieldDictionary extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(FieldDictionary.class.toString());
+            Logger.getLogger(FieldDictionary.class.getName());
 
     /**
      * Required for terminal fields; inheritable) The type of field that this

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/InteractiveForm.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/InteractiveForm.java
@@ -112,7 +112,7 @@ public class InteractiveForm extends Dictionary {
     public static final int SIG_FLAGS_APPEND_ONLY = 2;
 
     private static final Logger logger =
-            Logger.getLogger(InteractiveForm.class.toString());
+            Logger.getLogger(InteractiveForm.class.getName());
 
     // field list, we keep reference as we don't want these garbage collected.
     private ArrayList<Object> fields;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/SignatureHandler.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/SignatureHandler.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class SignatureHandler {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureHandler.class.toString());
+            Logger.getLogger(SignatureHandler.class.getName());
 
     public SignatureHandler() {
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/VariableTextFieldDictionary.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/VariableTextFieldDictionary.java
@@ -38,7 +38,7 @@ import static org.icepdf.core.pobjects.acroform.InteractiveForm.DR_KEY;
  */
 public class VariableTextFieldDictionary extends FieldDictionary {
 
-    private static final Logger logger = Logger.getLogger(VariableTextFieldDictionary.class.toString());
+    private static final Logger logger = Logger.getLogger(VariableTextFieldDictionary.class.getName());
 
     public enum Quadding {
         LEFT_JUSTIFIED, CENTERED, RIGHT_JUSTIFIED

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/AbstractPkcsValidator.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/AbstractPkcsValidator.java
@@ -56,7 +56,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractPkcsValidator implements SignatureValidator {
 
     private static final Logger logger =
-            Logger.getLogger(AbstractPkcsValidator.class.toString());
+            Logger.getLogger(AbstractPkcsValidator.class.getName());
 
     private static String caCertLocation = "/lib/security/cacerts";
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/Pkcs7Validator.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/Pkcs7Validator.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public class Pkcs7Validator extends AbstractPkcsValidator {
 
     private static final Logger logger =
-            Logger.getLogger(Pkcs7Validator.class.toString());
+            Logger.getLogger(Pkcs7Validator.class.getName());
 
     public Pkcs7Validator(SignatureFieldDictionary signatureFieldDictionary) throws SignatureIntegrityException {
         super(signatureFieldDictionary);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/CertificateUtils.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/CertificateUtils.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class CertificateUtils {
 
     private static final Logger logger =
-            Logger.getLogger(CertificateUtils.class.toString());
+            Logger.getLogger(CertificateUtils.class.getName());
 
     /**
      * Checks whether given X.509 certificate is self-signed.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/CertificateVerifier.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/CertificateVerifier.java
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
 public class CertificateVerifier {
 
     private static final Logger logger =
-            Logger.getLogger(CertificateVerifier.class.toString());
+            Logger.getLogger(CertificateVerifier.class.getName());
 
     /**
      * Attempts to build a certification chain for given certificate and to verify

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/OCSPVerifier.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/OCSPVerifier.java
@@ -60,7 +60,7 @@ import java.util.logging.Logger;
  */
 public class OCSPVerifier {
 
-    private static final Logger logger = Logger.getLogger(OCSPVerifier.class.toString());
+    private static final Logger logger = Logger.getLogger(OCSPVerifier.class.getName());
 
     /**
      * Verify whether the certificate has been revoked at signing date, and verify whether

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/OcspHelper.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/OcspHelper.java
@@ -61,7 +61,7 @@ import java.util.logging.Logger;
  */
 public class OcspHelper {
 
-    private static final Logger logger = Logger.getLogger(OcspHelper.class.toString());
+    private static final Logger logger = Logger.getLogger(OcspHelper.class.getName());
 
     private final X509Certificate issuerCertificate;
     private final Date signDate;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/RevocationsVerifier.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/RevocationsVerifier.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
  */
 public class RevocationsVerifier {
 
-    private static final Logger logger = Logger.getLogger(RevocationsVerifier.class.toString());
+    private static final Logger logger = Logger.getLogger(RevocationsVerifier.class.getName());
 
     public static void verifyRevocations(X509Certificate cert,
                                          Set<X509Certificate> additionalCerts,

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/TSAClient.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/certificates/TSAClient.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
  * @author John Hewson
  */
 public class TSAClient {
-    private static final Logger logger = Logger.getLogger(TSAClient.class.toString());
+    private static final Logger logger = Logger.getLogger(TSAClient.class.getName());
 
     private static final DigestAlgorithmIdentifierFinder ALGORITHM_OID_FINDER =
             new DefaultDigestAlgorithmIdentifierFinder();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/handlers/SignerHandler.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/handlers/SignerHandler.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
  */
 public abstract class SignerHandler {
 
-    private static final Logger logger = Logger.getLogger(SignerHandler.class.toString());
+    private static final Logger logger = Logger.getLogger(SignerHandler.class.getName());
 
     protected static final String algorithm = "SHA256WithRSA";
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/utils/SignatureUtilities.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/acroform/signature/utils/SignatureUtilities.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public class SignatureUtilities {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureUtilities.class.toString());
+            Logger.getLogger(SignatureUtilities.class.getName());
 
     /**
      * Parse out a known data element from an X500Name.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/SubmitFormAction.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/actions/SubmitFormAction.java
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
 public class SubmitFormAction extends FormAction {
 
     private static final Logger logger =
-            Logger.getLogger(SubmitFormAction.class.toString());
+            Logger.getLogger(SubmitFormAction.class.getName());
 
     private static final String USER_AGENT = "Mozilla/5.0";
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AbstractWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AbstractWidgetAnnotation.java
@@ -45,7 +45,7 @@ public abstract class AbstractWidgetAnnotation<T extends FieldDictionary> extend
     public static final Name HIGHLIGHT_NONE = new Name("N");
 
     protected static final Logger logger =
-            Logger.getLogger(AbstractWidgetAnnotation.class.toString());
+            Logger.getLogger(AbstractWidgetAnnotation.class.getName());
 
     /**
      * Transparency value used to simulate text highlighting.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/Annotation.java
@@ -335,7 +335,7 @@ import java.util.logging.Logger;
 public abstract class Annotation extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(Annotation.class.toString());
+            Logger.getLogger(Annotation.class.getName());
 
     public static final Name TYPE = new Name("Annot");
     public static final Name RESOURCES_VALUE = new Name("Resources");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AnnotationFactory.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AnnotationFactory.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class AnnotationFactory {
 
     private static final Logger logger =
-            Logger.getLogger(AnnotationFactory.class.toString());
+            Logger.getLogger(AnnotationFactory.class.getName());
 
     /**
      * Creates a new Annotation object using properties from the annotationState

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AppearanceState.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/AppearanceState.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public class AppearanceState extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(AppearanceState.class.toString());
+            Logger.getLogger(AppearanceState.class.getName());
 
     // shapes form appearance stream
     protected Shapes shapes;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/CircleAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/CircleAnnotation.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 public class CircleAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(CircleAnnotation.class.toString());
+            Logger.getLogger(CircleAnnotation.class.getName());
 
     // state properties for generate the content stream and shapes representation.
     // of the annnotation state.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
@@ -54,7 +54,7 @@ import static org.icepdf.core.pobjects.annotations.utils.ContentWriterUtils.EMBE
 public class FreeTextAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(FreeTextAnnotation.class.toString());
+            Logger.getLogger(FreeTextAnnotation.class.getName());
 
     public static final int INSETS = 5;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/InkAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/InkAnnotation.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 public class InkAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(InkAnnotation.class.toString());
+            Logger.getLogger(InkAnnotation.class.getName());
 
     /**
      * (Required) An array of n arrays, each representing a stroked path. Each

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LineAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LineAnnotation.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class LineAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(LineAnnotation.class.toString());
+            Logger.getLogger(LineAnnotation.class.getName());
 
     /**
      * (Required) An array of four numbers, [x1 y1 x2 y2], specifying the starting

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LinkAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/LinkAnnotation.java
@@ -62,7 +62,7 @@ import java.util.logging.Logger;
 public class LinkAnnotation extends Annotation {
 
     private static final Logger logger =
-            Logger.getLogger(LinkAnnotation.class.toString());
+            Logger.getLogger(LinkAnnotation.class.getName());
 
     /**
      * Key used to indicate highlight mode.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PolyAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PolyAnnotation.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public class PolyAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(PolyAnnotation.class.toString());
+            Logger.getLogger(PolyAnnotation.class.getName());
 
     public static final Name SUBTYPE_POLYLINE = new Name("PolyLine");
     public static final Name SUBTYPE_POLYGON = new Name("Polygon");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PopupAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/PopupAnnotation.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 public class PopupAnnotation extends Annotation {
 
     private static final Logger logger =
-            Logger.getLogger(PopupAnnotation.class.toString());
+            Logger.getLogger(PopupAnnotation.class.getName());
 
     public static final Color BORDER_COLOR = new Color(153, 153, 153);
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/RedactionAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/RedactionAnnotation.java
@@ -44,7 +44,7 @@ import static org.icepdf.core.pobjects.annotations.utils.QuadPoints.parseQuadPoi
 public class RedactionAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(RedactionAnnotation.class.toString());
+            Logger.getLogger(RedactionAnnotation.class.getName());
 
     private static Color redactionColor;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SignatureWidgetAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SignatureWidgetAnnotation.java
@@ -46,7 +46,7 @@ import static org.icepdf.core.pobjects.acroform.SignatureDictionary.V_KEY;
 public class SignatureWidgetAnnotation extends AbstractWidgetAnnotation<SignatureFieldDictionary> {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureWidgetAnnotation.class.toString());
+            Logger.getLogger(SignatureWidgetAnnotation.class.getName());
 
     // signature field dictionary,
     private final SignatureFieldDictionary fieldDictionary;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SquareAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/SquareAnnotation.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
 public class SquareAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(SquareAnnotation.class.toString());
+            Logger.getLogger(SquareAnnotation.class.getName());
 
     private Color fillColor;
     private boolean isFillColor;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextAnnotation.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
 public class TextAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(TextAnnotation.class.toString());
+            Logger.getLogger(TextAnnotation.class.getName());
 
     /**
      * (Optional) A flag specifying whether the annotation shall initially be

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextMarkupAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/TextMarkupAnnotation.java
@@ -48,7 +48,7 @@ import static org.icepdf.core.pobjects.annotations.utils.QuadPoints.parseQuadPoi
 public class TextMarkupAnnotation extends MarkupAnnotation {
 
     private static final Logger logger =
-            Logger.getLogger(TextMarkupAnnotation.class.toString());
+            Logger.getLogger(TextMarkupAnnotation.class.getName());
 
     public static final Name SUBTYPE_HIGHLIGHT = new Name("Highlight");
     public static final Name SUBTYPE_UNDERLINE = new Name("Underline");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/utils/ContentWriterUtils.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/utils/ContentWriterUtils.java
@@ -48,7 +48,7 @@ import static org.icepdf.core.pobjects.fonts.FontDescriptor.FONT_FILE_2;
 public class ContentWriterUtils {
 
     private static final Logger logger =
-            Logger.getLogger(ContentWriterUtils.class.toString());
+            Logger.getLogger(ContentWriterUtils.class.getName());
 
     public static final Name EMBEDDED_FONT_NAME = new Name("ice1");
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/filters/CCITTFax.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/filters/CCITTFax.java
@@ -57,7 +57,7 @@ import static org.icepdf.core.pobjects.graphics.images.FaxDecoder.K_KEY;
 public class CCITTFax {
 
     private static final Logger logger =
-            Logger.getLogger(CCITTFax.class.toString());
+            Logger.getLogger(CCITTFax.class.getName());
 
     // white codes
     static final String[] _twcodes = {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/AFM.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/AFM.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class AFM {
 
     private static final Logger logger =
-            Logger.getLogger(AFM.class.toString());
+            Logger.getLogger(AFM.class.getName());
 
     public static final int COURIER = 0;
     public static final int COURIER_BOLD = 1;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontDescriptor.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontDescriptor.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class FontDescriptor extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(FontDescriptor.class.toString());
+            Logger.getLogger(FontDescriptor.class.getName());
 
     private FontFile font;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontFactory.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontFactory.java
@@ -42,7 +42,7 @@ import static org.icepdf.core.pobjects.Dictionary.SUBTYPE_KEY;
 public class FontFactory {
 
     private static final Logger logger =
-            Logger.getLogger(FontFactory.class.toString());
+            Logger.getLogger(FontFactory.class.getName());
 
     public static final boolean useEmbeddedFonts;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/FontManager.java
@@ -48,7 +48,7 @@ import java.util.regex.Pattern;
 public class FontManager {
 
     private static final Logger logger =
-            Logger.getLogger(FontManager.class.toString());
+            Logger.getLogger(FontManager.class.getName());
 
     /**
      * You can set an allowListPattern by Setting the System Property "org.icepdf.core.pobjects.fonts

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Encoding.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Encoding.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 public class Encoding implements org.icepdf.core.pobjects.fonts.Encoding {
 
     protected static final Logger logger =
-            Logger.getLogger(Encoding.class.toString());
+            Logger.getLogger(Encoding.class.getName());
 
     // Latin-text encoding names
     public static final String STANDARD_ENCODING_NAME = "StandardEncoding";

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/GlyphList.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/GlyphList.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class GlyphList {
 
     protected static final Logger logger =
-            Logger.getLogger(GlyphList.class.toString());
+            Logger.getLogger(GlyphList.class.getName());
 
     public static GlyphList adobeGlyphList;
     public static GlyphList zapfDingBatsGlyphList;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/SimpleFont.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/SimpleFont.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class SimpleFont extends org.icepdf.core.pobjects.fonts.Font {
 
     protected static final Logger logger =
-            Logger.getLogger(SimpleFont.class.toString());
+            Logger.getLogger(SimpleFont.class.getName());
 
     // get list of all available fonts.
     private static final java.awt.Font[] fonts =

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/Type0Font.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class Type0Font extends SimpleFont {
 
     private static final Logger logger =
-            Logger.getLogger(SimpleFont.class.toString());
+            Logger.getLogger(SimpleFont.class.getName());
 
     public static final Name DESCENDANT_FONTS_KEY = new Name("DescendantFonts");
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/TypeCidType0Font.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/TypeCidType0Font.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 public class TypeCidType0Font extends CompositeFont {
 
     private static final Logger logger =
-            Logger.getLogger(TypeCidType0Font.class.toString());
+            Logger.getLogger(TypeCidType0Font.class.getName());
 
     public TypeCidType0Font(Library library, DictionaryEntries entries) {
         super(library, entries);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/TypeCidType2Font.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/TypeCidType2Font.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 public class TypeCidType2Font extends CompositeFont {
 
     private static final Logger logger =
-            Logger.getLogger(TypeCidType2Font.class.toString());
+            Logger.getLogger(TypeCidType2Font.class.getName());
 
     public TypeCidType2Font(Library library, DictionaryEntries entries) {
         super(library, entries);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/cmap/CMapFactory.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/cmap/CMapFactory.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 public class CMapFactory {
 
     private static final Logger logger =
-            Logger.getLogger(CMapFactory.class.toString());
+            Logger.getLogger(CMapFactory.class.getName());
 
     public static final Name TYPE = new Name("CMap");
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontOpenType.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontOpenType.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class ZFontOpenType extends ZFontTrueType {
 
     private static final Logger logger =
-            Logger.getLogger(ZFontOpenType.class.toString());
+            Logger.getLogger(ZFontOpenType.class.getName());
 
     public ZFontOpenType(Stream fontStream) throws Exception {
         this(fontStream.getDecodedStreamBytes());

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class ZFontTrueType extends ZSimpleFont {
 
     private static final Logger logger =
-            Logger.getLogger(ZFontTrueType.class.toString());
+            Logger.getLogger(ZFontTrueType.class.getName());
 
     private static final int START_RANGE_F000 = 0xF000;
     private static final int START_RANGE_F100 = 0xF100;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType0.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType0.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class ZFontType0 extends ZSimpleFont {
 
     private static final Logger logger =
-            Logger.getLogger(ZFontType0.class.toString());
+            Logger.getLogger(ZFontType0.class.getName());
 
     private CFFCIDFont cidFont;  // Top DICT that uses CIDFont operators
     private FontBoxFont t1Font; // Top DICT that does not use CIDFont operators

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public class ZFontType1 extends ZSimpleFont {
 
     private static final Logger logger =
-            Logger.getLogger(ZFontType1.class.toString());
+            Logger.getLogger(ZFontType1.class.getName());
 
     private static final int PFB_START_MARKER = 0x80;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1C.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType1C.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class ZFontType1C extends ZSimpleFont {
 
     private static final Logger logger =
-            Logger.getLogger(ZFontType1C.class.toString());
+            Logger.getLogger(ZFontType1C.class.getName());
 
     private CFFType1Font cffType1Font;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
 public class ZFontType2 extends ZSimpleFont { //extends ZFontTrueType {
 
     private static final Logger logger =
-            Logger.getLogger(ZFontType2.class.toString());
+            Logger.getLogger(ZFontType2.class.getName());
 
     private final TrueTypeFont trueTypeFont;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType3.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType3.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 
 public class ZFontType3 extends ZSimpleFont implements Cloneable {
     private static final Logger logger =
-            Logger.getLogger(ZFontType3.class.toString());
+            Logger.getLogger(ZFontType3.class.getName());
 
     public static final Name FONT_BBOX_KEY = new Name("FontBBox");
     public static final Name FONT_MATRIX_KEY = new Name("FontMatrix");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
@@ -42,7 +42,7 @@ import static java.awt.Font.PLAIN;
 public abstract class ZSimpleFont implements FontFile {
 
     private static final Logger logger =
-            Logger.getLogger(ZSimpleFont.class.toString());
+            Logger.getLogger(ZSimpleFont.class.getName());
 
     // text layout map, very expensive to create, so we'll cache them.
     private HashMap<String, Point2D.Float> echarAdvanceCache;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function.java
@@ -62,7 +62,7 @@ import java.util.logging.Logger;
 public abstract class Function {
 
     private static final Logger logger =
-            Logger.getLogger(Function.class.toString());
+            Logger.getLogger(Function.class.getName());
 
     public static final Name FUNCTIONTYPE_NAME = new Name("FunctionType");
     public static final Name DOMAIN_NAME = new Name("Domain");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_0.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_0.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 public class Function_0 extends Function {
 
     private static final Logger logger =
-            Logger.getLogger(Function_0.class.toString());
+            Logger.getLogger(Function_0.class.getName());
 
     public static final Name SIZE_KEY = new Name("Size");
     public static final Name BITSPERSAMPLE_KEY = new Name("BitsPerSample");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_4.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_4.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 public class Function_4 extends Function {
 
     private static final Logger logger =
-            Logger.getLogger(Function_4.class.toString());
+            Logger.getLogger(Function_4.class.getName());
 
     // decoded content that makes up the type 4 functions.
     private byte[] functionContent;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
 public final class BlendComposite implements Composite {
 
     private static final Logger logger =
-            Logger.getLogger(BlendComposite.class.toString());
+            Logger.getLogger(BlendComposite.class.getName());
 
     public enum BlendingMode {
         NORMAL,

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/DeviceCMYK.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/DeviceCMYK.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class DeviceCMYK extends PColorSpace {
 
     private static final Logger logger =
-            Logger.getLogger(DeviceCMYK.class.toString());
+            Logger.getLogger(DeviceCMYK.class.getName());
 
     public static final Name DEVICECMYK_KEY = new Name("DeviceCMYK");
     public static final Name CMYK_KEY = new Name("CMYK");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ExtGState.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ExtGState.java
@@ -224,7 +224,7 @@ import java.util.logging.Logger;
 public class ExtGState extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(ExtGState.class.toString());
+            Logger.getLogger(ExtGState.class.getName());
 
     public static final Name SMASK_KEY = new Name("SMask");
     public static final Name LW_KEY = new Name("LW");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/GraphicsState.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/GraphicsState.java
@@ -208,7 +208,7 @@ import java.util.logging.Logger;
 public class GraphicsState {
 
     private static final Logger logger =
-            Logger.getLogger(GraphicsState.class.toString());
+            Logger.getLogger(GraphicsState.class.getName());
 
     public static final Name CA_STROKING_KEY = new Name("CA");
     public static final Name CA_NON_STROKING_KEY = new Name("ca");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ICCBased.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ICCBased.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class ICCBased extends PColorSpace {
 
     private static final Logger logger =
-            Logger.getLogger(ICCBased.class.toString());
+            Logger.getLogger(ICCBased.class.getName());
 
     private static final Object lock = new Object();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/PColorSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/PColorSpace.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public abstract class PColorSpace extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(PColorSpace.class.toString());
+            Logger.getLogger(PColorSpace.class.getName());
 
     public abstract int getNumComponents();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/PaintTimer.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/PaintTimer.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
 public class PaintTimer {
 
     protected static final Logger logger =
-            Logger.getLogger(PaintTimer.class.toString());
+            Logger.getLogger(PaintTimer.class.getName());
 
     protected static int paintDelay;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public abstract class ShadingMeshPattern extends ShadingPattern implements Pattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingMeshPattern.class.toString());
+            Logger.getLogger(ShadingMeshPattern.class.getName());
 
     public static final Name BITS_PER_FLAG_KEY = new Name("BitsPerFlag");
     public static final Name BITS_PER_COORDINATE_KEY = new Name("BitsPerCoordinate");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingPattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingPattern.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public abstract class ShadingPattern extends Dictionary implements Pattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingPattern.class.toString());
+            Logger.getLogger(ShadingPattern.class.getName());
 
     public static final Name PATTERN_TYPE_KEY = new Name("PatternType");
     public static final Name EXTGSTATE_KEY = new Name("ExtGState");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType1Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType1Pattern.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 public class ShadingType1Pattern extends ShadingType2Pattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingType1Pattern.class.toString());
+            Logger.getLogger(ShadingType1Pattern.class.getName());
 
     /*
       (Optional) An array of four numbers [xmin xmax ymin ymax] specifying the

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType2Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType2Pattern.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 public class ShadingType2Pattern extends ShadingPattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingType2Pattern.class.toString());
+            Logger.getLogger(ShadingType2Pattern.class.getName());
 
     // An array of two numbers [t0, t1] specifying the limiting values of a
     // parametric variable t. The variable is considered to vary linearly between

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType3Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType3Pattern.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 public class ShadingType3Pattern extends ShadingPattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingType3Pattern.class.toString());
+            Logger.getLogger(ShadingType3Pattern.class.getName());
 
     // An array of two numbers [t0, t1] specifying the limiting values of a
     // parametric variable t. The variable is considered to vary linearly between

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType4Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType4Pattern.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class ShadingType4Pattern extends ShadingMeshPattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingType4Pattern.class.toString());
+            Logger.getLogger(ShadingType4Pattern.class.getName());
 
     private ArrayList<Color> colorComponents = new ArrayList<>();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType5Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType5Pattern.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class ShadingType5Pattern extends ShadingMeshPattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingType5Pattern.class.toString());
+            Logger.getLogger(ShadingType5Pattern.class.getName());
 
     private ArrayList<Color> colorComponents = new ArrayList<>();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType6Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType6Pattern.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class ShadingType6Pattern  extends ShadingMeshPattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingType6Pattern.class.toString());
+            Logger.getLogger(ShadingType6Pattern.class.getName());
 
     private ArrayList<Color> colorComponents = new ArrayList<>();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType7Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType7Pattern.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class ShadingType7Pattern extends ShadingMeshPattern {
 
     private static final Logger logger =
-            Logger.getLogger(ShadingType7Pattern.class.toString());
+            Logger.getLogger(ShadingType7Pattern.class.getName());
 
     private ArrayList<Color> colorComponents = new ArrayList<>();
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 public class Shapes {
 
     private static final Logger logger =
-            Logger.getLogger(Shapes.class.toString());
+            Logger.getLogger(Shapes.class.getName());
 
     private static int shapesInitialCapacity = 5000;
     // disables alpha painting.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/SoftMask.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/SoftMask.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
 public class SoftMask extends Dictionary {
 
     private static final Logger logger =
-            Logger.getLogger(SoftMask.class.toString());
+            Logger.getLogger(SoftMask.class.getName());
 
     public static final Name S_KEY = new Name("S");
     public static final Name G_KEY = new Name("G");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TilingPattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TilingPattern.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public class TilingPattern extends Stream implements Pattern {
 
     private static final Logger logger =
-            Logger.getLogger(TilingPattern.class.toString());
+            Logger.getLogger(TilingPattern.class.getName());
 
     // max x or y dimension of an image tile.
     public static final int MAX_BUFFER_SIZE = 9000;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/AbstractDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/AbstractDrawCmd.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public abstract class AbstractDrawCmd implements DrawCmd {
 
     protected static final Logger logger =
-            Logger.getLogger(AbstractDrawCmd.class.toString());
+            Logger.getLogger(AbstractDrawCmd.class.getName());
 
     protected static final boolean disableClipping;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/PostScriptEncoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/PostScriptEncoder.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 public class PostScriptEncoder {
 
     private static final Logger logger =
-            Logger.getLogger(PostScriptEncoder.class.toString());
+            Logger.getLogger(PostScriptEncoder.class.getName());
 
     private static final String SPACE = " ";
     private static final String NEWLINE = "\r\n";

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/AbstractImageDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/AbstractImageDecoder.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 public abstract class AbstractImageDecoder implements ImageDecoder {
 
     private static final Logger logger =
-            Logger.getLogger(AbstractImageDecoder.class.toString());
+            Logger.getLogger(AbstractImageDecoder.class.getName());
 
     public static int maxImageWidth = 10000;
     public static int maxImageHeight = 10000;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/DctDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/DctDecoder.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class DctDecoder extends AbstractImageDecoder {
 
     private static final Logger logger =
-            Logger.getLogger(DctDecoder.class.toString());
+            Logger.getLogger(DctDecoder.class.getName());
 
     private static final int JPEG_ENC_UNKNOWN_PROBABLY_YCbCr = 0;
     private static final int JPEG_ENC_RGB = 1;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/FaxDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/FaxDecoder.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public class FaxDecoder extends AbstractImageDecoder {
 
     private static final Logger logger =
-            Logger.getLogger(FaxDecoder.class.toString());
+            Logger.getLogger(FaxDecoder.class.getName());
 
     public static final Name K_KEY = new Name("K");
     public static final Name ENCODED_BYTE_ALIGN_KEY = new Name("EncodedByteAlign");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageStream.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageStream.java
@@ -38,7 +38,7 @@ import static org.icepdf.core.pobjects.graphics.images.ImageParams.*;
  */
 public class ImageStream extends Stream {
 
-    private static final Logger logger = Logger.getLogger(ImageStream.class.toString());
+    private static final Logger logger = Logger.getLogger(ImageStream.class.getName());
 
     public static final Name TYPE_VALUE = new Name("Image");
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
 public class ImageUtility {
 
     static final Logger logger =
-            Logger.getLogger(ImageUtility.class.toString());
+            Logger.getLogger(ImageUtility.class.getName());
 
     static final int[] GRAY_1_BIT_INDEX_TO_RGB_REVERSED = new int[]{
             0xFFFFFFFF,

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JBig2Decoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JBig2Decoder.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class JBig2Decoder extends AbstractImageDecoder {
 
     private static final Logger logger =
-            Logger.getLogger(JBig2Decoder.class.toString());
+            Logger.getLogger(JBig2Decoder.class.getName());
 
     private static final String[] JBIG2_PDF_BOX = new String[]{
             "org.apache.pdfbox.jbig2.JBIG2ImageReader",

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JpxDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JpxDecoder.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class JpxDecoder extends AbstractImageDecoder {
 
     private static final Logger logger =
-            Logger.getLogger(JpxDecoder.class.toString());
+            Logger.getLogger(JpxDecoder.class.getName());
 
     public JpxDecoder(ImageStream imageStream, GraphicsState graphicsState) {
         super(imageStream, graphicsState);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/RasterDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/RasterDecoder.java
@@ -24,7 +24,7 @@ import java.util.logging.Logger;
 public class RasterDecoder extends AbstractImageDecoder {
 
     private static final Logger logger =
-            Logger.getLogger(RasterDecoder.class.toString());
+            Logger.getLogger(RasterDecoder.class.getName());
 
     public RasterDecoder(ImageStream imageStream, GraphicsState graphicsState) {
         super(imageStream, graphicsState);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/RawDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/RawDecoder.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 public class RawDecoder extends AbstractImageDecoder {
 
     private static final Logger logger =
-            Logger.getLogger(RawDecoder.class.toString());
+            Logger.getLogger(RawDecoder.class.getName());
 
     public RawDecoder(ImageStream imageStream, GraphicsState graphicsState) {
         super(imageStream, graphicsState);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/BlurredImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/BlurredImageReference.java
@@ -53,7 +53,7 @@ import java.util.logging.Logger;
 public class BlurredImageReference extends CachedImageReference {
 
     private static final Logger logger =
-            Logger.getLogger(ImageStreamReference.class.toString());
+            Logger.getLogger(ImageStreamReference.class.getName());
 
     private static final int dimension;
     private static final int minWidth;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/FloydSteinbergImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/FloydSteinbergImageReference.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class FloydSteinbergImageReference{// extends CachedImageReference {
    /*
     private static final Logger logger =
-            Logger.getLogger(ScaledImageReference.class.toString());
+            Logger.getLogger(ScaledImageReference.class.getName());
 
     // scaled image size.
     private int width;
@@ -180,13 +180,17 @@ public class FloydSteinbergImageReference{// extends CachedImageReference {
                     // pixel[x  ][y+1] := pixel[x  ][y+1] + 5/16 * quant_error
                     // pixel[x+1][y+1] := pixel[x+1][y+1] + 1/16 * quant_error
                     if (x < w - 1)
-                        img.setRGB(x + 1, y, encode((int) ((float) decode(img.getRGB(x + 1, y)) + (7.0 / 16.0 * quant_error))));
+                        img.setRGB(x + 1, y, encode((int) ((float) decode(img.getRGB(x + 1, y)) + (7.0 / 16.0 *
+                        quant_error))));
                     if (y < h - 1) {
                         if (x > 0)
-                            img.setRGB(x - 1, y + 1, encode((int) ((float) decode(img.getRGB(x - 1, y + 1)) + (3.0 / 16.0 * quant_error))));
-                        img.setRGB(x, y + 1, encode((int) ((float) decode(img.getRGB(x, y + 1)) + (5.0 / 16.0 * quant_error))));
+                            img.setRGB(x - 1, y + 1, encode((int) ((float) decode(img.getRGB(x - 1, y + 1)) + (3.0 /
+                            16.0 * quant_error))));
+                        img.setRGB(x, y + 1, encode((int) ((float) decode(img.getRGB(x, y + 1)) + (5.0 / 16.0 *
+                        quant_error))));
                         if (x < w - 1)
-                            img.setRGB(x + 1, y + 1, encode((int) ((float) decode(img.getRGB(x + 1, y + 1)) + (1.0 / 16.0 * quant_error))));
+                            img.setRGB(x + 1, y + 1, encode((int) ((float) decode(img.getRGB(x + 1, y + 1)) + (1.0 /
+                            16.0 * quant_error))));
                     }
                 }
             }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImagePool.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImagePool.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
  */
 public class ImagePool {
     private static final Logger log =
-            Logger.getLogger(ImagePool.class.toString());
+            Logger.getLogger(ImagePool.class.getName());
 
     // Image pool
     private final Map<Reference, BufferedImage> fCache;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReference.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 public abstract class ImageReference implements Callable<BufferedImage> {
 
     private static final Logger logger =
-            Logger.getLogger(ImageReference.class.toString());
+            Logger.getLogger(ImageReference.class.getName());
 
     public static boolean useProxy;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageStreamReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageStreamReference.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 public class ImageStreamReference extends CachedImageReference {
 
     private static final Logger logger =
-            Logger.getLogger(ImageStreamReference.class.toString());
+            Logger.getLogger(ImageStreamReference.class.getName());
 
     protected ImageStreamReference(ImageStream imageStream, Name xobjectName, GraphicsState graphicsState,
                                    Resources resources, int imageIndex,

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/InlineImageStreamReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/InlineImageStreamReference.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
 public class InlineImageStreamReference extends ImageReference {
 
     private static final Logger logger =
-            Logger.getLogger(InlineImageStreamReference.class.toString());
+            Logger.getLogger(InlineImageStreamReference.class.getName());
 
     public InlineImageStreamReference(ImageStream imageStream, Name xobjectName, GraphicsState graphicsState,
                                       Resources resources, int iamgeIndex,

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/MipMappedImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/MipMappedImageReference.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 class MipMappedImageReference extends ImageReference {
 
     private static final Logger logger =
-            Logger.getLogger(MipMappedImageReference.class.toString());
+            Logger.getLogger(MipMappedImageReference.class.getName());
 
     private final ArrayList<ImageReference> images;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ScaledImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ScaledImageReference.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class ScaledImageReference extends CachedImageReference {
 
     private static final Logger logger =
-            Logger.getLogger(ScaledImageReference.class.toString());
+            Logger.getLogger(ScaledImageReference.class.getName());
 
     // scaled image size.
     private final int width;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/SmoothScaledImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/SmoothScaledImageReference.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 public class SmoothScaledImageReference extends CachedImageReference {
 
     private static final Logger logger =
-            Logger.getLogger(SmoothScaledImageReference.class.toString());
+            Logger.getLogger(SmoothScaledImageReference.class.getName());
 
     private static int maxImageWidth = 7000;
     private static int maxImageHeight = 7000;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/GlyphText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/GlyphText.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class GlyphText extends AbstractText {
 
     private static final Logger logger =
-            Logger.getLogger(GlyphText.class.toString());
+            Logger.getLogger(GlyphText.class.getName());
 
     // x and y coordinates used for painting glyph
     private final float x;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/WordText.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/text/WordText.java
@@ -39,7 +39,7 @@ import java.util.logging.Logger;
 public class WordText extends AbstractText implements TextSelect {
 
     private static final Logger logger =
-            Logger.getLogger(WordText.class.toString());
+            Logger.getLogger(WordText.class.getName());
 
     // Space Glyph width fraction, the default is 1/x of the character width,
     // constitutes a potential space between glyphs.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/security/JceProvider.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/security/JceProvider.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 public class JceProvider {
 
     private static final Logger logger =
-            Logger.getLogger(JceProvider.class.toString());
+            Logger.getLogger(JceProvider.class.getName());
 
     /**
      * Try and load a JCE provider specified by org.icepdf.core.security.jceProvider system property.  If not set

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/security/SecurityManager.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/security/SecurityManager.java
@@ -18,15 +18,10 @@ package org.icepdf.core.pobjects.security;
 import org.icepdf.core.exceptions.PDFSecurityException;
 import org.icepdf.core.pobjects.DictionaryEntries;
 import org.icepdf.core.pobjects.Reference;
-import org.icepdf.core.util.Defs;
 import org.icepdf.core.util.Library;
 
 import java.io.InputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.security.Provider;
-import java.security.Security;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -53,7 +48,7 @@ import java.util.logging.Logger;
 public class SecurityManager {
 
     private static final Logger logger =
-            Logger.getLogger(SecurityManager.class.toString());
+            Logger.getLogger(SecurityManager.class.getName());
 
     // Default Encryption dictionary, which also contians keys need for
     // standard, crypt and public security handlers.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/security/StandardEncryption.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/security/StandardEncryption.java
@@ -45,7 +45,7 @@ import java.util.logging.Logger;
 class StandardEncryption {
 
     private static final Logger logger =
-            Logger.getLogger(StandardEncryption.class.toString());
+            Logger.getLogger(StandardEncryption.class.getName());
 
     /**
      * The application shall not decrypt data but shall direct the input stream

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/CrossReferenceRoot.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/CrossReferenceRoot.java
@@ -36,7 +36,7 @@ import static org.icepdf.core.pobjects.PTrailer.ROOT_KEY;
  */
 public class CrossReferenceRoot {
 
-    private static final Logger log = Logger.getLogger(CrossReferenceRoot.class.toString());
+    private static final Logger log = Logger.getLogger(CrossReferenceRoot.class.getName());
 
     private final Library library;
     private Trailer trailer;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/CrossReferenceStream.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/CrossReferenceStream.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public class CrossReferenceStream extends CrossReferenceBase<Stream> implements CrossReference{
 
     private static final Logger logger =
-            Logger.getLogger(CrossReferenceStream.class.toString());
+            Logger.getLogger(CrossReferenceStream.class.getName());
 
     public static final Name TYPE = new Name("XRef");
     public static final Name SIZE_KEY = new Name("Size");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/structure/Indexer.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class Indexer {
 
     private static final Logger logger =
-            Logger.getLogger(Indexer.class.toString());
+            Logger.getLogger(Indexer.class.getName());
 
     private final Library library;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/util/Defs.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/Defs.java
@@ -23,7 +23,7 @@ import java.util.logging.Logger;
 public class Defs {
 
     private static final Logger logger =
-            Logger.getLogger(Defs.class.toString());
+            Logger.getLogger(Defs.class.getName());
 
     /**
      * Equivalent to property(name, null)

--- a/core/core-awt/src/main/java/org/icepdf/core/util/FontUtil.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/FontUtil.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  */
 public class FontUtil {
 
-    private static final Logger logger = Logger.getLogger(FontUtil.class.toString());
+    private static final Logger logger = Logger.getLogger(FontUtil.class.getName());
 
     // awt font style lookup style tokens
     private static final String AWT_STYLE_BOLD_ITAL = "boldital";

--- a/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/Library.java
@@ -60,7 +60,7 @@ import java.util.logging.Logger;
  */
 public class Library {
 
-    private static final Logger logger = Logger.getLogger(Library.class.toString());
+    private static final Logger logger = Logger.getLogger(Library.class.getName());
 
     protected static ThreadPoolExecutor commonThreadPool;
     protected static ThreadPoolExecutor imageThreadPool;

--- a/core/core-awt/src/main/java/org/icepdf/core/util/Parser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/Parser.java
@@ -16,8 +16,8 @@
 package org.icepdf.core.util;
 
 import org.icepdf.core.io.*;
-import org.icepdf.core.pobjects.Dictionary;
 import org.icepdf.core.pobjects.*;
+import org.icepdf.core.pobjects.Dictionary;
 import org.icepdf.core.pobjects.annotations.Annotation;
 import org.icepdf.core.pobjects.fonts.CMap;
 import org.icepdf.core.pobjects.fonts.Font;
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public class Parser {
 
     private static final Logger logger =
-            Logger.getLogger(Parser.class.toString());
+            Logger.getLogger(Parser.class.getName());
 
     public static final int PARSE_MODE_NORMAL = 0;
     public static final int PARSE_MODE_OBJECT_STREAM = 1;

--- a/core/core-awt/src/main/java/org/icepdf/core/util/Utils.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/Utils.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public class Utils {
 
     private static final Logger logger =
-            Logger.getLogger(Utils.class.toString());
+            Logger.getLogger(Utils.class.getName());
 
     /**
      * Sets the value into the buffer, at the designated offset, using big-endian rules

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
@@ -48,7 +48,7 @@ import java.util.logging.Logger;
  */
 public abstract class AbstractContentParser {
     private static final Logger logger =
-            Logger.getLogger(AbstractContentParser.class.toString());
+            Logger.getLogger(AbstractContentParser.class.getName());
 
     private static final boolean disableTransparencyGroups;
     private static final boolean enabledOverPrint;

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/ContentParser.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 public class ContentParser extends AbstractContentParser {
 
     private static final Logger logger =
-            Logger.getLogger(ContentParser.class.toString());
+            Logger.getLogger(ContentParser.class.getName());
 
     /**
      * Inline image cache,  for heavily tiled background images.  Can be cleared

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/Lexer.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/Lexer.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
 public class Lexer {
 
     private static final Logger logger =
-            Logger.getLogger(Lexer.class.toString());
+            Logger.getLogger(Lexer.class.getName());
 
     private static final int
             NO_MORE = 1,

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/object/Lexer.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/object/Lexer.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class Lexer {
 
     private static final Logger logger =
-            Logger.getLogger(Lexer.class.toString());
+            Logger.getLogger(Lexer.class.getName());
 
     private final Library library;
 

--- a/core/core-awt/src/main/java/org/icepdf/core/util/redaction/RedactionContentBurner.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/redaction/RedactionContentBurner.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
  */
 public class RedactionContentBurner {
     private static final Logger logger =
-            Logger.getLogger(RedactionContentBurner.class.toString());
+            Logger.getLogger(RedactionContentBurner.class.getName());
 
     public static void burn(Page page,
                             List<RedactionAnnotation> redactionAnnotations) throws InterruptedException, IOException {

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/DocumentBuilder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/DocumentBuilder.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class DocumentBuilder {
 
     private static final Logger logger =
-            Logger.getLogger(Document.class.toString());
+            Logger.getLogger(Document.class.getName());
 
     public long createDocument(
             WriteMode writeMode,

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/FullUpdater.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/FullUpdater.java
@@ -48,7 +48,7 @@ import java.util.logging.Logger;
 public class FullUpdater {
 
     private static final Logger logger =
-            Logger.getLogger(FullUpdater.class.toString());
+            Logger.getLogger(FullUpdater.class.getName());
 
     /**
      * Write the xrefTable in a compressed format by default.  Can be disabled if to aid in debugging or to

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/IncrementalUpdater.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/IncrementalUpdater.java
@@ -42,7 +42,7 @@ import java.util.logging.Logger;
 public class IncrementalUpdater {
 
     private static final Logger logger =
-            Logger.getLogger(IncrementalUpdater.class.toString());
+            Logger.getLogger(IncrementalUpdater.class.getName());
 
     /**
      * Appends modified objects to the specified output stream.

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/callbacks/ContentStreamCallback.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/callbacks/ContentStreamCallback.java
@@ -42,7 +42,7 @@ import static org.icepdf.core.util.parser.content.Operands.*;
  */
 public abstract class ContentStreamCallback {
 
-    protected static final Logger logger = Logger.getLogger(ContentStreamCallback.class.toString());
+    protected static final Logger logger = Logger.getLogger(ContentStreamCallback.class.getName());
 
     protected Stream currentStream;
     protected ByteArrayOutputStream burnedContentOutputStream;

--- a/core/core-awt/src/main/java/org/icepdf/core/util/updater/modifiers/ModifierFactory.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/updater/modifiers/ModifierFactory.java
@@ -29,7 +29,7 @@ import java.util.logging.Logger;
  * @since 7.2
  */
 public class ModifierFactory {
-    private static final Logger logger = Logger.getLogger(ModifierFactory.class.toString());
+    private static final Logger logger = Logger.getLogger(ModifierFactory.class.getName());
 
     public static Modifier getModifier(Dictionary parent, Dictionary modify) {
         if (modify instanceof Page) {

--- a/core/core-fonts/src/main/java/org/icepdf/core/fonts/util/EmbeddedFontUtil.java
+++ b/core/core-fonts/src/main/java/org/icepdf/core/fonts/util/EmbeddedFontUtil.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 public class EmbeddedFontUtil {
 
     private static final Logger logger =
-            Logger.getLogger(EmbeddedFontUtil.class.toString());
+            Logger.getLogger(EmbeddedFontUtil.class.getName());
 
     // font available in the icepdf font resources jar
     private static final Map<String, String> otfFontMapper = new java.util.HashMap<>();

--- a/examples/annotation/callback/src/main/java/org/icepdf/examples/annotation/callback/MyAnnotationCallback.java
+++ b/examples/annotation/callback/src/main/java/org/icepdf/examples/annotation/callback/MyAnnotationCallback.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public class MyAnnotationCallback implements AnnotationCallback {
 
     private static final Logger logger =
-            Logger.getLogger(MyAnnotationCallback.class.toString());
+            Logger.getLogger(MyAnnotationCallback.class.getName());
 
     private final DocumentViewController documentViewController;
 

--- a/examples/printservices/src/main/java/org/icepdf/examples/print/PrintServices.java
+++ b/examples/printservices/src/main/java/org/icepdf/examples/print/PrintServices.java
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
 public class PrintServices {
 
     private static final Logger logger =
-            Logger.getLogger(PrintServices.class.toString());
+            Logger.getLogger(PrintServices.class.getName());
 
     static {
         Defs.setProperty("java.awt.headless", "true");

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/CurrentPageChanger.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/CurrentPageChanger.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class CurrentPageChanger extends MouseAdapter implements AdjustmentListener {
 
     private static final Logger logger =
-            Logger.getLogger(CurrentPageChanger.class.toString());
+            Logger.getLogger(CurrentPageChanger.class.getName());
 
     private boolean isScrolled = false;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/DropDownButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/DropDownButton.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class DropDownButton extends JButton
         implements MouseListener {
 
-    private static final Logger logger = Logger.getLogger(DropDownButton.class.toString());
+    private static final Logger logger = Logger.getLogger(DropDownButton.class.getName());
 
     protected final Controller controller;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/ListItemTransferHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/ListItemTransferHandler.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
  */
 public class ListItemTransferHandler extends TransferHandler {
 
-    private static final Logger logger = Logger.getLogger(ListItemTransferHandler.class.toString());
+    private static final Logger logger = Logger.getLogger(ListItemTransferHandler.class.getName());
 
     private static DataFlavor dataFlavor;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/MyAnnotationCallback.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/MyAnnotationCallback.java
@@ -41,7 +41,7 @@ import java.util.logging.Logger;
 public class MyAnnotationCallback implements AnnotationCallback {
 
     private static final Logger logger =
-            Logger.getLogger(MyAnnotationCallback.class.toString());
+            Logger.getLogger(MyAnnotationCallback.class.getName());
 
     private final DocumentViewController documentViewController;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/PageThumbnailComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/PageThumbnailComponent.java
@@ -44,7 +44,7 @@ import java.util.logging.Logger;
 public class PageThumbnailComponent extends AbstractPageViewComponent implements MouseListener {
 
     private static final Logger logger =
-            Logger.getLogger(PageThumbnailComponent.class.toString());
+            Logger.getLogger(PageThumbnailComponent.class.getName());
 
     public PageThumbnailComponent(DocumentViewController documentViewController,
                                   DocumentViewModel documentViewModel, PageTree pageTree,

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingController.java
@@ -120,7 +120,7 @@ import static org.icepdf.ri.util.ViewerPropertiesManager.*;
 public class SwingController extends ComponentAdapter implements org.icepdf.ri.common.views.Controller,
         ActionListener, FocusListener, ItemListener, WindowListener, DropTargetListener, PropertyChangeListener {
 
-    protected static final Logger logger = Logger.getLogger(SwingController.class.toString());
+    protected static final Logger logger = Logger.getLogger(SwingController.class.getName());
 
     private static final boolean USE_JFILECHOOSER;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/SwingViewBuilder.java
@@ -287,7 +287,7 @@ import java.util.prefs.Preferences;
 public class SwingViewBuilder implements ViewBuilder {
 
     private static final Logger logger =
-            Logger.getLogger(SwingViewBuilder.class.toString());
+            Logger.getLogger(SwingViewBuilder.class.getName());
 
     public static final int TOOL_BAR_STYLE_FIXED = 2;
     protected static final float[] DEFAULT_ZOOM_LEVELS = {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/fonts/FindFontsTask.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/fonts/FindFontsTask.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
  */
 public class FindFontsTask extends AbstractTask<Void, Font> {
 
-    private static final Logger logger = Logger.getLogger(FindFontsTask.class.toString());
+    private static final Logger logger = Logger.getLogger(FindFontsTask.class.getName());
 
     // canned internationalized messages.
     private final MessageFormat searchingMessageForm;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/print/PrintHelperImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/print/PrintHelperImpl.java
@@ -49,7 +49,7 @@ import java.util.logging.Logger;
 public class PrintHelperImpl extends PrintHelper {
 
     private static final Logger logger =
-            Logger.getLogger(PrintHelperImpl.class.toString());
+            Logger.getLogger(PrintHelperImpl.class.getName());
 
     private final PageTree pageTree;
     private final Container container;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/print/PrinterTask.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/print/PrinterTask.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class PrinterTask implements Runnable {
 
     private static final Logger logger =
-            Logger.getLogger(PrinterTask.class.toString());
+            Logger.getLogger(PrinterTask.class.getName());
 
     // PrinterJob to print
     private final PrintHelper printHelper;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/search/DocumentSearchControllerImpl.java
@@ -64,7 +64,7 @@ import java.util.stream.Collectors;
 public class DocumentSearchControllerImpl implements DocumentSearchController {
 
     private static final Logger logger =
-            Logger.getLogger(DocumentSearchControllerImpl.class.toString());
+            Logger.getLogger(DocumentSearchControllerImpl.class.getName());
 
     // search model contains caching and memory optimizations.
     private final DocumentSearchModelImpl searchModel;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/CircleAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/CircleAnnotationHandler.java
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
 public class CircleAnnotationHandler extends SquareAnnotationHandler {
 
     private static final Logger logger =
-            Logger.getLogger(CircleAnnotationHandler.class.toString());
+            Logger.getLogger(CircleAnnotationHandler.class.getName());
 
     protected final static float DEFAULT_STROKE_WIDTH = 3.0f;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/CommonToolHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/CommonToolHandler.java
@@ -36,7 +36,7 @@ import java.util.prefs.Preferences;
 public abstract class CommonToolHandler {
 
     private static final Logger logger =
-            Logger.getLogger(CommonToolHandler.class.toString());
+            Logger.getLogger(CommonToolHandler.class.getName());
 
     // parent page component
     protected final AbstractPageViewComponent pageViewComponent;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/DynamicZoomHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/DynamicZoomHandler.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public class DynamicZoomHandler implements ToolHandler, MouseWheelListener {
 
     private static final Logger logger =
-            Logger.getLogger(ZoomOutPageHandler.class.toString());
+            Logger.getLogger(ZoomOutPageHandler.class.getName());
 
     private final DocumentViewController documentViewController;
     protected final JScrollPane documentScrollPane;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/FreeTextAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/FreeTextAnnotationHandler.java
@@ -53,7 +53,7 @@ public class FreeTextAnnotationHandler extends SelectionBoxHandler
         implements ToolHandler {
 
     private static final Logger logger =
-            Logger.getLogger(LineAnnotationHandler.class.toString());
+            Logger.getLogger(LineAnnotationHandler.class.getName());
 
     public static final int DEFAULT_WIDTH = 30;
     public static final int DEFAULT_HEIGHT = 20;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/InkAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/InkAnnotationHandler.java
@@ -56,7 +56,7 @@ import java.util.logging.Logger;
 public class InkAnnotationHandler extends CommonToolHandler implements ToolHandler, ActionListener {
 
     private static final Logger logger =
-            Logger.getLogger(LineAnnotationHandler.class.toString());
+            Logger.getLogger(LineAnnotationHandler.class.getName());
 
     // need to make the stroke cap, thickness configurable. Or potentially
     // static from the lineAnnotationHandle, so it would look like the last

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/LineAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/LineAnnotationHandler.java
@@ -57,7 +57,7 @@ public class LineAnnotationHandler extends SelectionBoxHandler implements ToolHa
 
 
     private static final Logger logger =
-            Logger.getLogger(LineAnnotationHandler.class.toString());
+            Logger.getLogger(LineAnnotationHandler.class.getName());
 
     // need to make the stroke cap, thickness configurable. Or potentially
     // static from the lineAnnotationHandle so it would look like the last

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/LineArrowAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/LineArrowAnnotationHandler.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class LineArrowAnnotationHandler extends LineAnnotationHandler {
 
     private static final Logger logger =
-            Logger.getLogger(LineAnnotationHandler.class.toString());
+            Logger.getLogger(LineAnnotationHandler.class.getName());
 
 
     public LineArrowAnnotationHandler(DocumentViewController documentViewController,

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/LinkAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/LinkAnnotationHandler.java
@@ -39,7 +39,7 @@ public class LinkAnnotationHandler extends SelectionBoxHandler
         implements ToolHandler, MouseInputListener {
 
     private static final Logger logger =
-            Logger.getLogger(LinkAnnotationHandler.class.toString());
+            Logger.getLogger(LinkAnnotationHandler.class.getName());
 
     public LinkAnnotationHandler(DocumentViewController documentViewController,
                                  AbstractPageViewComponent pageViewComponent) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/SignatureAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/SignatureAnnotationHandler.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class SignatureAnnotationHandler extends SelectionBoxHandler
         implements ToolHandler, MouseInputListener {
 
-    private static final Logger logger = Logger.getLogger(SignatureAnnotationHandler.class.toString());
+    private static final Logger logger = Logger.getLogger(SignatureAnnotationHandler.class.getName());
 
     public SignatureAnnotationHandler(DocumentViewController documentViewController,
                                       AbstractPageViewComponent pageViewComponent) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/SquareAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/SquareAnnotationHandler.java
@@ -52,7 +52,7 @@ import java.util.logging.Logger;
 public class SquareAnnotationHandler extends SelectionBoxHandler implements ToolHandler {
 
     private static final Logger logger =
-            Logger.getLogger(SquareAnnotationHandler.class.toString());
+            Logger.getLogger(SquareAnnotationHandler.class.getName());
 
     protected final static float DEFAULT_STROKE_WIDTH = 3.0f;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextAnnotationHandler.java
@@ -55,7 +55,7 @@ import java.util.logging.Logger;
 public class TextAnnotationHandler extends CommonToolHandler implements ToolHandler {
 
     private static final Logger logger =
-            Logger.getLogger(TextAnnotationHandler.class.toString());
+            Logger.getLogger(TextAnnotationHandler.class.getName());
 
     protected static Color defaultFillColor;
     protected static String defaultIcon;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelection.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelection.java
@@ -41,7 +41,7 @@ import static org.icepdf.ri.common.tools.TextSelection.enableMarginExclusion;
 public class TextSelection extends SelectionBoxHandler {
 
     protected static final Logger logger =
-            Logger.getLogger(TextSelection.class.toString());
+            Logger.getLogger(TextSelection.class.getName());
 
     public int selectedCount;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelectionViewHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/TextSelectionViewHandler.java
@@ -46,7 +46,7 @@ public class TextSelectionViewHandler extends TextSelection
         implements ToolHandler, MouseWheelListener {
 
     protected static final Logger logger =
-            Logger.getLogger(TextSelectionViewHandler.class.toString());
+            Logger.getLogger(TextSelectionViewHandler.class.getName());
 
     protected final JComponent parentComponent;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/ZoomInPageHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/ZoomInPageHandler.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class ZoomInPageHandler extends SelectionBoxHandler implements ToolHandler {
 
     private static final Logger logger =
-            Logger.getLogger(ZoomInPageHandler.class.toString());
+            Logger.getLogger(ZoomInPageHandler.class.getName());
 
     private final Point initialPoint = new Point();
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/ZoomInViewHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/ZoomInViewHandler.java
@@ -37,7 +37,7 @@ import java.util.logging.Logger;
 public class ZoomInViewHandler extends SelectionBoxHandler implements ToolHandler {
 
     private static final Logger logger =
-            Logger.getLogger(ZoomInPageHandler.class.toString());
+            Logger.getLogger(ZoomInPageHandler.class.getName());
 
     private final AbstractDocumentView parentComponent;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/ZoomOutPageHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/ZoomOutPageHandler.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 public class ZoomOutPageHandler implements ToolHandler {
 
     private static final Logger logger =
-            Logger.getLogger(ZoomOutPageHandler.class.toString());
+            Logger.getLogger(ZoomOutPageHandler.class.getName());
 
     private final AbstractPageViewComponent pageViewComponent;
     private final DocumentViewController documentViewController;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/AnnotationTreeNode.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/AnnotationTreeNode.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 public class AnnotationTreeNode extends AbstractAnnotationTreeNode<Annotation> {
 
     private static final Logger logger =
-            Logger.getLogger(AnnotationTreeNode.class.toString());
+            Logger.getLogger(AnnotationTreeNode.class.getName());
 
     private Annotation annotation;
     private final Pattern searchPattern;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/destinations/DestinationsPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/destinations/DestinationsPanel.java
@@ -62,7 +62,7 @@ public class DestinationsPanel extends JPanel
         implements MutableDocument, TreeSelectionListener, MouseListener, ActionListener, PropertyChangeListener {
 
     private static final Logger logger =
-            Logger.getLogger(DestinationsPanel.class.toString());
+            Logger.getLogger(DestinationsPanel.class.getName());
 
     // layouts constraint
     protected final GridBagConstraints constraints;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/markup/FindMarkupAnnotationTask.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/markup/FindMarkupAnnotationTask.java
@@ -32,8 +32,8 @@ import java.text.MessageFormat;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.FormatStyle;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -44,7 +44,7 @@ import static org.icepdf.core.util.SystemProperties.PRIVATE_PROPERTY_ENABLED;
 public class FindMarkupAnnotationTask extends AbstractTask<Void, Object> {
 
     private static final Logger logger =
-            Logger.getLogger(FindMarkupAnnotationTask.class.toString());
+            Logger.getLogger(FindMarkupAnnotationTask.class.getName());
 
     private static ArrayList<DragDropColorList.ColorLabel> colorLabels;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/markup/MarkupAnnotationPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/markup/MarkupAnnotationPanel.java
@@ -61,7 +61,7 @@ public class MarkupAnnotationPanel extends JPanel implements ActionListener, Pro
         MutableDocument, DocumentListener {
 
     private static final Logger logger =
-            Logger.getLogger(MarkupAnnotationPanel.class.toString());
+            Logger.getLogger(MarkupAnnotationPanel.class.getName());
 
     public static final String COLUMN_PROPERTY = "Column";
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/properties/ActionsPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/properties/ActionsPanel.java
@@ -45,7 +45,7 @@ public class ActionsPanel extends AnnotationPanelAdapter
         implements ListSelectionListener, ActionListener {
 
     private static final Logger logger =
-            Logger.getLogger(ActionsPanel.class.toString());
+            Logger.getLogger(ActionsPanel.class.getName());
 
     // actionList of action actions
     private DefaultListModel<ActionEntry> actionListModel;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/attachment/AttachmentPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/attachment/AttachmentPanel.java
@@ -54,7 +54,7 @@ import static org.icepdf.ri.common.utility.attachment.FileTableModel.*;
 public class AttachmentPanel extends JPanel implements MouseListener, ActionListener, MutableDocument {
 
     private static final Logger logger =
-            Logger.getLogger(AttachmentPanel.class.toString());
+            Logger.getLogger(AttachmentPanel.class.getName());
 
     private static final String PDF_EXTENSION = ".pdf";
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/outline/TreeTransferHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/outline/TreeTransferHandler.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 class TreeTransferHandler extends TransferHandler {
 
     protected static final Logger logger =
-            Logger.getLogger(TreeTransferHandler.class.toString());
+            Logger.getLogger(TreeTransferHandler.class.getName());
 
     DataFlavor nodesFlavor;
     DataFlavor[] flavors = new DataFlavor[1];

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/search/SearchPanel.java
@@ -70,7 +70,7 @@ public class SearchPanel extends JPanel implements ActionListener, MutableDocume
         TreeSelectionListener, DocumentListener, BaseSearchModel, BaseRedactModel {
 
     private static final Logger logger =
-            Logger.getLogger(SearchPanel.class.toString());
+            Logger.getLogger(SearchPanel.class.getName());
 
     private static final int maxPagesForLiveSearch;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SigPropertyTreeNode.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SigPropertyTreeNode.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 public class SigPropertyTreeNode extends DefaultMutableTreeNode {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureTreeNode.class.toString());
+            Logger.getLogger(SignatureTreeNode.class.getName());
 
     public SigPropertyTreeNode(Object userObject) {
         super(userObject);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureCertTreeNode.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureCertTreeNode.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
 public class SignatureCertTreeNode extends DefaultMutableTreeNode {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureTreeNode.class.toString());
+            Logger.getLogger(SignatureTreeNode.class.getName());
 
     private final Collection<? extends Certificate> certificateChain;
     private final Icon icon;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureTreeNode.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignatureTreeNode.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 public class SignatureTreeNode extends DefaultMutableTreeNode {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureTreeNode.class.toString());
+            Logger.getLogger(SignatureTreeNode.class.getName());
 
     private final ResourceBundle messageBundle;
     private final SignatureWidgetAnnotation signatureWidgetAnnotation;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignaturesHandlerPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/SignaturesHandlerPanel.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
 public class SignaturesHandlerPanel extends AbstractWorkerPanel {
 
     private static final Logger logger =
-            Logger.getLogger(SignaturesHandlerPanel.class.toString());
+            Logger.getLogger(SignaturesHandlerPanel.class.getName());
 
     public SignaturesHandlerPanel(Controller controller) {
         super(controller);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/VerifyAllSignaturesTask.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/signatures/VerifyAllSignaturesTask.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
  */
 public class VerifyAllSignaturesTask extends AbstractTask<Void, Object> {
 
-    private static final Logger logger = Logger.getLogger(VerifyAllSignaturesTask.class.toString());
+    private static final Logger logger = Logger.getLogger(VerifyAllSignaturesTask.class.getName());
 
     public VerifyAllSignaturesTask(Controller controller, AbstractWorkerPanel workerPanel, ResourceBundle messageBundle) {
         super(controller, workerPanel, messageBundle);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractDocumentView.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractDocumentView.java
@@ -46,7 +46,7 @@ public abstract class AbstractDocumentView
         implements DocumentView, PropertyChangeListener, MouseListener, MouseMotionListener, ActionListener {
 
     private static final Logger logger =
-            Logger.getLogger(AbstractDocumentView.class.toString());
+            Logger.getLogger(AbstractDocumentView.class.getName());
 
     // background colour
     public static Color backgroundColour;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractDocumentViewModel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractDocumentViewModel.java
@@ -22,16 +22,12 @@ import org.icepdf.core.pobjects.Page;
 import org.icepdf.core.pobjects.PageTree;
 import org.icepdf.core.pobjects.Reference;
 import org.icepdf.ri.common.UndoCaretaker;
-import org.icepdf.ri.common.views.annotations.AbstractAnnotationComponent;
-import org.icepdf.ri.common.views.annotations.AnnotationState;
-import org.icepdf.ri.common.views.annotations.MarkupGlueComponent;
-import org.icepdf.ri.common.views.annotations.PageViewAnnotationComponent;
-import org.icepdf.ri.common.views.annotations.PopupAnnotationComponent;
+import org.icepdf.ri.common.views.annotations.*;
 
 import javax.swing.*;
 import java.awt.*;
-import java.util.List;
 import java.util.*;
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -48,7 +44,7 @@ import java.util.stream.Collectors;
 public abstract class AbstractDocumentViewModel implements DocumentViewModel {
 
     private static final Logger log =
-            Logger.getLogger(AbstractDocumentViewModel.class.toString());
+            Logger.getLogger(AbstractDocumentViewModel.class.getName());
 
     // document that model is associated.
     protected final Document currentDocument;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractPageViewComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/AbstractPageViewComponent.java
@@ -44,7 +44,7 @@ public abstract class AbstractPageViewComponent
         implements PageViewComponent {
 
     private static final Logger logger =
-            Logger.getLogger(AbstractPageViewComponent.class.toString());
+            Logger.getLogger(AbstractPageViewComponent.class.getName());
 
     protected static final int PAGE_BOUNDARY_BOX = Page.BOUNDARY_CROPBOX;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewComponent.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
  * @since 5.1.0
  */
 public class DocumentViewComponent extends JComponent implements MouseListener, Runnable {
-    private static final Logger logger = Logger.getLogger(DocumentViewComponent.class.toString());
+    private static final Logger logger = Logger.getLogger(DocumentViewComponent.class.getName());
 
     private static final long serialVersionUID = -8881023489246309889L;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/DocumentViewControllerImpl.java
@@ -57,7 +57,7 @@ public class DocumentViewControllerImpl
         implements DocumentViewController, ComponentListener, PropertyChangeListener {
 
     private static final Logger logger =
-            Logger.getLogger(DocumentViewControllerImpl.class.toString());
+            Logger.getLogger(DocumentViewControllerImpl.class.getName());
 
     private static final Pattern MULTI_SPACE_PATTERN = Pattern.compile(" +");
     private static final Pattern DASH_NEWLINE_PATTERN = Pattern.compile("- *\n");

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/FullScreenDocumentView.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/FullScreenDocumentView.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public class FullScreenDocumentView extends OnePageView implements WindowListener {
 
     private static final Logger logger =
-            Logger.getLogger(FullScreenDocumentView.class.toString());
+            Logger.getLogger(FullScreenDocumentView.class.getName());
 
     private static Object instance;
     private boolean disposed;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/PageViewComponentImpl.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/PageViewComponentImpl.java
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public class PageViewComponentImpl extends AbstractPageViewComponent implements FocusListener {
 
     private static final Logger logger =
-            Logger.getLogger(PageViewComponentImpl.class.toString());
+            Logger.getLogger(PageViewComponentImpl.class.getName());
 
     // currently selected tool
     protected ToolHandler currentToolHandler;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/PageViewDecorator.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/PageViewDecorator.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
 public class PageViewDecorator extends JComponent {
 
     private static final Logger log =
-            Logger.getLogger(PageViewDecorator.class.toString());
+            Logger.getLogger(PageViewDecorator.class.getName());
 
     protected JComponent pageViewComponent;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/ResizableBorder.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/ResizableBorder.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
 public class ResizableBorder extends AbstractBorder {
 
     private static final Logger logger =
-            Logger.getLogger(ResizableBorder.class.toString());
+            Logger.getLogger(ResizableBorder.class.getName());
 
     private static Color selectColor;
     private static Color outlineColor;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AbstractAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AbstractAnnotationComponent.java
@@ -56,7 +56,7 @@ public abstract class AbstractAnnotationComponent<T extends Annotation> extends 
         MouseInputListener, AnnotationComponent, ResizeableComponent {
 
     protected static final Logger logger =
-            Logger.getLogger(AbstractAnnotationComponent.class.toString());
+            Logger.getLogger(AbstractAnnotationComponent.class.getName());
     protected static Color annotationHighlightColor;
     protected static float annotationHighlightAlpha;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AnnotationComponentFactory.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/AnnotationComponentFactory.java
@@ -41,7 +41,7 @@ import static org.icepdf.core.pobjects.acroform.ButtonFieldDictionary.ButtonFiel
 public class AnnotationComponentFactory {
 
     protected static final Logger logger =
-            Logger.getLogger(AnnotationComponentFactory.class.toString());
+            Logger.getLogger(AnnotationComponentFactory.class.getName());
 
     private AnnotationComponentFactory() {
     }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/FreeTextAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/FreeTextAnnotationComponent.java
@@ -64,7 +64,7 @@ public class FreeTextAnnotationComponent extends MarkupAnnotationComponent<FreeT
         implements PropertyChangeListener, DocumentListener {
 
     private static final Logger logger =
-            Logger.getLogger(FreeTextAnnotation.class.toString());
+            Logger.getLogger(FreeTextAnnotation.class.getName());
     private final ScalableTextArea freeTextPane;
     // font file cache.
     protected Font fontFile;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationComponent.java
@@ -54,7 +54,7 @@ import java.util.logging.Logger;
 public abstract class MarkupAnnotationComponent<T extends MarkupAnnotation> extends AbstractAnnotationComponent<T> {
 
     protected static final Logger logger =
-            Logger.getLogger(MarkupAnnotationComponent.class.toString());
+            Logger.getLogger(MarkupAnnotationComponent.class.getName());
 
     protected static final boolean isInteractivePopupAnnotationsEnabled;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationPopupMenu.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/MarkupAnnotationPopupMenu.java
@@ -56,7 +56,7 @@ import static org.icepdf.core.util.SystemProperties.PRIVATE_PROPERTY_ENABLED;
 public class MarkupAnnotationPopupMenu extends AnnotationPopup<MarkupAnnotationComponent> {
 
     private static final Logger logger =
-            Logger.getLogger(MarkupAnnotationPopupMenu.class.toString());
+            Logger.getLogger(MarkupAnnotationPopupMenu.class.getName());
 
     // reply commands
     protected JMenuItem replyMenuItem;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/SpellCheckLoader.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/SpellCheckLoader.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class SpellCheckLoader {
 
     private static final Logger logger =
-            Logger.getLogger(SpellCheckLoader.class.toString());
+            Logger.getLogger(SpellCheckLoader.class.getName());
 
     protected static final String JORTHO_SPELL_CHECKER_CLASS = "com.inet.jortho.SpellChecker";
     protected static final String JORTHO_FILE_USER_DICTIONARY_CLASS = "com.inet.jortho.UserDictionaryProvider";

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/TextAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/TextAnnotationComponent.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class TextAnnotationComponent extends MarkupAnnotationComponent<TextAnnotation> {
 
     private static final Logger logger =
-            Logger.getLogger(TextAnnotationComponent.class.toString());
+            Logger.getLogger(TextAnnotationComponent.class.getName());
 
     public TextAnnotationComponent(TextAnnotation annotation, DocumentViewController documentViewController,
                                    AbstractPageViewComponent pageViewComponent) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/TextMarkupAnnotationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/TextMarkupAnnotationComponent.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 public class TextMarkupAnnotationComponent extends MarkupAnnotationComponent<TextMarkupAnnotation> {
 
     private static final Logger logger =
-            Logger.getLogger(TextMarkupAnnotationComponent.class.toString());
+            Logger.getLogger(TextMarkupAnnotationComponent.class.getName());
 
     public TextMarkupAnnotationComponent(TextMarkupAnnotation annotation, DocumentViewController documentViewController,
                                          AbstractPageViewComponent pageViewComponent) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/AbstractChoiceComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/AbstractChoiceComponent.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 public abstract class AbstractChoiceComponent extends AbstractAnnotationComponent<ChoiceWidgetAnnotation> implements
         FocusListener, PropertyChangeListener {
 
-    private static final Logger logger = Logger.getLogger(AbstractChoiceComponent.class.toString());
+    private static final Logger logger = Logger.getLogger(AbstractChoiceComponent.class.getName());
 
     public AbstractChoiceComponent(ChoiceWidgetAnnotation annotation, DocumentViewController documentViewController,
                                    AbstractPageViewComponent pageViewComponent) {

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/ChoiceComboComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/ChoiceComboComponent.java
@@ -38,7 +38,7 @@ import static org.icepdf.core.util.SystemProperties.INTERACTIVE_ANNOTATIONS;
 
 public class ChoiceComboComponent extends AbstractChoiceComponent implements FocusListener, PropertyChangeListener {
 
-    private static final Logger logger = Logger.getLogger(ChoiceComboComponent.class.toString());
+    private static final Logger logger = Logger.getLogger(ChoiceComboComponent.class.getName());
 
     private ScalableJComboBox comboBoxList;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/ChoiceListComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/ChoiceListComponent.java
@@ -41,7 +41,7 @@ import static org.icepdf.core.util.SystemProperties.INTERACTIVE_ANNOTATIONS;
 public class ChoiceListComponent extends AbstractChoiceComponent implements
         AdjustmentListener, FocusListener, PropertyChangeListener {
 
-    private static final Logger logger = Logger.getLogger(AbstractChoiceComponent.class.toString());
+    private static final Logger logger = Logger.getLogger(AbstractChoiceComponent.class.getName());
 
     private ScalableJList choiceList;
     private ScalableJScrollPane choiceListPane;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/SignatureComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/SignatureComponent.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
 public class SignatureComponent extends AbstractAnnotationComponent<SignatureWidgetAnnotation> {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureComponent.class.toString());
+            Logger.getLogger(SignatureComponent.class.getName());
 
     protected final JMenuItem validationMenu;
     protected final JMenuItem signaturePropertiesMenu;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/TextWidgetComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/acroform/TextWidgetComponent.java
@@ -56,7 +56,7 @@ public class TextWidgetComponent extends AbstractAnnotationComponent<TextWidgetA
         implements PropertyChangeListener {
 
     private static final Logger logger =
-            Logger.getLogger(TextWidgetComponent.class.toString());
+            Logger.getLogger(TextWidgetComponent.class.getName());
 
     private boolean textContentChange;
     private JTextComponent textWidgetComponent;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/CertificatePropertiesDialog.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/CertificatePropertiesDialog.java
@@ -18,9 +18,9 @@ package org.icepdf.ri.common.views.annotations.signatures;
 import org.bouncycastle.asn1.ASN1ObjectIdentifier;
 import org.bouncycastle.asn1.x500.X500Name;
 import org.bouncycastle.asn1.x500.style.BCStyle;
+import org.icepdf.core.pobjects.acroform.signature.utils.SignatureUtilities;
 import org.icepdf.core.util.HexDumper;
 import org.icepdf.ri.common.EscapeJDialog;
-import org.icepdf.core.pobjects.acroform.signature.utils.SignatureUtilities;
 import org.icepdf.ri.images.IconPack;
 import org.icepdf.ri.images.Images;
 
@@ -46,7 +46,7 @@ import java.util.logging.Logger;
 public class CertificatePropertiesDialog extends EscapeJDialog {
 
     private static final Logger logger =
-            Logger.getLogger(CertificatePropertiesDialog.class.toString());
+            Logger.getLogger(CertificatePropertiesDialog.class.getName());
 
     protected static ResourceBundle messageBundle;
     private final Collection<? extends Certificate> certs;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignaturePropertiesDialog.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignaturePropertiesDialog.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 public class SignaturePropertiesDialog extends EscapeJDialog {
 
     private static final Logger logger =
-            Logger.getLogger(SignaturePropertiesDialog.class.toString());
+            Logger.getLogger(SignaturePropertiesDialog.class.getName());
 
     // layouts constraint
     private GridBagConstraints constraints;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignatureValidationDialog.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signatures/SignatureValidationDialog.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
 public class SignatureValidationDialog extends EscapeJDialog {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureValidationDialog.class.toString());
+            Logger.getLogger(SignatureValidationDialog.class.getName());
 
     private final SignatureValidator signatureValidator;
     protected static ResourceBundle messageBundle;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signing/BasicSignatureAppearanceCallback.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signing/BasicSignatureAppearanceCallback.java
@@ -56,7 +56,7 @@ import static org.icepdf.core.pobjects.annotations.utils.ContentWriterUtils.EMBE
 public class BasicSignatureAppearanceCallback implements SignatureAppearanceCallback<SignatureAppearanceModelImpl> {
 
     protected static final Logger logger =
-            Logger.getLogger(BasicSignatureAppearanceCallback.class.toString());
+            Logger.getLogger(BasicSignatureAppearanceCallback.class.getName());
 
     protected SignatureAppearanceModelImpl signatureAppearanceModel;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signing/SignatureCreationDialog.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/signing/SignatureCreationDialog.java
@@ -58,7 +58,7 @@ public class SignatureCreationDialog extends EscapeJDialog implements ActionList
         ItemListener, FocusListener, ChangeListener {
 
     private static final Logger logger =
-            Logger.getLogger(SignatureCreationDialog.class.toString());
+            Logger.getLogger(SignatureCreationDialog.class.getName());
 
     private static final Locale[] supportedLocales = {
             new Locale("da"),

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/summary/SummaryPopupMenu.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/annotations/summary/SummaryPopupMenu.java
@@ -38,7 +38,7 @@ import java.util.logging.Logger;
 public class SummaryPopupMenu extends AnnotationPopup<MarkupAnnotationComponent> implements ItemListener {
 
     private static final Logger logger =
-            Logger.getLogger(SummaryPopupMenu.class.toString());
+            Logger.getLogger(SummaryPopupMenu.class.getName());
 
     protected final AnnotationSummaryBox annotationSummaryBox;
     protected final MarkupAnnotation markupAnnotation;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/destinations/DestinationComponent.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/destinations/DestinationComponent.java
@@ -43,7 +43,7 @@ import static org.icepdf.core.util.SystemProperties.INTERACTIVE_ANNOTATIONS;
 public class DestinationComponent extends JComponent implements FocusListener, MouseInputListener, ResizeableComponent,
         ActionListener {
     protected static final Logger logger =
-            Logger.getLogger(DestinationComponent.class.toString());
+            Logger.getLogger(DestinationComponent.class.getName());
 
     private static final int HEIGHT = 24;
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/listeners/MetricsPageLoadingListener.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/views/listeners/MetricsPageLoadingListener.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 public class MetricsPageLoadingListener implements PageLoadingListener {
 
     private static final Logger logger =
-            Logger.getLogger(MetricsPageLoadingListener.class.toString());
+            Logger.getLogger(MetricsPageLoadingListener.class.getName());
 
     public static final DecimalFormat formatter = new DecimalFormat("#.###");
     public static final DecimalFormat percentFormatter = new DecimalFormat("#");

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/AbstractColorButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/AbstractColorButton.java
@@ -36,7 +36,7 @@ import java.util.logging.Logger;
 public abstract class AbstractColorButton extends AbstractButton
         implements ActionListener, AncestorListener {
 
-    private static final Logger logger = Logger.getLogger(AbstractColorButton.class.toString());
+    private static final Logger logger = Logger.getLogger(AbstractColorButton.class.getName());
 
     protected final AnnotationColorPropertyPanel annotationColorPropertyPanel;
     protected AbstractButton colorButton;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/RgbColorChooser.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/RgbColorChooser.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 public class RgbColorChooser {
 
     private static final Logger logger =
-            Logger.getLogger(RgbColorChooser.class.toString());
+            Logger.getLogger(RgbColorChooser.class.getName());
 
     /**
      * Shows a modal color-chooser dialog and blocks until the

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorButton.java
@@ -33,7 +33,7 @@ import java.util.logging.Logger;
  */
 public abstract class AnnotationColorButton extends AbstractColorButton {
 
-    private static final Logger logger = Logger.getLogger(AnnotationColorToggleButton.class.toString());
+    private static final Logger logger = Logger.getLogger(AnnotationColorToggleButton.class.getName());
 
     protected AnnotationColorButton(Controller controller,
                                     ResourceBundle messageBundle,

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorToggleButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/AnnotationColorToggleButton.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
  */
 public abstract class AnnotationColorToggleButton extends AbstractColorButton {
 
-    private static final Logger logger = Logger.getLogger(AnnotationColorToggleButton.class.toString());
+    private static final Logger logger = Logger.getLogger(AnnotationColorToggleButton.class.getName());
     private final String colorProperty;
 
     protected AnnotationColorToggleButton(final Controller controller,

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/QuickPaintAnnotationButton.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/widgets/annotations/QuickPaintAnnotationButton.java
@@ -36,7 +36,7 @@ import java.util.prefs.Preferences;
  */
 public class QuickPaintAnnotationButton extends AnnotationColorButton {
 
-    private static final Logger logger = Logger.getLogger(QuickPaintAnnotationButton.class.toString());
+    private static final Logger logger = Logger.getLogger(QuickPaintAnnotationButton.class.getName());
 
     // define the bounded shape used to colourise the icon with the current colour
     private static final GeneralPath textIconPathSmall;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/BareBonesBrowserLaunch.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/BareBonesBrowserLaunch.java
@@ -35,7 +35,7 @@ import java.util.logging.Logger;
 public class BareBonesBrowserLaunch {
 
     private static final Logger logger =
-            Logger.getLogger(BareBonesBrowserLaunch.class.toString());
+            Logger.getLogger(BareBonesBrowserLaunch.class.getName());
     private static final String errMsg =
             "Error attempting to launch web browser";
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/FontPropertiesManager.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/FontPropertiesManager.java
@@ -42,7 +42,7 @@ import java.util.prefs.Preferences;
  */
 public class FontPropertiesManager {
 
-    private static final Logger logger = Logger.getLogger(FontPropertiesManager.class.toString());
+    private static final Logger logger = Logger.getLogger(FontPropertiesManager.class.getName());
 
     // can't use system level cache on window as of JDK 1.8_14, but should work in 9.
     private static final Preferences prefs = Preferences.userNodeForPackage(getPreferencesClass());

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/MacOSAdapter.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/MacOSAdapter.java
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  */
 public class MacOSAdapter implements InvocationHandler {
     private static final Logger logger =
-            Logger.getLogger(MacOSAdapter.class.toString());
+            Logger.getLogger(MacOSAdapter.class.getName());
 
     protected final Object targetObject;
     protected final Method targetMethod;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/MailSender.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/MailSender.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
 
 public final class MailSender {
 
-    private static final Logger logger = Logger.getLogger(MailSender.class.toString());
+    private static final Logger logger = Logger.getLogger(MailSender.class.getName());
 
     private MailSender() {
     }

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/TextExtractionTask.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/TextExtractionTask.java
@@ -43,7 +43,7 @@ import java.util.logging.Logger;
 public class TextExtractionTask extends SwingWorker<Void, StringBuilder> {
 
     private static final Logger logger =
-            Logger.getLogger(TextExtractionTask.class.toString());
+            Logger.getLogger(TextExtractionTask.class.getName());
 
     // total length of task (total page count), used for progress bar
     private final int lengthOfTask;

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/ViewerPropertiesManager.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/util/ViewerPropertiesManager.java
@@ -53,7 +53,7 @@ import java.util.prefs.Preferences;
 public final class ViewerPropertiesManager {
 
     private static final Logger logger =
-            Logger.getLogger(ViewerPropertiesManager.class.toString());
+            Logger.getLogger(ViewerPropertiesManager.class.getName());
 
     // use ascii '27' or ESC as the delimiting character when storing multiple values in one property name.
     public static final String PROPERTY_TOKEN_SEPARATOR = "|";

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/viewer/Launcher.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/viewer/Launcher.java
@@ -67,7 +67,7 @@ import static org.icepdf.ri.common.preferences.SigningPreferencesPanel.PKCS_12_T
 public class Launcher {
 
     private static final Logger logger =
-            Logger.getLogger(Launcher.class.toString());
+            Logger.getLogger(Launcher.class.getName());
 
     public static final String APPLICATION_LOOK_AND_FEEL = "application.lookandfeel";
 


### PR DESCRIPTION
GH-488

- update loggers to use class.getName() over class.toString()
- will print out clean canonical class names like  `org.icepdf.core.pobjects.fonts.zfont.fontFiles.ZFontTrueType` instead of  `class org.icepdf.core.pobjects.fonts.zfont.fontFiles.ZFontTrueType `