### PR TITLE
GH-496 statistical image diff with fuzz tolerance, ink-weighting and SSIM

### DIFF
--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/config/Result.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/config/Result.java
@@ -36,8 +36,12 @@ public class Result {
     private final SimpleStringProperty captureNameA;
     private final SimpleStringProperty captureNameB;
 
-    // percent difference between captureOne and captureTwo
+    // headline similarity (%) between captureOne and captureTwo; ink-weighted so missing content scores low.
     private final SimpleDoubleProperty difference;
+    // fuzz-tolerant absolute-error similarity (%) over the whole page.
+    private final SimpleDoubleProperty aeSimilarity;
+    // mean windowed structural similarity (%).
+    private final SimpleDoubleProperty structuralSimilarity;
 
     // can be extended for other properties.
 
@@ -45,13 +49,25 @@ public class Result {
     public Result(@JsonProperty("documentName") String documentName,
                   @JsonProperty("fileNameA") String fileNameA,
                   @JsonProperty("fileName") String fileNameB,
-                  @JsonProperty("difference") double difference) {
+                  @JsonProperty("difference") double difference,
+                  @JsonProperty("aeSimilarity") double aeSimilarity,
+                  @JsonProperty("structuralSimilarity") double structuralSimilarity) {
         // relative path to content set location
         this.documentName = new SimpleStringProperty(documentName);
         // relative path to capture set location
         this.captureNameA = new SimpleStringProperty(fileNameA);
         this.captureNameB = new SimpleStringProperty(fileNameB);
         this.difference = new SimpleDoubleProperty(difference);
+        this.aeSimilarity = new SimpleDoubleProperty(aeSimilarity);
+        this.structuralSimilarity = new SimpleDoubleProperty(structuralSimilarity);
+    }
+
+    /**
+     * Backward-compatible constructor for callers that only have a single
+     * similarity score (e.g. the text compare task or older saved projects).
+     */
+    public Result(String documentName, String fileNameA, String fileNameB, double difference) {
+        this(documentName, fileNameA, fileNameB, difference, difference, difference);
     }
 
     public String getDocumentName() {
@@ -94,5 +110,21 @@ public class Result {
 
     public void setDifference(double difference) {
         this.difference.set(difference);
+    }
+
+    public double getAeSimilarity() {
+        return Math.round(aeSimilarity.get() * 100.0) / 100.0;
+    }
+
+    public void setAeSimilarity(double aeSimilarity) {
+        this.aeSimilarity.set(aeSimilarity);
+    }
+
+    public double getStructuralSimilarity() {
+        return Math.round(structuralSimilarity.get() * 100.0) / 100.0;
+    }
+
+    public void setStructuralSimilarity(double structuralSimilarity) {
+        this.structuralSimilarity.set(structuralSimilarity);
     }
 }

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/tests/ImageCompareTask.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/tests/ImageCompareTask.java
@@ -16,11 +16,11 @@
 package org.icepdf.qa.tests;
 
 import javafx.application.Platform;
-import javafx.scene.image.PixelFormat;
-import javafx.scene.image.PixelReader;
 import org.icepdf.qa.config.*;
 import org.icepdf.qa.tests.exceptions.ConfigurationException;
 import org.icepdf.qa.tests.exceptions.ValidationException;
+import org.icepdf.qa.utilities.CompareMetrics;
+import org.icepdf.qa.utilities.ImageCompare;
 import org.icepdf.qa.utilities.TimeTestWatcher;
 import org.icepdf.qa.viewer.common.Mediator;
 import org.icepdf.qa.viewer.common.PreferencesController;
@@ -51,7 +51,7 @@ import java.util.concurrent.Executors;
  */
 public class ImageCompareTask extends AbstractTestTask {
 
-    private static final int THREAD_EXECUTOR_SIZE = 8;
+    private static final int THREAD_EXECUTOR_SIZE = 4;
 
     // page capture test
     public static final String PAGE_CAPTURE_CLASS = "org.icepdf.ri.util.qa.PageCapture";
@@ -462,21 +462,31 @@ public class ImageCompareTask extends AbstractTestTask {
                         captureSets[1].getCaptureSetPath().getFileName().toString(),
                         fileName.getFileName() + "_" + pageNumber + ".png");
 
-                FileInputStream imageCaptureAFileStream = new FileInputStream(imageCaptureA.toFile());
-                FileInputStream imageCaptureBFileStream = new FileInputStream(imageCaptureB.toFile());
+                // A document may have fewer pages than commonPageCount, in which
+                // case the capture for this page was never written. Skip quietly,
+                // matching the original FileInputStream behaviour.
+                if (!Files.exists(imageCaptureA) || !Files.exists(imageCaptureB)) {
+                    return null;
+                }
 
-                javafx.scene.image.Image imageA = new javafx.scene.image.Image(imageCaptureAFileStream);
-                javafx.scene.image.Image imageB = new javafx.scene.image.Image(imageCaptureBFileStream);
+                BufferedImage imageA = ImageIO.read(imageCaptureA.toFile());
+                BufferedImage imageB = ImageIO.read(imageCaptureB.toFile());
+                if (imageA == null || imageB == null) {
+                    return null;
+                }
 
-                double diff = percentageCompare(imageA, imageB);
-
-                imageCaptureAFileStream.close();
-                imageCaptureBFileStream.close();
+                CompareMetrics metrics = ImageCompare.compare(imageA, imageB,
+                        PreferencesController.getImageCompareFuzz());
+                imageA.flush();
+                imageB.flush();
 
                 return new Result(
                         fileName.toString(),
                         imageCaptureA.toString(),
-                        imageCaptureB.toString(), diff);
+                        imageCaptureB.toString(),
+                        metrics.getInkSimilarity(),
+                        metrics.getAeSimilarity(),
+                        metrics.getStructuralSimilarity());
 
             } catch (FileNotFoundException e) {
                 // silently move on if the page wasn't created.
@@ -527,36 +537,5 @@ public class ImageCompareTask extends AbstractTestTask {
             return null;
         }
     }
-
-    private static double percentageCompare(javafx.scene.image.Image image1, javafx.scene.image.Image image2) {
-
-        assert (image1.getWidth() == image2.getWidth() && image2.getHeight() == image2.getHeight());
-
-        PixelReader pixelReader1 = image1.getPixelReader();
-        PixelReader pixelReader2 = image2.getPixelReader();
-
-        int width = (int) image1.getWidth();
-        int height = (int) image1.getHeight();
-
-        int[] buffer1 = new int[width];
-        int[] buffer2 = new int[width];
-
-        int badPixels = 0;
-        for (int y = 0; y < height; y++) {
-            pixelReader1.getPixels(0, y, width, 1, PixelFormat.getIntArgbInstance(), buffer1, 0, 1);
-            pixelReader2.getPixels(0, y, width, 1, PixelFormat.getIntArgbInstance(), buffer2, 0, 1);
-            for (int x = 0; x < width; x++) {
-                if (buffer1[x] != buffer2[x]) {
-                    badPixels++;
-                }
-            }
-        }
-
-        int totalPixels = width * height;
-        int goodPixels = totalPixels - badPixels;
-
-        return 100d * goodPixels / totalPixels;
-    }
-
 
 }

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/utilities/CompareMetrics.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/utilities/CompareMetrics.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Patrick Corless
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.icepdf.qa.utilities;
+
+/**
+ * Immutable bag of similarity scores produced by {@link ImageCompare}.  All
+ * scores are expressed as a percentage in the range [0, 100] where 100 means
+ * the two images are identical.  Higher is more similar, matching the existing
+ * {@code Result.difference} semantics used throughout the qa harness.
+ *
+ * <ul>
+ *     <li>{@link #aeSimilarity} – fuzz-tolerant absolute-error over the whole
+ *     page.  This is the classic metric (differing pixels / total pixels) but
+ *     with a colour tolerance so sub-pixel anti-aliasing noise no longer
+ *     counts.  It is still diluted by the large white background.</li>
+ *     <li>{@link #inkSimilarity} – the same differing-pixel count, but measured
+ *     against the union of "ink" (non-background) pixels rather than the whole
+ *     page.  Missing content now shows up as a large fraction of the
+ *     <em>content</em> instead of a tiny fraction of a mostly-white page, which
+ *     is the headline regression number.</li>
+ *     <li>{@link #structuralSimilarity} – mean windowed SSIM on luminance.  A
+ *     local, perceptual measure that drops sharply where structure (text,
+ *     lines) is lost even when that region is a small share of the page.</li>
+ * </ul>
+ */
+public class CompareMetrics {
+
+    private final double aeSimilarity;
+    private final double inkSimilarity;
+    private final double structuralSimilarity;
+
+    private final int totalPixels;
+    private final int unionInkPixels;
+    private final int diffPixels;
+    private final int diffInkPixels;
+
+    public CompareMetrics(double aeSimilarity, double inkSimilarity, double structuralSimilarity,
+                          int totalPixels, int unionInkPixels, int diffPixels, int diffInkPixels) {
+        this.aeSimilarity = aeSimilarity;
+        this.inkSimilarity = inkSimilarity;
+        this.structuralSimilarity = structuralSimilarity;
+        this.totalPixels = totalPixels;
+        this.unionInkPixels = unionInkPixels;
+        this.diffPixels = diffPixels;
+        this.diffInkPixels = diffInkPixels;
+    }
+
+    public double getAeSimilarity() {
+        return aeSimilarity;
+    }
+
+    public double getInkSimilarity() {
+        return inkSimilarity;
+    }
+
+    public double getStructuralSimilarity() {
+        return structuralSimilarity;
+    }
+
+    public int getTotalPixels() {
+        return totalPixels;
+    }
+
+    public int getUnionInkPixels() {
+        return unionInkPixels;
+    }
+
+    public int getDiffPixels() {
+        return diffPixels;
+    }
+
+    public int getDiffInkPixels() {
+        return diffInkPixels;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ink %.2f%%  ae %.2f%%  ssim %.2f%%  (%d/%d ink px differ)",
+                inkSimilarity, aeSimilarity, structuralSimilarity, diffInkPixels, unionInkPixels);
+    }
+}

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/utilities/ImageCompare.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/utilities/ImageCompare.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 Patrick Corless
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.icepdf.qa.utilities;
+
+import java.awt.image.BufferedImage;
+
+/**
+ * Pure (no JavaFX) image comparison engine shared by the batch
+ * {@code ImageCompareTask} and the interactive compare pane.  Because the
+ * batch score and the on-screen diff mask are produced by the exact same code
+ * path, the number recorded in the results table and the highlight the user
+ * sees behind the fuzz slider can never disagree.
+ * <p>
+ * Two design choices address the "mostly-white page" blind spot of a naive
+ * pixel-equality count:
+ * <ol>
+ *     <li><b>Fuzz tolerance</b> – two pixels are considered equal when no
+ *     colour channel differs by more than {@code fuzz} (0-255).  This discards
+ *     the 1-LSB anti-aliasing noise along glyph edges that a different
+ *     rasteriser produces but a human cannot see.</li>
+ *     <li><b>Ink weighting</b> – differences are also measured against the
+ *     union of non-background pixels, so a dropped paragraph scores as a large
+ *     fraction of the content rather than a tiny fraction of the page.</li>
+ * </ol>
+ */
+public final class ImageCompare {
+
+    /** Per-channel colour tolerance (0-255). A pixel pair within this distance is "equal". */
+    public static final int DEFAULT_FUZZ = 8;
+
+    /**
+     * Luminance at or above this value (0-255) is treated as background and
+     * ignored by the ink-weighted metric. 250 keeps faint anti-aliased greys
+     * as ink while discarding pure/near white paper.
+     */
+    public static final int BACKGROUND_LUMINANCE = 250;
+
+    // SSIM stabilisation constants for an 8-bit dynamic range (L = 255).
+    private static final double C1 = (0.01 * 255) * (0.01 * 255);
+    private static final double C2 = (0.03 * 255) * (0.03 * 255);
+    private static final int SSIM_WINDOW = 8;
+
+    private ImageCompare() {
+    }
+
+    /**
+     * Compares two images and returns the full set of similarity scores.
+     *
+     * @param a    first image
+     * @param b    second image
+     * @param fuzz per-channel colour tolerance, 0-255 (see {@link #DEFAULT_FUZZ})
+     * @return populated metrics, never {@code null}
+     */
+    public static CompareMetrics compare(BufferedImage a, BufferedImage b, int fuzz) {
+        return compare(a, b, fuzz, structuralSimilarity(a, b));
+    }
+
+    /**
+     * Compares two images using a pre-computed structural similarity score.
+     * Only the fuzz-dependent metrics (AE, ink, diff mask counts) are
+     * recalculated here, so an interactive fuzz slider can re-score on every
+     * tick without repeating the comparatively expensive, fuzz-independent SSIM
+     * pass.
+     *
+     * @param a                        first image
+     * @param b                        second image
+     * @param fuzz                     per-channel colour tolerance, 0-255
+     * @param structuralSimilarityPercent SSIM (%) from {@link #structuralSimilarity}
+     * @return populated metrics, never {@code null}
+     */
+    public static CompareMetrics compare(BufferedImage a, BufferedImage b, int fuzz,
+                                         double structuralSimilarityPercent) {
+        // Use the union of the two canvases; any area present in one image but
+        // not the other is, by definition, a difference (and ink).
+        int width = Math.max(a.getWidth(), b.getWidth());
+        int height = Math.max(a.getHeight(), b.getHeight());
+
+        int diffPixels = 0;
+        int unionInkPixels = 0;
+        int diffInkPixels = 0;
+
+        int[] rowA = new int[width];
+        int[] rowB = new int[width];
+
+        for (int y = 0; y < height; y++) {
+            readRow(a, y, rowA);
+            readRow(b, y, rowB);
+            for (int x = 0; x < width; x++) {
+                int argbA = rowA[x];
+                int argbB = rowB[x];
+
+                boolean differ = !equalWithinFuzz(argbA, argbB, fuzz);
+                if (differ) {
+                    diffPixels++;
+                }
+
+                boolean ink = isInk(argbA) || isInk(argbB);
+                if (ink) {
+                    unionInkPixels++;
+                    if (differ) {
+                        diffInkPixels++;
+                    }
+                }
+            }
+        }
+
+        int totalPixels = width * height;
+        double aeSimilarity = totalPixels == 0
+                ? 100d : 100d * (totalPixels - diffPixels) / totalPixels;
+        double inkSimilarity = unionInkPixels == 0
+                ? 100d : 100d * (unionInkPixels - diffInkPixels) / unionInkPixels;
+
+        return new CompareMetrics(aeSimilarity, inkSimilarity, structuralSimilarityPercent,
+                totalPixels, unionInkPixels, diffPixels, diffInkPixels);
+    }
+
+    /**
+     * Mean windowed structural similarity, expressed as a percentage in
+     * [0, 100].  This is fuzz-independent, so callers driving an interactive
+     * fuzz slider can compute it once per image pair and feed it back into
+     * {@link #compare(BufferedImage, BufferedImage, int, double)}.
+     */
+    public static double structuralSimilarity(BufferedImage a, BufferedImage b) {
+        return meanSsim(a, b) * 100d;
+    }
+
+    /**
+     * Builds a transparent overlay the size of the union canvas with every
+     * differing pixel painted in {@code highlightArgb}.  Matching pixels are
+     * left fully transparent so the mask can be drawn over either source image.
+     * Used by the interactive fuzz slider.
+     *
+     * @param a             first image
+     * @param b             second image
+     * @param fuzz          per-channel colour tolerance, 0-255
+     * @param highlightArgb packed ARGB colour for differing pixels
+     * @return an ARGB overlay image
+     */
+    public static BufferedImage differenceMask(BufferedImage a, BufferedImage b, int fuzz, int highlightArgb) {
+        int width = Math.max(a.getWidth(), b.getWidth());
+        int height = Math.max(a.getHeight(), b.getHeight());
+        BufferedImage mask = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+
+        int[] rowA = new int[width];
+        int[] rowB = new int[width];
+        int[] rowOut = new int[width];
+
+        for (int y = 0; y < height; y++) {
+            readRow(a, y, rowA);
+            readRow(b, y, rowB);
+            for (int x = 0; x < width; x++) {
+                rowOut[x] = equalWithinFuzz(rowA[x], rowB[x], fuzz) ? 0 : highlightArgb;
+            }
+            mask.setRGB(0, y, width, 1, rowOut, 0, 1);
+        }
+        return mask;
+    }
+
+    /**
+     * Reads one row of ARGB pixels into {@code dest}, zero-filling any portion
+     * of the row that lies outside the image (so a smaller image reads as a
+     * transparent/background region rather than throwing).
+     */
+    private static void readRow(BufferedImage image, int y, int[] dest) {
+        int w = image.getWidth();
+        if (y < image.getHeight() && w > 0) {
+            image.getRGB(0, y, w, 1, dest, 0, w);
+        } else {
+            w = 0;
+        }
+        for (int x = w; x < dest.length; x++) {
+            dest[x] = 0;
+        }
+    }
+
+    /** True when no colour channel of the two packed ARGB pixels differs by more than {@code fuzz}. */
+    private static boolean equalWithinFuzz(int argbA, int argbB, int fuzz) {
+        if (argbA == argbB) {
+            return true;
+        }
+        // Flatten any transparency onto white so a transparent pixel and a
+        // white pixel are treated as the same background.
+        int a = flattenOntoWhite(argbA);
+        int b = flattenOntoWhite(argbB);
+        if (a == b) {
+            return true;
+        }
+        int dr = Math.abs(((a >> 16) & 0xff) - ((b >> 16) & 0xff));
+        int dg = Math.abs(((a >> 8) & 0xff) - ((b >> 8) & 0xff));
+        int db = Math.abs((a & 0xff) - (b & 0xff));
+        return dr <= fuzz && dg <= fuzz && db <= fuzz;
+    }
+
+    /** A pixel is "ink" when its luminance is below the background threshold. */
+    private static boolean isInk(int argb) {
+        return luminance(flattenOntoWhite(argb)) < BACKGROUND_LUMINANCE;
+    }
+
+    /** Rec. 601 luma of an opaque packed RGB pixel. */
+    private static int luminance(int rgb) {
+        int r = (rgb >> 16) & 0xff;
+        int g = (rgb >> 8) & 0xff;
+        int b = rgb & 0xff;
+        return (int) (0.299 * r + 0.587 * g + 0.114 * b);
+    }
+
+    /** Alpha-composite a packed ARGB pixel over an opaque white background. */
+    private static int flattenOntoWhite(int argb) {
+        int alpha = (argb >> 24) & 0xff;
+        if (alpha == 0xff) {
+            return argb & 0xffffff;
+        }
+        if (alpha == 0) {
+            return 0xffffff;
+        }
+        int r = (argb >> 16) & 0xff;
+        int g = (argb >> 8) & 0xff;
+        int b = argb & 0xff;
+        int inv = 255 - alpha;
+        r = (r * alpha + 255 * inv) / 255;
+        g = (g * alpha + 255 * inv) / 255;
+        b = (b * alpha + 255 * inv) / 255;
+        return (r << 16) | (g << 8) | b;
+    }
+
+    /**
+     * Mean SSIM over non-overlapping {@value #SSIM_WINDOW}x{@value #SSIM_WINDOW}
+     * luminance windows of the overlapping region.  Returns a value in [0, 1].
+     */
+    private static double meanSsim(BufferedImage a, BufferedImage b) {
+        int width = Math.min(a.getWidth(), b.getWidth());
+        int height = Math.min(a.getHeight(), b.getHeight());
+        if (width < SSIM_WINDOW || height < SSIM_WINDOW) {
+            return a.getWidth() == b.getWidth() && a.getHeight() == b.getHeight() ? 1d : 0d;
+        }
+        double[][] lumA = luminanceField(a, width, height);
+        double[][] lumB = luminanceField(b, width, height);
+
+        double ssimSum = 0;
+        int windows = 0;
+        for (int wy = 0; wy + SSIM_WINDOW <= height; wy += SSIM_WINDOW) {
+            for (int wx = 0; wx + SSIM_WINDOW <= width; wx += SSIM_WINDOW) {
+                ssimSum += windowSsim(lumA, lumB, wx, wy);
+                windows++;
+            }
+        }
+        return windows == 0 ? 1d : ssimSum / windows;
+    }
+
+    private static double windowSsim(double[][] a, double[][] b, int ox, int oy) {
+        int n = SSIM_WINDOW * SSIM_WINDOW;
+        double sumA = 0, sumB = 0;
+        for (int y = 0; y < SSIM_WINDOW; y++) {
+            for (int x = 0; x < SSIM_WINDOW; x++) {
+                sumA += a[oy + y][ox + x];
+                sumB += b[oy + y][ox + x];
+            }
+        }
+        double meanA = sumA / n;
+        double meanB = sumB / n;
+
+        double varA = 0, varB = 0, cov = 0;
+        for (int y = 0; y < SSIM_WINDOW; y++) {
+            for (int x = 0; x < SSIM_WINDOW; x++) {
+                double da = a[oy + y][ox + x] - meanA;
+                double db = b[oy + y][ox + x] - meanB;
+                varA += da * da;
+                varB += db * db;
+                cov += da * db;
+            }
+        }
+        varA /= (n - 1);
+        varB /= (n - 1);
+        cov /= (n - 1);
+
+        return ((2 * meanA * meanB + C1) * (2 * cov + C2))
+                / ((meanA * meanA + meanB * meanB + C1) * (varA + varB + C2));
+    }
+
+    private static double[][] luminanceField(BufferedImage image, int width, int height) {
+        double[][] lum = new double[height][width];
+        int[] row = new int[width];
+        for (int y = 0; y < height; y++) {
+            image.getRGB(0, y, width, 1, row, 0, width);
+            for (int x = 0; x < width; x++) {
+                lum[y][x] = luminance(flattenOntoWhite(row[x]));
+            }
+        }
+        return lum;
+    }
+}

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/common/PreferencesController.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/common/PreferencesController.java
@@ -44,6 +44,12 @@ public class PreferencesController {
     public static final String IMAGE_COMPARE_BLENDING_MODE_VALUE = ImageComparePane.DIFFERENCE_BLENDING_MODE;
     public static final String IMAGE_COMPARE_DIFF_ENABLED_KEY = "imageCompareDiffEnabled";
     public static final boolean IMAGE_COMPARE_DIFF_ENABLED_VALUE = true;
+    // per-channel colour tolerance (0-255) used by the compare engine and the interactive fuzz slider.
+    public static final String IMAGE_COMPARE_FUZZ_KEY = "imageCompareFuzz";
+    public static final int IMAGE_COMPARE_FUZZ_VALUE = org.icepdf.qa.utilities.ImageCompare.DEFAULT_FUZZ;
+    // ink-weighted similarity (%) at or below which a result is flagged as a regression in the results tab.
+    public static final String IMAGE_COMPARE_THRESHOLD_KEY = "imageCompareThreshold";
+    public static final double IMAGE_COMPARE_THRESHOLD_VALUE = 99.99d;
     public static final String LAST_CONTENT_SET_KEY = "contentSetBasePath";
     public static final String APPLICATION_HOME_PATH_KEY = "applicationHomePath";
 
@@ -116,6 +122,22 @@ public class PreferencesController {
 
     public static void saveLastUsedImageCompareDiffEnabled(boolean lastImageCompareName) {
         prefs.putBoolean(IMAGE_COMPARE_DIFF_ENABLED_KEY, lastImageCompareName);
+    }
+
+    public static int getImageCompareFuzz() {
+        return prefs.getInt(IMAGE_COMPARE_FUZZ_KEY, IMAGE_COMPARE_FUZZ_VALUE);
+    }
+
+    public static void saveImageCompareFuzz(int fuzz) {
+        prefs.putInt(IMAGE_COMPARE_FUZZ_KEY, fuzz);
+    }
+
+    public static double getImageCompareThreshold() {
+        return prefs.getDouble(IMAGE_COMPARE_THRESHOLD_KEY, IMAGE_COMPARE_THRESHOLD_VALUE);
+    }
+
+    public static void saveImageCompareThreshold(double threshold) {
+        prefs.putDouble(IMAGE_COMPARE_THRESHOLD_KEY, threshold);
     }
 
     public static void saveLastUsedContentSetPath(Path directoryPath) {

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/comparitors/ImageComparePane.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/comparitors/ImageComparePane.java
@@ -22,17 +22,24 @@ import javafx.scene.effect.BlendMode;
 import javafx.scene.effect.DropShadow;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.image.PixelFormat;
+import javafx.scene.image.WritableImage;
 import javafx.scene.input.ScrollEvent;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import org.icepdf.qa.config.Result;
+import org.icepdf.qa.utilities.CompareMetrics;
+import org.icepdf.qa.utilities.ImageCompare;
 import org.icepdf.qa.viewer.common.Mediator;
 import org.icepdf.qa.viewer.common.PreferencesController;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 
 /**
  * Image compare pane allows the easy identification of changed
@@ -46,6 +53,11 @@ public class ImageComparePane extends ComparatorPane {
     public static final String DIFFERENCE_BLENDING_MODE = "Difference";
     public static final String GREEN_BLENDING_MODE = "Green Subtraction";
     public static final String MULTIPLY_BLENDING_MODE = "Multiply";
+    // computed diff mask honouring the live fuzz slider; not a JavaFX BlendMode.
+    public static final String DIFF_MASK_MODE = "Diff Mask (fuzz)";
+
+    // semi-opaque red highlight for differing pixels in the computed mask.
+    private static final int MASK_HIGHLIGHT_ARGB = 0x90ff0000;
 
     // toggle value for enabling/disabling the compare effect.
     private boolean enableBlendingMode;
@@ -55,12 +67,23 @@ public class ImageComparePane extends ComparatorPane {
     private ImageView imageViewA2;
     private ImageView imageViewB1;
     private ImageView imageViewB2;
+    // computed difference-mask overlay (used by DIFF_MASK_MODE).
+    private ImageView maskView;
+
+    // source captures kept in awt form so the mask can be recomputed live as the fuzz slider moves.
+    private BufferedImage bufferedA;
+    private BufferedImage bufferedB;
+    // SSIM is fuzz-independent, so compute it once per opened result and reuse it across slider ticks.
+    private double cachedStructuralSimilarity;
 
     // view type,  side-by-side, blending mode etc.
     private ChoiceBox<String> viewTypesChoiceBox;
     // effects that can be applied to show differences.
     private ChoiceBox<String> blendingModeChoiceBox;
     private ToggleButton blendingToggleButton;
+    // live per-channel colour tolerance for the computed diff mask.
+    private Slider fuzzSlider;
+    private Label metricsLabel;
 
     private ScrollPane scrollPane;
 
@@ -71,6 +94,7 @@ public class ImageComparePane extends ComparatorPane {
             imageViewB1 = new ImageView();
             imageViewA2 = new ImageView();
             imageViewB2 = new ImageView();
+            maskView = new ImageView();
 
             ToolBar viewTools = new ToolBar();
             // view type
@@ -87,7 +111,7 @@ public class ImageComparePane extends ComparatorPane {
             Label modeLabel = new Label("Mode:");
             blendingModeChoiceBox = new ChoiceBox<>();
             blendingModeChoiceBox.getItems().addAll(
-                    DIFFERENCE_BLENDING_MODE, GREEN_BLENDING_MODE);//, MULTIPLY_BLENDING_MODE);
+                    DIFFERENCE_BLENDING_MODE, GREEN_BLENDING_MODE, DIFF_MASK_MODE);//, MULTIPLY_BLENDING_MODE);
             blendingModeChoiceBox.getSelectionModel().select(PreferencesController.getLastUsedImageCompareBlendingMode());
             blendingModeChoiceBox.getSelectionModel().selectedItemProperty().addListener((
                     observable, oldValue, newValue) -> {
@@ -99,7 +123,26 @@ public class ImageComparePane extends ComparatorPane {
             blendingToggleButton.setSelected(enableBlendingMode);
             blendingToggleButton.setOnAction(event -> enableBlendingMode());
 
-            viewTools.getItems().addAll(viewLabel, viewTypesChoiceBox, modeLabel, blendingModeChoiceBox, blendingToggleButton);
+            // Live fuzz tolerance for the computed diff mask. Dragging it re-runs
+            // the same compare engine the batch task uses and repaints the mask,
+            // so you can watch anti-aliasing noise drop out (and real content
+            // stay highlighted) as the tolerance rises.
+            Label fuzzLabel = new Label("Fuzz:");
+            fuzzSlider = new Slider(0, 64, PreferencesController.getImageCompareFuzz());
+            fuzzSlider.setShowTickMarks(true);
+            fuzzSlider.setMajorTickUnit(16);
+            fuzzSlider.setMinorTickCount(3);
+            fuzzSlider.setPrefWidth(160);
+            metricsLabel = new Label();
+            fuzzSlider.valueProperty().addListener((observable, oldValue, newValue) -> recomputeMask());
+            fuzzSlider.valueChangingProperty().addListener((observable, wasChanging, changing) -> {
+                if (!changing) {
+                    PreferencesController.saveImageCompareFuzz((int) Math.round(fuzzSlider.getValue()));
+                }
+            });
+
+            viewTools.getItems().addAll(viewLabel, viewTypesChoiceBox, modeLabel, blendingModeChoiceBox,
+                    blendingToggleButton, new Separator(), fuzzLabel, fuzzSlider, metricsLabel);
             setTop(new VBox(20, viewTools));
             scrollPane = new ScrollPane();
             setCenter(scrollPane);
@@ -166,7 +209,16 @@ public class ImageComparePane extends ComparatorPane {
                 imageViewB1.setImage(image2);
                 imageViewA2.setImage(image1);
                 imageViewB2.setImage(image2);
+                // keep an awt copy so the diff mask can be recomputed live.
+                bufferedA = ImageIO.read(file);
+                bufferedB = ImageIO.read(file2);
+                // SSIM doesn't depend on fuzz, so compute it once here rather than on every slider tick.
+                cachedStructuralSimilarity = (bufferedA != null && bufferedB != null)
+                        ? ImageCompare.structuralSimilarity(bufferedA, bufferedB) : 0d;
+                recomputeMask();
             } catch (FileNotFoundException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
                 e.printStackTrace();
             }
         } else {
@@ -174,7 +226,50 @@ public class ImageComparePane extends ComparatorPane {
             imageViewB1.setImage(null);
             imageViewA2.setImage(null);
             imageViewB2.setImage(null);
+            maskView.setImage(null);
+            bufferedA = null;
+            bufferedB = null;
+            metricsLabel.setText("");
         }
+    }
+
+    /**
+     * Re-runs the shared compare engine on the currently open pair at the slider's
+     * fuzz value, repaints the overlay, and updates the live metrics readout. Cheap
+     * enough to call on every slider tick for page-sized images.
+     */
+    private void recomputeMask() {
+        if (bufferedA == null || bufferedB == null) {
+            maskView.setImage(null);
+            if (metricsLabel != null) {
+                metricsLabel.setText("");
+            }
+            return;
+        }
+        int fuzz = (int) Math.round(fuzzSlider.getValue());
+        // Reuse the SSIM computed once in openResult; only the fuzz-dependent
+        // AE/ink metrics are recalculated as the slider moves.
+        CompareMetrics metrics = ImageCompare.compare(bufferedA, bufferedB, fuzz, cachedStructuralSimilarity);
+        metricsLabel.setText(String.format("ink %.2f%%  |  ae %.2f%%  |  ssim %.2f%%",
+                metrics.getInkSimilarity(), metrics.getAeSimilarity(), metrics.getStructuralSimilarity()));
+        if (DIFF_MASK_MODE.equals(blendingModeChoiceBox.getSelectionModel().getSelectedItem())) {
+            BufferedImage mask = ImageCompare.differenceMask(bufferedA, bufferedB, fuzz, MASK_HIGHLIGHT_ARGB);
+            // maskView is already in the displayed pane (built by refreshView when
+            // the mode is selected); swapping its image repaints in place. Do NOT
+            // rebuild the scene graph here - doing so on every slider tick drops the
+            // in-progress drag gesture.
+            maskView.setImage(toFxImage(mask));
+        }
+    }
+
+    /** Converts an ARGB {@link BufferedImage} to a JavaFX image without the javafx.swing module. */
+    private static Image toFxImage(BufferedImage source) {
+        int w = source.getWidth();
+        int h = source.getHeight();
+        WritableImage target = new WritableImage(w, h);
+        int[] pixels = source.getRGB(0, 0, w, h, null, 0, w);
+        target.getPixelWriter().setPixels(0, 0, w, h, PixelFormat.getIntArgbInstance(), pixels, 0, w);
+        return target;
     }
 
     public void refreshView() {
@@ -183,6 +278,21 @@ public class ImageComparePane extends ComparatorPane {
         String blendingMode = blendingModeChoiceBox.getSelectionModel().getSelectedItem();
         scrollPane.setContent(null);
         clearBlending(imageViewA1, imageViewA2, imageViewB1, imageViewB2);
+
+        // Computed diff mask: draw the base capture with the red highlight overlay
+        // on top, rather than relying on a JavaFX BlendMode. Honours the fuzz slider.
+        if (enableBlendingMode && DIFF_MASK_MODE.equals(blendingMode)) {
+            if (maskView.getImage() == null) {
+                recomputeMask();
+            }
+            StackPane maskPane = new StackPane();
+            maskPane.setPadding(new Insets(25, 25, 25, 25));
+            maskPane.setEffect(new DropShadow());
+            maskPane.getChildren().addAll(imageViewA1, maskView);
+            scrollPane.setContent(maskPane);
+            return;
+        }
+
         if (SINGLE_COMPARE_VIEW.equals(viewType)) {
             applyBlending(imageViewB1, blendingMode);
             StackPane singleViewPane = new StackPane();

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/project/ResultsTab.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/project/ResultsTab.java
@@ -27,6 +27,7 @@ import javafx.scene.layout.VBox;
 import org.icepdf.qa.config.Project;
 import org.icepdf.qa.config.Result;
 import org.icepdf.qa.viewer.common.Mediator;
+import org.icepdf.qa.viewer.common.PreferencesController;
 import org.icepdf.qa.viewer.common.Viewer;
 
 import java.util.ArrayList;
@@ -37,7 +38,7 @@ import java.util.List;
  */
 public class ResultsTab extends Tab {
 
-    private final TextField filterTextField;
+    private final Slider filterSlider;
 
     private final ContextMenu openFileContextMenu;
     private final TableView<Result> resultsTable;
@@ -47,7 +48,15 @@ public class ResultsTab extends Tab {
         super(title);
         setClosable(false);
 
-        filterTextField = new TextField("99.99");
+        // Threshold slider: show only results whose similarity is at or below
+        // the slider value, i.e. drag right to widen the net and include
+        // near-identical pages, drag left to surface only the worst regressions.
+        filterSlider = new Slider(0, 100, PreferencesController.getImageCompareThreshold());
+        filterSlider.setShowTickMarks(true);
+        filterSlider.setShowTickLabels(true);
+        filterSlider.setMajorTickUnit(25);
+        filterSlider.setMinorTickCount(4);
+        filterSlider.setPrefWidth(260);
 
         resultsTable = new TableView<>();
         resultsTable.setEditable(false);
@@ -61,11 +70,18 @@ public class ResultsTab extends Tab {
         TableColumn<Result, String> captureNameColumn = new TableColumn<>("Capture ");
         captureNameColumn.setCellValueFactory(new PropertyValueFactory<>("fileNameA"));
 
-        TableColumn<Result, Double> compareColumn = new TableColumn<>("Compare");
+        // Ink-weighted similarity is the headline regression number.
+        TableColumn<Result, Double> compareColumn = new TableColumn<>("Ink %");
         compareColumn.setCellValueFactory(new PropertyValueFactory<>("difference"));
 
+        TableColumn<Result, Double> aeColumn = new TableColumn<>("AE %");
+        aeColumn.setCellValueFactory(new PropertyValueFactory<>("aeSimilarity"));
+
+        TableColumn<Result, Double> ssimColumn = new TableColumn<>("SSIM %");
+        ssimColumn.setCellValueFactory(new PropertyValueFactory<>("structuralSimilarity"));
+
         resultsTable.getSortOrder().add(fileNameColumn);
-        resultsTable.getColumns().addAll(fileNameColumn, captureNameColumn, compareColumn);
+        resultsTable.getColumns().addAll(fileNameColumn, captureNameColumn, compareColumn, aeColumn, ssimColumn);
 
         openFileContextMenu = new ContextMenu();
         MenuItem openClassPathA = new MenuItem("Open With classpath A");
@@ -103,24 +119,21 @@ public class ResultsTab extends Tab {
 
         FilteredList<Result> filteredData = new FilteredList<>(data, p -> true);
 
-        filterTextField.textProperty().addListener((observable, oldValue, newValue) -> filteredData.setPredicate(result -> {
-            // If filter text is empty, display all persons.
-            if (newValue == null || newValue.isEmpty()) {
-                return true;
-            }
-
-            return result.getDifference() <= Double.parseDouble(newValue);// Does not match.
-        }));
-        filterTextField.textProperty().addListener((observable, oldValue, newValue) -> {
-            if (!newValue.matches("\\d+(?:\\.\\d+)?")) {
-                filterTextField.setText(newValue.replaceAll("[^\\d.]", ""));
+        Label filterValueLabel = new Label();
+        filterValueLabel.setMinWidth(60);
+        Runnable applyFilter = () -> {
+            double threshold = filterSlider.getValue();
+            filterValueLabel.setText(String.format("≤ %.2f%%", threshold));
+            filteredData.setPredicate(result -> result.getDifference() <= threshold);
+        };
+        filterSlider.valueProperty().addListener((observable, oldValue, newValue) -> applyFilter.run());
+        // Persist the chosen threshold as the new default once the drag settles.
+        filterSlider.valueChangingProperty().addListener((observable, wasChanging, changing) -> {
+            if (!changing) {
+                PreferencesController.saveImageCompareThreshold(filterSlider.getValue());
             }
         });
-
-        filteredData.setPredicate(result -> {
-            // If filter text is empty, display all persons.
-            return result.getDifference() < Double.parseDouble(filterTextField.getText());
-        });
+        applyFilter.run();
 
         SortedList<Result> sortedData = new SortedList<>(filteredData);
         sortedData.comparatorProperty().bind(resultsTable.comparatorProperty());
@@ -128,7 +141,7 @@ public class ResultsTab extends Tab {
 
         BorderPane borderPane = new BorderPane();
         ToolBar viewTools = new ToolBar();
-        viewTools.getItems().addAll(new Label("Filter"), filterTextField);
+        viewTools.getItems().addAll(new Label("Show ≤"), filterSlider, filterValueLabel);
         borderPane.setTop(new VBox(20, viewTools));
         borderPane.setCenter(resultsTable);
         this.setContent(borderPane);


### PR DESCRIPTION
The image compare scored differing-pixels over total-pixels with exact equality. On mostly-white PDF pages this both under-reported missing content (a dropped paragraph is ~2% of the page, so it scored ~98% identical) and over-reported sub-pixel anti-aliasing noise.

Add a shared, JavaFX-free compare engine used by both the batch task and the interactive pane so the recorded score and the on-screen mask can never disagree:

- ImageCompare/CompareMetrics: fuzz-tolerant AE, ink-weighted similarity (differences measured against the union of non-background pixels, the new headline number), and mean windowed SSIM on luminance.
- ImageCompareTask: read captures as BufferedImage and score off the FX thread; difference is now the ink-weighted value, AE/SSIM ride along.
- Result: carry AE and SSIM columns, backward-compatible with saved projects.
- PreferencesController: configurable fuzz tolerance and pass/fail threshold.
- ResultsTab: threshold text field becomes a live slider; add AE % and SSIM % columns.
- ImageComparePane: new "Diff Mask (fuzz)" mode with a live fuzz slider that re-runs the engine and repaints the highlight overlay in place; SSIM is computed once per result and cached across slider ticks.