### PR TITLE
GH-492 fix parsing numeric values in FreeTextAnnotation

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
@@ -645,7 +645,7 @@ public class FreeTextAnnotation extends MarkupAnnotation {
                     }
                 } else if (cssProperty != null && cssProperty.contains("font-size")) {
                     String fontSize = cssProperty.substring(cssProperty.indexOf(":") + 1).trim();
-                    fontSize = fontSize.substring(0, fontSize.indexOf('p'));
+                    fontSize = fontSize.replaceFirst(".*?(\\d+).*", "$1");
                     try {
                         this.fontSize = (int) Float.parseFloat(fontSize);
                     } catch (NumberFormatException e) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/FreeTextAnnotation.java
@@ -164,7 +164,7 @@ public class FreeTextAnnotation extends MarkupAnnotation {
     public static Color defaultFontColor;
     public static Color defaultFillColor;
     public static Color defaultBorderColor;
-    public static int defaultFontSize;
+    public static float defaultFontSize;
 
     static {
 
@@ -212,8 +212,7 @@ public class FreeTextAnnotation extends MarkupAnnotation {
 
         // sets annotation free text fill colour
         try {
-            defaultFontSize = Defs.sysPropertyInt(
-                    "org.icepdf.core.views.page.annotation.freeText.font.size", 12);
+            defaultFontSize = Defs.floatProperty("org.icepdf.core.views.page.annotation.freeText.font.size", 12.0f);
         } catch (NumberFormatException e) {
             if (logger.isLoggable(Level.WARNING)) {
                 logger.warning("Error reading free text annotation fill colour");
@@ -233,7 +232,7 @@ public class FreeTextAnnotation extends MarkupAnnotation {
     // the annotations appearance stream and other needed properties on edits.
     private String fontName = "Helvetica";
     private int fontStyle = Font.PLAIN;
-    private int fontSize = defaultFontSize;
+    private float fontSize = defaultFontSize;
     private Color fontColor = defaultFontColor;
     // fill
     private boolean fillType = false;
@@ -585,11 +584,11 @@ public class FreeTextAnnotation extends MarkupAnnotation {
         this.fontStyle = fontStyle;
     }
 
-    public int getFontSize() {
+    public float getFontSize() {
         return fontSize;
     }
 
-    public void setFontSize(int fontSize) {
+    public void setFontSize(float fontSize) {
         this.fontSize = fontSize;
         fontPropertyChanged = true;
     }
@@ -645,9 +644,9 @@ public class FreeTextAnnotation extends MarkupAnnotation {
                     }
                 } else if (cssProperty != null && cssProperty.contains("font-size")) {
                     String fontSize = cssProperty.substring(cssProperty.indexOf(":") + 1).trim();
-                    fontSize = fontSize.replaceFirst(".*?(\\d+).*", "$1");
+                    fontSize = fontSize.replaceFirst(".*?(\\d+(?:\\.\\d+)?).*", "$1");
                     try {
-                        this.fontSize = (int) Float.parseFloat(fontSize);
+                        this.fontSize = Float.parseFloat(fontSize);
                     } catch (NumberFormatException e) {
                         logger.finer("Error parsing font size: " + fontSize);
                     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/utils/ContentWriterUtils.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/annotations/utils/ContentWriterUtils.java
@@ -94,7 +94,7 @@ public class ContentWriterUtils {
                                                        final float advanceX,
                                                        final float advanceY,
                                                        Shapes shapes,
-                                                       int fontSize,
+                                                       float fontSize,
                                                        float lineSpacing,
                                                        Color fontColor,
                                                        String content) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TextSprite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TextSprite.java
@@ -69,7 +69,7 @@ public class TextSprite {
     private FontFile font;
     // font's resource name and size, used by PS writer.
     private String fontName;
-    private int fontSize;
+    private float fontSize;
 
     private static final String TYPE_3 = "Type3";
 
@@ -294,11 +294,11 @@ public class TextSprite {
         this.fontName = fontName;
     }
 
-    public int getFontSize() {
+    public float getFontSize() {
         return fontSize;
     }
 
-    public void setFontSize(int fontSize) {
+    public void setFontSize(float fontSize) {
         this.fontSize = fontSize;
     }
 

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/FreeTextAnnotationHandler.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/tools/FreeTextAnnotationHandler.java
@@ -180,8 +180,8 @@ public class FreeTextAnnotationHandler extends SelectionBoxHandler
         String fontName = preferences.get(ViewerPropertiesManager.PROPERTY_ANNOTATION_FREE_TEXT_FONT, "Helvetica");
         annotation.setFontName(fontName);
         // apply font size
-        int fontSize = preferences.getInt(ViewerPropertiesManager.PROPERTY_ANNOTATION_FREE_TEXT_SIZE, FreeTextAnnotation.defaultFontSize);
-        annotation.setFontSize(fontSize);
+        float floatFontSize = preferences.getFloat(ViewerPropertiesManager.PROPERTY_ANNOTATION_FREE_TEXT_SIZE, FreeTextAnnotation.defaultFontSize);
+        annotation.setFontSize(floatFontSize);
         // opacity
         int opacity = preferences.getInt(ViewerPropertiesManager.PROPERTY_ANNOTATION_FREE_TEXT_OPACITY, 255);
         annotation.setOpacity(opacity);

--- a/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/properties/FreeTextAnnotationPanel.java
+++ b/viewer/viewer-awt/src/main/java/org/icepdf/ri/common/utility/annotation/properties/FreeTextAnnotationPanel.java
@@ -126,7 +126,7 @@ public class FreeTextAnnotationPanel extends AnnotationPanelAdapter implements I
 
         // font comps
         applySelectedValue(fontNameBox, freeTextAnnotation.getFontName());
-        applySelectedValue(fontSizeBox, freeTextAnnotation.getFontSize());
+        applySelectedValue(fontSizeBox, (int) freeTextAnnotation.getFontSize());
         setButtonBackgroundColor(fontColorButton, freeTextAnnotation.getFontColor());
 
         // border comps.
@@ -176,8 +176,8 @@ public class FreeTextAnnotationPanel extends AnnotationPanelAdapter implements I
                 freeTextAnnotation.setFontName((String) item.getValue());
                 preferences.put(ViewerPropertiesManager.PROPERTY_ANNOTATION_FREE_TEXT_FONT, freeTextAnnotation.getFontName());
             } else if (e.getSource() == fontSizeBox) {
-                freeTextAnnotation.setFontSize((Integer) item.getValue());
-                preferences.putInt(ViewerPropertiesManager.PROPERTY_ANNOTATION_FREE_TEXT_SIZE, freeTextAnnotation.getFontSize());
+                freeTextAnnotation.setFontSize((float) (Integer) item.getValue());
+                preferences.putInt(ViewerPropertiesManager.PROPERTY_ANNOTATION_FREE_TEXT_SIZE, Math.round(freeTextAnnotation.getFontSize()));
             } else if (e.getSource() == strokeTypeBox) {
                 Boolean visible = (Boolean) item.getValue();
                 freeTextAnnotation.setStrokeType(visible);


### PR DESCRIPTION
parsing of cssProperty font-size with numeric-only value causes StringIndexOutOfBoundsException