### PR TITLE
GH-497 qa stack traces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 # Gradle build output (exclude)
 /.gradle/
 /build/
+**/build/
 **/target/
+
+# Test output (exclude)
+**/src/test/out/
 
 # IDE files (exclude)
 /.idea/

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontTrueType.java
@@ -261,7 +261,7 @@ public class ZFontTrueType extends ZSimpleFont {
         try {
             if (cmapWinSymbol == null) {
                 if (encoding == null) {
-                    return cmapMacRoman.getGlyphId(code);
+                    return cmapMacRoman != null ? cmapMacRoman.getGlyphId(code) : 0;
                 }
                 String name = encoding.getName(code);
                 // this is slow,  would like to improve.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
@@ -153,7 +153,10 @@ public class ZFontType2 extends ZSimpleFont { //extends ZFontTrueType {
                 g.draw(outline);
             }
             g.setTransform(af);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
+            // RuntimeException covers fontbox throwing for unsupported tables
+            // (e.g. "OTF fonts do not have a glyf table"); skip the glyph rather
+            // than abort the whole text run / page.
             logger.log(Level.FINE, "Error painting FontType2 font", e);
         }
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
@@ -130,7 +130,8 @@ public class ZFontType2 extends ZSimpleFont { //extends ZFontTrueType {
         try {
             AffineTransform af = g.getTransform();
             int gid = getCharToGid(estr);
-            GlyphData glyphData = trueTypeFont.getGlyph().getGlyph(gid);
+            GlyphData glyphData = trueTypeFont.getGlyph() != null
+                    ? trueTypeFont.getGlyph().getGlyph(gid) : null;
             Shape outline;
             if (glyphData == null) {
                 outline = new GeneralPath();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_4.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_4.java
@@ -51,6 +51,11 @@ public class Function_4 extends Function {
     // cache for calculated colour values
     private final ConcurrentHashMap<Integer, float[]> resultCache;
 
+    // a malformed type 4 program fails deterministically on every sample of a
+    // shading; only log the parse failure once per function rather than once
+    // per colour lookup.
+    private volatile boolean evaluationFailureLogged = false;
+
     public Function_4(Dictionary d) {
         super(d);
         // decode the stream for parsing.
@@ -92,7 +97,10 @@ public class Function_4 extends Function {
         try {
             lex.parse(x);
         } catch (Exception e) {
-            logger.log(Level.WARNING, "Error Processing Type 4 definition", e);
+            if (!evaluationFailureLogged) {
+                evaluationFailureLogged = true;
+                logger.log(Level.WARNING, "Error Processing Type 4 definition", e);
+            }
         }
 
         // get the remaining numbers on the stack which are the return values.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_4.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/functions/Function_4.java
@@ -95,7 +95,7 @@ public class Function_4 extends Function {
             logger.log(Level.WARNING, "Error Processing Type 4 definition", e);
         }
 
-        // get the remaining number on the stack which are the return values.
+        // get the remaining numbers on the stack which are the return values.
         Stack stack = lex.getStack();
 
         // length of output array
@@ -103,10 +103,24 @@ public class Function_4 extends Function {
         // ready output array
         float[] y = new float[n];
 
-        // pop remaining items off the stack and apply the range bounds.
+        // The n output values are the top-most n items left on the stack.  If
+        // evaluation failed or underflowed the stack may hold fewer than n
+        // items; fall back to the lower range bound rather than throwing and
+        // aborting the entire shading.
+        int available = stack.size();
+        if (available < n) {
+            for (int i = 0; i < n; i++) {
+                y[i] = range[2 * i];
+            }
+            return y;
+        }
+        // read the top n items (a well-behaved function leaves exactly n), and
+        // clamp each to its range; tolerate non-Float numbers defensively.
+        int base = available - n;
         for (int i = 0; i < n; i++) {
-            y[i] = Math.min(Math.max((Float) stack.elementAt(i),
-                    range[2 * i]), range[2 * i + 1]);
+            Object value = stack.elementAt(base + i);
+            float f = value instanceof Number ? ((Number) value).floatValue() : range[2 * i];
+            y[i] = Math.min(Math.max(f, range[2 * i]), range[2 * i + 1]);
         }
         // add the new value to the cache.
         resultCache.put(colourKey, y);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/AbstractImageDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/AbstractImageDecoder.java
@@ -19,6 +19,8 @@ import com.twelvemonkeys.image.AffineTransformOp;
 import org.icepdf.core.pobjects.graphics.GraphicsState;
 import org.icepdf.core.util.Defs;
 
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
 import java.awt.image.WritableRaster;
@@ -70,7 +72,13 @@ public abstract class AbstractImageDecoder implements ImageDecoder {
      * @return true if the image is really, really, really big.
      */
     boolean isImageReallyBig(WritableRaster raster) {
-        return raster.getWidth() > maxImageWidth && raster.getHeight() > maxImageHeight;
+        return isImageReallyBig(raster.getWidth(), raster.getHeight());
+    }
+
+    boolean isImageReallyBig(int width, int height) {
+        // either dimension being absurd is enough to pop the heap once the image
+        // is expanded/transformed for painting, so guard on OR not AND.
+        return width > maxImageWidth || height > maxImageHeight;
     }
 
     /**
@@ -86,5 +94,34 @@ public abstract class AbstractImageDecoder implements ImageDecoder {
         at.scale(scale, scale);
         AffineTransformOp scaleOp = new AffineTransformOp(at, AffineTransformOp.TYPE_BILINEAR);
         return scaleOp.filter(raster, null);
+    }
+
+    /**
+     * Scales an already-decoded image whose dimensions exceed the configured
+     * maximums down to {@link #preferredSize} on its longest edge.  Used by
+     * decoders that produce a BufferedImage rather than a raw raster, so that a
+     * very large image (e.g. a multi-thousand pixel CCITT fax) does not exhaust
+     * the heap when Java2D later expands and transforms it for painting.
+     *
+     * @param image decoded image to bound.
+     * @return a scaled copy, or the original image when no scaling is needed.
+     */
+    BufferedImage scaleReallyBigImage(BufferedImage image) {
+        double scale = Math.min(preferredSize / (double) image.getWidth(),
+                preferredSize / (double) image.getHeight());
+        if (scale >= 1.0) {
+            return image;
+        }
+        int width = (int) Math.ceil(image.getWidth() * scale);
+        int height = (int) Math.ceil(image.getHeight() * scale);
+        BufferedImage scaled = ImageUtility.hasAlpha(image)
+                ? ImageUtility.createTranslucentCompatibleImage(width, height)
+                : ImageUtility.createCompatibleImage(width, height);
+        Graphics2D g = scaled.createGraphics();
+        g.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+        g.drawImage(image, 0, 0, width, height, null);
+        g.dispose();
+        image.flush();
+        return scaled;
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/FaxDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/FaxDecoder.java
@@ -113,6 +113,11 @@ public class FaxDecoder extends AbstractImageDecoder {
                         imageStream.getEntries(), graphicsState.getFillColor());
             }
         }
+        // bound ludicrously large fax images before they reach Java2D, where the
+        // transformed paint would otherwise pop the heap.
+        if (decodedImage != null && isImageReallyBig(decodedImage.getWidth(), decodedImage.getHeight())) {
+            decodedImage = scaleReallyBigImage(decodedImage);
+        }
         return decodedImage;
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
@@ -657,7 +657,11 @@ public class ImageUtility {
      * @return resultant image.
      */
     public static BufferedImage applyExplicitSMask(BufferedImage baseImage, BufferedImage sMaskImage) {
-
+        // if either image failed to decode there is nothing to composite; return
+        // whatever base we have rather than NPE inside the scaling step.
+        if (baseImage == null || sMaskImage == null) {
+            return baseImage;
+        }
         // check to make sure the mask and the image are the same size.
         BufferedImage[] images = scaleImagesToSameSize(baseImage, sMaskImage);
         baseImage = images[0];
@@ -880,6 +884,9 @@ public class ImageUtility {
     }
 
     static BufferedImage applyGrayDecode(BufferedImage rgbImage, ImageParams imageParams) {
+        if (rgbImage == null) {
+            return null;
+        }
         WritableRaster wr = rgbImage.getRaster();
         int[] cmap = null;
         int bitsPerComponent = imageParams.getBitsPerComponent();
@@ -891,6 +898,10 @@ public class ImageUtility {
             cmap = GRAY_2_BIT_INDEX_TO_RGB;
         } else if (bitsPerComponent == 4) {
             cmap = GRAY_4_BIT_INDEX_TO_RGB;
+        }
+        if (cmap == null) {
+            // unsupported bits-per-component, leave the image unchanged.
+            return rgbImage;
         }
         ColorModel cm = new IndexColorModel(bitsPerComponent, cmap.length, cmap, 0, false, -1,
                 wr.getDataBuffer().getDataType());

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JBig2Decoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JBig2Decoder.java
@@ -84,8 +84,9 @@ public class JBig2Decoder extends AbstractImageDecoder {
             }
         }
 
-        // apply decode
-        if (imageStream.getColourSpace() instanceof DeviceGray) {
+        // apply decode (tmpImage is null when the optional JBIG2 library is
+        // absent or decoding failed, in which case there is nothing to decode)
+        if (tmpImage != null && imageStream.getColourSpace() instanceof DeviceGray) {
             tmpImage = ImageUtility.applyGrayDecode(tmpImage, imageParams);
         }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JBig2Decoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/JBig2Decoder.java
@@ -29,6 +29,9 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -44,6 +47,10 @@ public class JBig2Decoder extends AbstractImageDecoder {
 
     private static final Name JBIG2_GLOBALS_KEY = new Name("JBIG2Globals");
     private static final Name DECODE_PARMS_KEY = new Name("DecodeParms");
+
+    // the JBIG2 library is optional; only warn about it being absent once per
+    // JVM rather than for every JBIG2 image encountered.
+    private static final AtomicBoolean jbig2LibraryMissingLogged = new AtomicBoolean(false);
 
     public JBig2Decoder(ImageStream imageStream, GraphicsState graphicsState) {
         super(imageStream, graphicsState);
@@ -70,9 +77,19 @@ public class JBig2Decoder extends AbstractImageDecoder {
             byte[] data = imageStream.getDecodedStreamBytes(imageParams.getDataLength());
             imageInputStream = ImageIO.createImageInputStream(new ByteArrayInputStream(data));
             tmpImage = decodeJbig2(decodeParams, globalsStream, imageInputStream, JBIG2_PDF_BOX);
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+            // the optional library isn't reachable from the class loader that
+            // loaded this class; warn once with enough detail to diagnose it.
+            if (jbig2LibraryMissingLogged.compareAndSet(false, true)) {
+                logger.log(Level.WARNING, "Optional Apache PDFBox JBIG2 library (" + JBIG2_PDF_BOX[0]
+                        + ") was not found on the class path of " + describeClassLoader()
+                        + "; JBIG2 images will not be decoded.");
+                logger.log(Level.FINE, "JBIG2 library class load failure", e);
+            }
         } catch (IOException | InstantiationException | InvocationTargetException | NoSuchMethodException |
-                IllegalAccessException | ClassNotFoundException e) {
-            logger.log(Level.WARNING, "Could not find Apache JBIG2 library on class path.");
+                IllegalAccessException e) {
+            // the library is present but failed to decode this particular image.
+            logger.log(Level.WARNING, "Error decoding JBIG2 image with the Apache PDFBox JBIG2 library.", e);
         } finally {
             // dispose the stream
             if (imageInputStream != null) {
@@ -149,5 +166,21 @@ public class JBig2Decoder extends AbstractImageDecoder {
         Method dispose = jbig2ImageReaderClass.getMethod("dispose");
         dispose.invoke(jbig2Reader);
         return tmpImage;
+    }
+
+    /**
+     * Describes the class loader that loaded this class, including its URLs when
+     * it is a {@link URLClassLoader}. The reflective JBIG2 load resolves against
+     * this loader, so surfacing its search path makes a missing optional jar
+     * (e.g. an isolated QA capture-set class path) diagnosable at a glance.
+     *
+     * @return human readable description of the loader and its class path.
+     */
+    private static String describeClassLoader() {
+        ClassLoader classLoader = JBig2Decoder.class.getClassLoader();
+        if (classLoader instanceof URLClassLoader) {
+            return classLoader + " " + Arrays.toString(((URLClassLoader) classLoader).getURLs());
+        }
+        return String.valueOf(classLoader);
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReference.java
@@ -87,6 +87,17 @@ public abstract class ImageReference implements Callable<BufferedImage> {
         if (image != null) {
             try {
                 aG.drawImage(image, aX, aY, aW, aH, null);
+            } catch (OutOfMemoryError e) {
+                // Java2D sizes the destination raster to the transformed image
+                // bounds, so re-scaling the source cannot shrink it (and a
+                // redraw would just OOM again). Skip this image and let the rest
+                // of the page render rather than aborting the whole capture.
+                logger.warning("Out of memory painting image, skipping " +
+                        imageStream.getPObjectReference() +
+                        " (" + imageStream.getImageParams().getWidth() + "x" +
+                        imageStream.getImageParams().getHeight() + ")");
+                image.flush();
+                this.image = null;
             } catch (Exception e) {
                 logger.warning("There was a problem painting image, falling back to scaled instance " +
                         imageStream.getPObjectReference() +

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
@@ -812,8 +812,16 @@ public abstract class AbstractContentParser {
     }
 
     protected static void consume_Tf(GraphicsState graphicState, Stack<Object> stack, Resources resources) {
-        float size = ((Number) stack.pop()).floatValue();
-        Name name2 = (Name) stack.pop();
+        // Tf expects "/FontName size Tf" with the size on top of the stack.
+        // Malformed streams can supply non-numeric operands or too few of them;
+        // guard so a single bad Tf doesn't abort the whole text block.
+        Object sizeObj = stack.isEmpty() ? null : stack.pop();
+        Object nameObj = stack.isEmpty() ? null : stack.pop();
+        if (!(sizeObj instanceof Number) || !(nameObj instanceof Name)) {
+            return;
+        }
+        float size = ((Number) sizeObj).floatValue();
+        Name name2 = (Name) nameObj;
         // build the new font and initialize it.
         graphicState.getTextState().tsize = size;
         graphicState.getTextState().fontName = name2;
@@ -852,9 +860,9 @@ public abstract class AbstractContentParser {
         }
         if (graphicState.getTextState().font != null) {
             FontFile font = graphicState.getTextState().font.getFont();
-            font.deriveFont(size);
-            graphicState.getTextState().currentfont =
-                    graphicState.getTextState().font.getFont().deriveFont(size);
+            if (font != null) {
+                graphicState.getTextState().currentfont = font.deriveFont(size);
+            }
         } else {
             // not font found which is a problem,  so we need to check for interactive form dictionary
             graphicState.getTextState().font = resources.getLibrary().getInteractiveFormFont(name2.getName());
@@ -1088,15 +1096,30 @@ public abstract class AbstractContentParser {
         return null;
     }
 
+    /**
+     * Pops the top operand as a float, returning 0 when the stack is empty or
+     * the operand is not numeric. Malformed content streams can leave Name or
+     * String operands where a number is expected.
+     */
+    private static float popFloat(Stack<Object> stack) {
+        Object o = stack.isEmpty() ? null : stack.pop();
+        return o instanceof Number ? ((Number) o).floatValue() : 0f;
+    }
+
     protected static GeneralPath consume_re(Stack<Object> stack,
                                             GeneralPath geometricPath) {
         if (geometricPath == null) {
             geometricPath = new GeneralPath();
         }
-        float h = ((Number) stack.pop()).floatValue();
-        float w = ((Number) stack.pop()).floatValue();
-        float y = ((Number) stack.pop()).floatValue();
-        float x = ((Number) stack.pop()).floatValue();
+        // re expects four numbers; malformed streams can supply too few or
+        // non-numeric operands, so pop defensively rather than abort the stream.
+        if (stack.size() < 4) {
+            return geometricPath;
+        }
+        float h = popFloat(stack);
+        float w = popFloat(stack);
+        float y = popFloat(stack);
+        float x = popFloat(stack);
         geometricPath.moveTo(x, y);
         geometricPath.lineTo(x + w, y);
         geometricPath.lineTo(x + w, y + h);

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
@@ -1455,7 +1455,10 @@ public abstract class AbstractContentParser {
                 // apply transparency
                 setAlpha(shapes, graphicState, AlphaPaintType.ALPHA_FILL);
                 // draw string will take care of text pageText construction
-                if (stringObject.getLength() > 0) {
+                // (skip when no usable font is in the text state, e.g. a Tj
+                // before a valid Tf or an unresolved font resource).
+                if (stringObject.getLength() > 0 && textState.font != null
+                        && textState.font.getFont() != null) {
                     TextSprite textSprite = drawString(stringObject.getLiteralStringBuffer(
                                     textState.font.getSubTypeFormat(),
                                     textState.font.getFont()),

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/Operands.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/Operands.java
@@ -297,7 +297,7 @@ public class Operands {
             case 'E':
                 if (length == 3) {
                     return new int[]{EMC, 0};
-                } else {
+                } else if (length >= 2) {
                     c1 = ch[offset + 1];
                     offset = 0;
                     switch (c1) {
@@ -323,6 +323,10 @@ public class Operands {
                             return new int[]{EMC, offset};
                     }
                 }
+                // lone 'E' or unrecognized E-operator: fall through to the
+                // unknown-operator (OP) result rather than read past the token
+                // or misclassify it as the following 'i' case.
+                break;
             case 'i':
                 offset = 0;
                 if (length > 1) {

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/config/ConfigSerializer.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/config/ConfigSerializer.java
@@ -40,6 +40,9 @@ public class ConfigSerializer {
     static {
         mapper.enable(SerializationFeature.WRITE_ENUMS_USING_TO_STRING);
         mapper.enable(DeserializationFeature.READ_ENUMS_USING_TO_STRING);
+        // tolerate config files written by other builds that carry extra
+        // fields (e.g. an older/newer Result schema) rather than failing to load.
+        mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 
     public static Path save(Object object) {


### PR DESCRIPTION
I have  a very large test set of PDF documents that I've collected over the last 25 years ish of debugging the library.   I used an agent to work though the stack traces to fine easy fixes and guards.  

One to minimize log noise and two to find and issues that might be muddling up rendering.   A few valid issue were found, mainly around handing large images. 