### PR TITLE
GH-496 two-level QA parallelism, batched console, clean shutdown

### DIFF
--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/tests/ImageCompareTask.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/tests/ImageCompareTask.java
@@ -42,16 +42,21 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  *
  */
 public class ImageCompareTask extends AbstractTestTask {
 
-    private static final int THREAD_EXECUTOR_SIZE = 4;
+    // ICEpdf system property that sizes the per-version image-proxy decode pool; sized from
+    // preferences before the capture-set class loaders (and their Library statics) are created.
+    private static final String ICEPDF_IMAGE_THREAD_POOL_PROPERTY = "org.icepdf.core.library.imageThreadPoolSize";
 
     // page capture test
     public static final String PAGE_CAPTURE_CLASS = "org.icepdf.ri.util.qa.PageCapture";
@@ -69,7 +74,10 @@ public class ImageCompareTask extends AbstractTestTask {
 
     private ArrayList<Path> filePaths;
 
-    protected static ExecutorService executorService;
+    // Capture concurrency, read once from preferences in setup() so a run uses a consistent value.
+    // P: documents captured/compared at once. Q: render threads per in-flight document (floor 2).
+    private int concurrentDocuments;
+    private int renderThreadsPerDocument;
 
     public ImageCompareTask(Mediator mediator) {
         this.mediator = mediator;
@@ -125,7 +133,13 @@ public class ImageCompareTask extends AbstractTestTask {
         captureSetA = project.getCaptureSetA();
         captureSetB = project.getCaptureSetB();
 
-        executorService = Executors.newFixedThreadPool(THREAD_EXECUTOR_SIZE);
+        // read capture-concurrency preferences once for the whole run.
+        concurrentDocuments = PreferencesController.getCaptureConcurrentDocuments();
+        renderThreadsPerDocument = PreferencesController.getCaptureRenderThreadsPerDocument();
+        // Size ICEpdf's image-proxy pool before config() creates the class loaders: Library reads
+        // this property in a static initializer, so it must be set before that class is loaded.
+        System.setProperty(ICEPDF_IMAGE_THREAD_POOL_PROPERTY,
+                Integer.toString(PreferencesController.getCaptureImageThreadPoolSize()));
     }
 
     @Override
@@ -165,8 +179,11 @@ public class ImageCompareTask extends AbstractTestTask {
             throw new ConfigurationException("Capture page count must be at least one.");
         }
 
-        // create new urlClass loaders for each capture set as part of this work and validate that the class loader
-        // have valid classes.
+        // Create the per-capture-set URLClassLoaders here, once, on the single config thread. This
+        // validates the classpath and, importantly, primes CaptureSet.classLoader before any
+        // document units run: getTestInstance() below and inside the render units then only ever
+        // read the already-created loader, so there is no lazy-init race once documents run
+        // concurrently (increment 2).
         try {
             getTestInstance(captureSetA);
         } catch (Exception e) {
@@ -219,31 +236,47 @@ public class ImageCompareTask extends AbstractTestTask {
     @Override
     public void testAndAnalyze() {
         System.out.println("---- Test and Analyze started -----");
-        try {
+        {
             List<Result> results = new ArrayList<>(commonContentSets.size() * commonPageCount);
             Platform.runLater(mediator::resetProjectResults);
 
             int testSize = filePaths.size();
-            int i = 1;
-            for (Path filePath : filePaths) {
-                if (isCancelled()) {
-                    updateMessage("Cancelled");
-                    break;
+            AtomicInteger completed = new AtomicInteger();
+            // Each document is a self-contained unit (capture A+B, dispose, compare all pages,
+            // publish) that owns its own render pool. The units are submitted to a document-level
+            // pool of size P (CONCURRENT_DOCUMENTS) so up to P documents run at once; each running
+            // unit still drives at least two threads over its own document. Only P inner render
+            // pools exist at any moment, which bounds the memory/thread footprint. Progress is
+            // reported by an atomic counter as units finish (any order); results are merged back in
+            // document order by iterating the futures in submission order, so the saved output is
+            // deterministic regardless of completion order.
+            ExecutorService documentPool = Executors.newFixedThreadPool(concurrentDocuments);
+            try {
+                List<Future<List<Result>>> futures = new ArrayList<>(testSize);
+                for (int idx = 0; idx < filePaths.size(); idx++) {
+                    Path filePath = filePaths.get(idx);
+                    int documentIndex = idx + 1;
+                    futures.add(documentPool.submit(
+                            new CaptureAndCompareDocument(filePath, documentIndex, completed, testSize)));
                 }
-                // update the UI
-                updateProgress(i, testSize);
-                // setup what needs to be captured.
-                if (!captureSetA.isComplete() && !captureSetB.isComplete()) {
-                    capturePages(filePath, i, captureSetA, captureSetB);
-                } else if (!captureSetA.isComplete()) {
-                    capturePages(filePath, i, captureSetA);
-                } else if (!captureSetB.isComplete()) {
-                    capturePages(filePath, i, captureSetB);
+                for (Future<List<Result>> future : futures) {
+                    if (isCancelled()) {
+                        updateMessage("Cancelled");
+                        break;
+                    }
+                    try {
+                        results.addAll(future.get());
+                    } catch (CancellationException e) {
+                        // unit was interrupted by documentPool.shutdownNow() during cancellation.
+                    } catch (ExecutionException e) {
+                        e.printStackTrace();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
                 }
-                // compare output
-                results.addAll(comparePages(i, filePath, captureSetA, captureSetB));
-
-                i++;
+            } finally {
+                documentPool.shutdownNow();
             }
             // mark each content set as complete.
             if (!captureSetA.isComplete() && !captureSetB.isComplete()) {
@@ -268,13 +301,6 @@ public class ImageCompareTask extends AbstractTestTask {
             //save teh projects state.
             project.setResults(results);
             ConfigSerializer.save(project);
-        } catch (InterruptedException e) {
-            if (isCancelled()) {
-                updateMessage("Cancelled");
-            }
-            e.printStackTrace();
-        } catch (ExecutionException e) {
-            e.printStackTrace();
         }
     }
 
@@ -282,7 +308,6 @@ public class ImageCompareTask extends AbstractTestTask {
     public void teardown() {
         // do and cleanup.
         Platform.runLater(mediator::setStopTestTaskGuiState);
-        executorService.shutdownNow();
     }
 
     private Object getTestInstance(CaptureSet captureSet) {
@@ -343,11 +368,17 @@ public class ImageCompareTask extends AbstractTestTask {
         return 0;
     }
 
-    private void capturePages(Path filePath, int documentIndex, CaptureSet... captureSet) throws InterruptedException, ExecutionException {
+    /**
+     * Captures the requested pages of a single document across the given capture sets. The page
+     * callables for every capture set are submitted together to the document's own render pool, so
+     * pages of the same document are always rendered by at least two threads concurrently - the
+     * stress condition that surfaces ICEpdf sync bugs.
+     */
+    private void capturePages(ExecutorService renderPool, Path filePath, int documentIndex, CaptureSet... captureSet)
+            throws InterruptedException, ExecutionException {
         // capture pageCaptureTest
-        Object[] testInstances;
-        List<Callable<Void>> callables = new ArrayList<>(commonPageCount * 2);
-        testInstances = new Object[captureSet.length];
+        Object[] testInstances = new Object[captureSet.length];
+        List<Callable<Void>> callables = new ArrayList<>(commonPageCount * captureSet.length);
         for (int i = 0; i < captureSet.length; i++) {
             Object testInstance = getTestInstance(captureSet[i]);
 
@@ -359,31 +390,91 @@ public class ImageCompareTask extends AbstractTestTask {
             testInstances[i] = testInstance;
         }
         // run the pageCaptureTest capture
-        executorService.invokeAll(callables);
+        renderPool.invokeAll(callables);
         // close
         for (int i = 0; i < captureSet.length; i++) {
-            executorService.submit(new DocumentCloser(captureSet[i], testInstances[i])).get();
+            renderPool.submit(new DocumentCloser(captureSet[i], testInstances[i])).get();
         }
     }
 
-    private List<Result> comparePages(int documentIndex, Path filePath, CaptureSet captureSetA, CaptureSet captureSetB)
+    private List<Result> comparePages(ExecutorService renderPool, int documentIndex, Path filePath,
+                                      CaptureSet captureSetA, CaptureSet captureSetB)
             throws InterruptedException, ExecutionException {
-        List<Result> results = new ArrayList<>();
+        List<Callable<Result>> compareCallables = new ArrayList<>(commonPageCount);
         for (int i = 0; i < commonPageCount; i++) {
-            Result result = executorService.submit(new DocumentImageCompare(filePath, i, captureSetA, captureSetB)).get();
+            compareCallables.add(new DocumentImageCompare(filePath, i, captureSetA, captureSetB));
+        }
+        // invokeAll preserves the callable order, so results stay in page order regardless of the
+        // order the compares actually finish.
+        List<Future<Result>> futures = renderPool.invokeAll(compareCallables);
+        List<Result> results = new ArrayList<>(commonPageCount);
+        // Buffer this document's compare output and flush it in a single call so that, with several
+        // documents comparing at once, each document's per-page lines stay contiguous instead of
+        // interleaving across documents.
+        StringBuilder log = new StringBuilder();
+        for (int page = 0; page < futures.size(); page++) {
+            Result result = futures.get(page).get();
             if (result != null) {
                 results.add(result);
                 if (result.getDifference() < 100) {
-                    System.err.format("File [%d/%d|%.2f%%]=%s%n", documentIndex, filePaths.size(), result.getDifference(), filePath.toString());
-                    System.out.print('~');
+                    log.append(String.format("Diff  [%d/%d] %s page %d: %.2f%%%n",
+                            documentIndex, filePaths.size(), filePath.toString(), page + 1, result.getDifference()));
                 } else {
-                    System.out.print('=');
+                    log.append(String.format("Match [%d/%d] %s page %d%n",
+                            documentIndex, filePaths.size(), filePath.toString(), page + 1));
                 }
             }
+        }
+        if (log.length() > 0) {
+            System.out.print(log);
+            System.out.flush();
         }
         Platform.runLater(() -> mediator.addProjectResults(results));
 
         return results;
+    }
+
+    /**
+     * Self-contained capture-and-compare pipeline for a single document. Owns a render pool of
+     * {@code renderThreadsPerDocument} threads for the duration of the document so that, no matter
+     * how many documents run at once, every in-flight document is exercised by at least two
+     * concurrent page-render threads. Returns the document's results in page order.
+     */
+    private class CaptureAndCompareDocument implements Callable<List<Result>> {
+
+        private final Path filePath;
+        private final int documentIndex;
+        private final AtomicInteger completed;
+        private final int testSize;
+
+        private CaptureAndCompareDocument(Path filePath, int documentIndex, AtomicInteger completed, int testSize) {
+            this.filePath = filePath;
+            this.documentIndex = documentIndex;
+            this.completed = completed;
+            this.testSize = testSize;
+        }
+
+        @Override
+        public List<Result> call() throws InterruptedException, ExecutionException {
+            ExecutorService renderPool = Executors.newFixedThreadPool(renderThreadsPerDocument);
+            try {
+                // setup what needs to be captured.
+                if (!captureSetA.isComplete() && !captureSetB.isComplete()) {
+                    capturePages(renderPool, filePath, documentIndex, captureSetA, captureSetB);
+                } else if (!captureSetA.isComplete()) {
+                    capturePages(renderPool, filePath, documentIndex, captureSetA);
+                } else if (!captureSetB.isComplete()) {
+                    capturePages(renderPool, filePath, documentIndex, captureSetB);
+                }
+                // compare output
+                return comparePages(renderPool, documentIndex, filePath, captureSetA, captureSetB);
+            } finally {
+                renderPool.shutdownNow();
+                // report progress as documents finish; completion order is not document order, but
+                // the count is monotonic so the progress bar only advances.
+                updateProgress(completed.incrementAndGet(), testSize);
+            }
+        }
     }
 
     public static class CapturePage implements Callable<Void> {
@@ -414,7 +505,7 @@ public class ImageCompareTask extends AbstractTestTask {
                             fileName + "_" + pageNumber + ".png");
 
                     if (!Files.exists(imageCapture)) {
-                        System.out.print("|");
+                        System.out.println("Capturing " + fileName + " page " + (pageNumber + 1) + "/" + numberOfPage);
 
                         // paint the page.
                         Method captureMethod = pageCaptureClass.getMethod(PAGE_CAPTURE_METHOD,

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/Launcher.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/Launcher.java
@@ -86,6 +86,21 @@ public class Launcher extends Application {
         mediator.loadOrCreateProject();
     }
 
+    /**
+     * Called by the JavaFX runtime when the application is shutting down (last window closed via the X button or the
+     * Exit menu). A completed or cancelled run leaves non-daemon worker threads alive — most notably ICEpdf's own
+     * internal {@code Library} thread pools, which live inside each capture-set's child classloader and cannot be
+     * reached to shut down from here — and those keep the JVM running after the window is gone. Cancel any in-flight
+     * run and force a hard exit so the process actually terminates.
+     */
+    @Override
+    public void stop() {
+        if (mediator != null) {
+            mediator.cancelTestInstance();
+        }
+        System.exit(0);
+    }
+
     private BorderPane createProjectViewContent() {
         BorderPane projectBorderPane = new BorderPane();
         projectBorderPane.setTop(buildProjectToolBar());

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/common/Mediator.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/common/Mediator.java
@@ -114,7 +114,10 @@ public class Mediator {
         // get the test and try to run
         currentTestTask = TestFactory.getInstance().createTestInstance(this);
         progressBar.progressProperty().bind(currentTestTask.progressProperty());
-        new Thread(currentTestTask).start();
+        // Daemon so the run thread can never hold the JVM alive on its own once the UI closes.
+        Thread testThread = new Thread(currentTestTask);
+        testThread.setDaemon(true);
+        testThread.start();
     }
 
     /**

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/common/PreferencesController.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/common/PreferencesController.java
@@ -50,6 +50,22 @@ public class PreferencesController {
     // ink-weighted similarity (%) at or below which a result is flagged as a regression in the results tab.
     public static final String IMAGE_COMPARE_THRESHOLD_KEY = "imageCompareThreshold";
     public static final double IMAGE_COMPARE_THRESHOLD_VALUE = 99.99d;
+
+    // Capture concurrency (see ImageCompareTask). P: number of documents captured/compared at once.
+    // Default is deliberately conservative because peak heap scales with P x versions x page rasters.
+    public static final String CAPTURE_CONCURRENT_DOCUMENTS_KEY = "captureConcurrentDocuments";
+    public static final int CAPTURE_CONCURRENT_DOCUMENTS_VALUE =
+            Math.max(1, Math.min(4, Runtime.getRuntime().availableProcessors() / 2));
+    // Q: threads that render the pages of a single document. Floored at 2 - rendering pages of the
+    // same document concurrently is the stress condition that surfaces ICEpdf sync bugs.
+    public static final String CAPTURE_RENDER_THREADS_KEY = "captureRenderThreadsPerDocument";
+    public static final int CAPTURE_RENDER_THREADS_VALUE = 4;
+    public static final int CAPTURE_RENDER_THREADS_MIN = 2;
+    // Passthrough to each capture set's ICEpdf -Dorg.icepdf.core.library.imageThreadPoolSize. Only the
+    // image-proxy decode path uses it, and it is read once when that version's Library class loads, so
+    // a change takes effect only for a freshly created capture-set class loader.
+    public static final String CAPTURE_IMAGE_THREAD_POOL_KEY = "captureImageThreadPoolSize";
+    public static final int CAPTURE_IMAGE_THREAD_POOL_VALUE = 2;
     public static final String LAST_CONTENT_SET_KEY = "contentSetBasePath";
     public static final String APPLICATION_HOME_PATH_KEY = "applicationHomePath";
 
@@ -138,6 +154,31 @@ public class PreferencesController {
 
     public static void saveImageCompareThreshold(double threshold) {
         prefs.putDouble(IMAGE_COMPARE_THRESHOLD_KEY, threshold);
+    }
+
+    public static int getCaptureConcurrentDocuments() {
+        return Math.max(1, prefs.getInt(CAPTURE_CONCURRENT_DOCUMENTS_KEY, CAPTURE_CONCURRENT_DOCUMENTS_VALUE));
+    }
+
+    public static void saveCaptureConcurrentDocuments(int concurrentDocuments) {
+        prefs.putInt(CAPTURE_CONCURRENT_DOCUMENTS_KEY, Math.max(1, concurrentDocuments));
+    }
+
+    public static int getCaptureRenderThreadsPerDocument() {
+        return Math.max(CAPTURE_RENDER_THREADS_MIN,
+                prefs.getInt(CAPTURE_RENDER_THREADS_KEY, CAPTURE_RENDER_THREADS_VALUE));
+    }
+
+    public static void saveCaptureRenderThreadsPerDocument(int renderThreadsPerDocument) {
+        prefs.putInt(CAPTURE_RENDER_THREADS_KEY, Math.max(CAPTURE_RENDER_THREADS_MIN, renderThreadsPerDocument));
+    }
+
+    public static int getCaptureImageThreadPoolSize() {
+        return Math.max(1, prefs.getInt(CAPTURE_IMAGE_THREAD_POOL_KEY, CAPTURE_IMAGE_THREAD_POOL_VALUE));
+    }
+
+    public static void saveCaptureImageThreadPoolSize(int imageThreadPoolSize) {
+        prefs.putInt(CAPTURE_IMAGE_THREAD_POOL_KEY, Math.max(1, imageThreadPoolSize));
     }
 
     public static void saveLastUsedContentSetPath(Path directoryPath) {

--- a/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/project/ProjectUtilityPane.java
+++ b/qa/viewer-jfx/src/main/java/org/icepdf/qa/viewer/project/ProjectUtilityPane.java
@@ -15,7 +15,7 @@
  */
 package org.icepdf.qa.viewer.project;
 
-import javafx.application.Platform;
+import javafx.animation.AnimationTimer;
 import javafx.geometry.Side;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -26,13 +26,26 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 
 /**
- * Contains a simple console view that take System.out as a source.  The TextArea has proven to be a little slow as
- * it get busy.  Sor the current work around is to do a little ascii art.
+ * Contains a simple console view that takes System.out as a source.  Writes are buffered off the writing thread and
+ * drained to the TextArea in batches on the JavaFX application thread, and the TextArea is capped to a rolling window
+ * of the most recent output.  This keeps a busy test run from flooding the FX event queue or growing the console
+ * without bound.
  */
 public class ProjectUtilityPane extends TabPane {
 
+    /**
+     * Maximum number of characters retained in the console.  Older text is trimmed from the front once this is
+     * exceeded, giving a rolling window of recent output.
+     */
+    private static final int MAX_CONSOLE_CHARS = 200_000;
+
+    /**
+     * Minimum time between TextArea updates, in nanoseconds.  Buffered output is coalesced into a single append per
+     * interval rather than one update per byte.
+     */
+    private static final long FLUSH_INTERVAL_NANOS = 100_000_000L; // 100ms
+
     private final TextArea consoleTextArea;
-    private int count;
 
     public ProjectUtilityPane(Mediator mediator) {
         super();
@@ -42,7 +55,7 @@ public class ProjectUtilityPane extends TabPane {
         consoleTab.setClosable(false);
 
         consoleTextArea = new TextArea();
-        PrintStream printStream = new PrintStream(new Console(consoleTextArea));
+        PrintStream printStream = new PrintStream(new Console(consoleTextArea), true);
 
         System.setOut(printStream);
 //        System.setErr(printStream);
@@ -54,30 +67,61 @@ public class ProjectUtilityPane extends TabPane {
 
     public void clearConsole() {
         consoleTextArea.clear();
-        count = 0;
     }
 
-    public class Console extends OutputStream {
+    /**
+     * OutputStream that buffers writes from any thread and periodically flushes them to a TextArea on the FX
+     * application thread, capping the total length to {@link #MAX_CONSOLE_CHARS}.
+     */
+    public static class Console extends OutputStream {
         private final TextArea console;
+        private final StringBuilder buffer = new StringBuilder();
+        private long lastFlush;
 
         public Console(TextArea console) {
             this.console = console;
+            // AnimationTimer.handle() runs on the FX application thread, so the drain can touch the TextArea directly.
+            new AnimationTimer() {
+                @Override
+                public void handle(long now) {
+                    if (now - lastFlush < FLUSH_INTERVAL_NANOS) {
+                        return;
+                    }
+                    lastFlush = now;
+                    flushToConsole();
+                }
+            }.start();
         }
 
-        public void appendText(String valueOf) {
-            Platform.runLater(() -> console.appendText(valueOf));
-        }
-
+        @Override
         public void write(int b) {
-            if (count % 80 == 0) {
-                appendText(String.valueOf('\n'));
+            synchronized (buffer) {
+                buffer.append((char) (b & 0xFF));
             }
-            appendText(String.valueOf((char) b));
-            // line break our ascii art at 80.
-            if (b == '=' || b == '|' || b == '~') {
-                count++;
-            } else {
-                count = 1;
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) {
+            synchronized (buffer) {
+                for (int i = 0; i < len; i++) {
+                    buffer.append((char) (b[off + i] & 0xFF));
+                }
+            }
+        }
+
+        private void flushToConsole() {
+            String pending;
+            synchronized (buffer) {
+                if (buffer.length() == 0) {
+                    return;
+                }
+                pending = buffer.toString();
+                buffer.setLength(0);
+            }
+            console.appendText(pending);
+            int overflow = console.getLength() - MAX_CONSOLE_CHARS;
+            if (overflow > 0) {
+                console.deleteText(0, overflow);
             }
         }
     }


### PR DESCRIPTION
Redesign ImageCompareTask around a two-level parallelism model: an outer document pool (P concurrent documents) with a per-document inner render pool (Q>=2 threads) so every in-flight document is always exercised by at least two concurrent render threads -- the condition that surfaces ICEpdf's own threading/missing-content bugs. Progress is tracked with an AtomicInteger and results are merged back in document order so saved output stays deterministic. Expose P, Q and the ICEpdf imageThreadPool size in PreferencesController.

Rewrite the Console (ProjectUtilityPane) to buffer writes off-thread and drain them to the TextArea in one batched append per 100ms via an AnimationTimer, capped to a 200k-char rolling window. This replaces the per-byte Platform.runLater model that flooded the FX event queue and grew the TextArea without bound on long runs, and lets us drop the old ||== ~= ascii-art progress hack in favour of readable per-page log lines.

Fix shutdown: the window-close handler only cancelled the run and never exited the JVM, so ICEpdf's internal Library pools (living in each capture-set classloader, unreachable from here) kept the process alive. Override Application.stop() to cancel and System.exit(0), and mark the run thread daemon.