### PR TITLE
GH-501 CMYK-correct transparency-group compositing & backdrop handling

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,11 +47,7 @@ distributions {
                 include '*-sources.jar'
             }
             into('libs') {
-                // dependency jars
-                def libs = []
-                libs << project(':core:core-awt').configurations.runtimeClasspath.files
-//                libs << project(':viewer:viewer-awt').configurations.runtimeClasspath.files
-                from libs
+                from { configurations.runtimeClasspath }
                 from project(':core:core-awt').jar
                 from project(':viewer:viewer-awt').jar
                 from project(':core:core-fonts').jar

--- a/core/core-awt/build.gradle
+++ b/core/core-awt/build.gradle
@@ -141,3 +141,20 @@ tasks.register('parsingBenchmark', JavaExec) {
         }
     }
 }
+
+// GH-501 strategic probe: report black-ink (K) stats of preserved DeviceCMYK
+// samples across a corpus, to find files where the raster-level subtractive path
+// could matter (maxK > 0).  See CmykSampleProbeTest.
+//   ./gradlew :core:core-awt:cmykProbe -Pcmyk.probe.dirs=/path/a:/path/b
+tasks.register('cmykProbe', JavaExec) {
+    group = 'verification'
+    description = 'Probes preserved DeviceCMYK samples for genuine black ink (GH-501).'
+    classpath = sourceSets.test.runtimeClasspath
+    mainClass = 'org.icepdf.core.pobjects.graphics.CmykSampleProbeTest'
+    workingDir = rootProject.projectDir
+    maxHeapSize = project.findProperty('cmyk.probe.heap') ?: '4g'
+    systemProperty('cmyk.probe', '1')
+    if (project.hasProperty('cmyk.probe.dirs')) {
+        systemProperty('cmyk.probe.dirs', project.property('cmyk.probe.dirs'))
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -135,16 +135,6 @@ public class Page extends Dictionary {
     private static final boolean EAGER_IMAGE_DECODE =
             Defs.booleanProperty("org.icepdf.core.imageReference.eagerDecode", false);
 
-    // GH-502 option (b): when the page is itself a transparency group, render its
-    // content into one shared offscreen buffer (seeded transparent) so the page's
-    // groups blend against each other before reaching the page backdrop, then
-    // composite that buffer over the (white) paper -- pdf.js's "treat non-isolated
-    // as isolated" behaviour.  Default ON, scoped to DeviceCMYK page groups
-    // (isPageGroupBufferCandidate); validated across the CMYK page-group corpus
-    // with no regressions.  Set -Dorg.icepdf.core.pageGroupBuffer=false to opt out.
-    private static final boolean PAGE_GROUP_BUFFER =
-            Defs.booleanProperty("org.icepdf.core.pageGroupBuffer", true);
-
     public static final Name TYPE = new Name("Page");
     public static final Name ANNOTS_KEY = new Name("Annots");
     public static final Name CONTENTS_KEY = new Name("Contents");
@@ -712,7 +702,7 @@ public class Page extends Dictionary {
             Shape pageClip = g2.getClip();
 
             shapes.setPageParent(this);
-            if (PAGE_GROUP_BUFFER && isPageGroupBufferCandidate()) {
+            if (isPageGroupBufferCandidate()) {
                 paintPageGroupBuffered(g2);
             } else {
                 shapes.paint(g2);

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -18,12 +18,8 @@ package org.icepdf.core.pobjects;
 import org.icepdf.core.events.*;
 import org.icepdf.core.io.SeekableInput;
 import org.icepdf.core.pobjects.annotations.*;
-import org.icepdf.core.pobjects.graphics.BlendComposite;
-import org.icepdf.core.pobjects.graphics.DeviceCMYK;
-import org.icepdf.core.pobjects.graphics.Shapes;
-import org.icepdf.core.pobjects.graphics.TransparencyGroup;
+import org.icepdf.core.pobjects.graphics.*;
 import org.icepdf.core.pobjects.graphics.commands.FormDrawCmd;
-import org.icepdf.core.pobjects.graphics.WatermarkCallback;
 import org.icepdf.core.pobjects.graphics.text.GlyphText;
 import org.icepdf.core.pobjects.graphics.text.LineText;
 import org.icepdf.core.pobjects.graphics.text.PageText;
@@ -771,7 +767,7 @@ public class Page extends Dictionary {
     }
 
     /**
-     * GH-502 option (b): paint the page content into a shared transparency-group
+     * GH-501 option (b): paint the page content into a shared transparency-group
      * buffer rather than straight onto {@code g2}, then composite that buffer back.
      * <br>
      * The page is itself a transparency group (page dict {@code /Group}); its inner

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -18,8 +18,10 @@ package org.icepdf.core.pobjects;
 import org.icepdf.core.events.*;
 import org.icepdf.core.io.SeekableInput;
 import org.icepdf.core.pobjects.annotations.*;
+import org.icepdf.core.pobjects.graphics.DeviceCMYK;
 import org.icepdf.core.pobjects.graphics.Shapes;
 import org.icepdf.core.pobjects.graphics.TransparencyGroup;
+import org.icepdf.core.pobjects.graphics.commands.FormDrawCmd;
 import org.icepdf.core.pobjects.graphics.WatermarkCallback;
 import org.icepdf.core.pobjects.graphics.text.GlyphText;
 import org.icepdf.core.pobjects.graphics.text.LineText;
@@ -33,6 +35,7 @@ import org.icepdf.core.util.updater.modifiers.ModifierFactory;
 
 import java.awt.*;
 import java.awt.geom.*;
+import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
@@ -130,6 +133,15 @@ public class Page extends Dictionary {
     // with spare CPU.  Opt in for image-heavy workloads.
     private static final boolean EAGER_IMAGE_DECODE =
             Defs.booleanProperty("org.icepdf.core.imageReference.eagerDecode", false);
+
+    // GH-502 option (b): when the page is itself a transparency group, render its
+    // content into one shared offscreen buffer (seeded transparent) so the page's
+    // groups blend against each other before reaching the page backdrop, then
+    // composite that buffer over the (white) paper -- pdf.js's "treat non-isolated
+    // as isolated" behaviour.  Default off; broad blast radius (most modern PDFs
+    // carry a page /Group) so opt-in while it is proven on metrics.
+    private static final boolean PAGE_GROUP_BUFFER =
+            Defs.booleanProperty("org.icepdf.core.pageGroupBuffer", false);
 
     public static final Name TYPE = new Name("Page");
     public static final Name ANNOTS_KEY = new Name("Annots");
@@ -698,7 +710,11 @@ public class Page extends Dictionary {
             Shape pageClip = g2.getClip();
 
             shapes.setPageParent(this);
-            shapes.paint(g2);
+            if (PAGE_GROUP_BUFFER && isPageGroupBufferCandidate()) {
+                paintPageGroupBuffered(g2);
+            } else {
+                shapes.paint(g2);
+            }
             shapes.setPageParent(null);
 
             g2.setTransform(pageTransform);
@@ -760,6 +776,84 @@ public class Page extends Dictionary {
         if (imageCount == 0 || (pageInitialized && pagePainted)) {
             notifyPageLoadingEnded();
         }
+    }
+
+    /**
+     * GH-502 option (b): paint the page content into a shared transparency-group
+     * buffer rather than straight onto {@code g2}, then composite that buffer back.
+     * <br>
+     * The page is itself a transparency group (page dict {@code /Group}); its inner
+     * groups must blend against each other (and against a transparent seed) inside
+     * one buffer, otherwise a darkening fill (e.g. a ColorBurn layer) composites
+     * against the white paper and washes out instead of darkening the accumulated
+     * content.  The buffer is built at device resolution under the current page CTM
+     * (so orientation/position/scale follow the CTM exactly -- no hand-rolled blit),
+     * then drawn back over the already-filled (white) paper with SRC_OVER.
+     * <br>
+     * While painting into the buffer, {@link FormDrawCmd}'s §10 backdrop-composite
+     * and its decline gate are bypassed (the buffer IS the backdrop), so each inner
+     * group takes the direct blended path against the live accumulating pixels.
+     */
+    /**
+     * Whether the page should be rendered through the shared transparency-group
+     * buffer.  Scoped to a <b>DeviceCMYK</b> page group: those are the subtractive
+     * CMYK stacks (e.g. 978-9-7315-0059-9_1.pdf) that build a dark field from ink
+     * and need isolated-style accumulation.  A DeviceRGB/DeviceGray page group is
+     * decorative content composited over the white paper -- buffering it as
+     * isolated makes its translucent groups interact with each other instead of
+     * the paper (dark halos), so it stays on the existing direct path.
+     */
+    private boolean isPageGroupBufferCandidate() {
+        TransparencyGroup pageGroup = shapes != null ? shapes.getPageGroup() : null;
+        return pageGroup != null && DeviceCMYK.DEVICECMYK_KEY.equals(pageGroup.getColorSpace());
+    }
+
+    private void paintPageGroupBuffered(Graphics2D g2) throws InterruptedException {
+        AffineTransform savedTx = g2.getTransform();
+        Shape savedClip = g2.getClip();
+        // device-space pixel bounds of the current clip (the page footprint).
+        Rectangle devBounds = savedClip != null
+                ? savedTx.createTransformedShape(savedClip).getBounds()
+                : savedTx.createTransformedShape(g2.getClipBounds()).getBounds();
+        if (devBounds.width <= 0 || devBounds.height <= 0) {
+            // nothing to buffer; fall back to the direct paint.
+            shapes.paint(g2);
+            return;
+        }
+        BufferedImage buffer = new BufferedImage(devBounds.width, devBounds.height,
+                BufferedImage.TYPE_INT_ARGB);
+        Graphics2D bg = buffer.createGraphics();
+        try {
+            bg.setRenderingHints(g2.getRenderingHints());
+            // map page user space -> buffer pixels: translate the device origin to
+            // (0,0), then apply the page CTM.  Painting the shapes through this is a
+            // 1:1 device-resolution render (sharp), and the clip carries over in the
+            // same user space.
+            AffineTransform bt = new AffineTransform();
+            bt.translate(-devBounds.x, -devBounds.y);
+            bt.concatenate(savedTx);
+            bg.setTransform(bt);
+            if (savedClip != null) {
+                bg.setClip(savedClip);
+            }
+            FormDrawCmd.setRenderingIntoPageGroup(true);
+            try {
+                shapes.paint(bg);
+            } finally {
+                FormDrawCmd.setRenderingIntoPageGroup(false);
+            }
+        } finally {
+            bg.dispose();
+        }
+        // composite the accumulated group buffer over the (white) paper in device
+        // space; opaque accumulated content covers the paper, residual transparent
+        // gaps reveal it.
+        g2.setTransform(new AffineTransform());
+        g2.setClip(null);
+        g2.drawImage(buffer, devBounds.x, devBounds.y, null);
+        g2.setTransform(savedTx);
+        g2.setClip(savedClip);
+        buffer.flush();
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -19,6 +19,7 @@ import org.icepdf.core.events.*;
 import org.icepdf.core.io.SeekableInput;
 import org.icepdf.core.pobjects.annotations.*;
 import org.icepdf.core.pobjects.graphics.Shapes;
+import org.icepdf.core.pobjects.graphics.TransparencyGroup;
 import org.icepdf.core.pobjects.graphics.WatermarkCallback;
 import org.icepdf.core.pobjects.graphics.text.GlyphText;
 import org.icepdf.core.pobjects.graphics.text.LineText;
@@ -142,6 +143,10 @@ public class Page extends Dictionary {
     public static final Name ARTBOX_KEY = new Name("ArtBox");
     public static final Name BLEEDBOX_KEY = new Name("BleedBox");
     public static final Name TRIMBOX_KEY = new Name("TrimBox");
+    // page-level transparency group (/Group) attribute keys (PDF §11.6.6).
+    public static final Name SUBTYPE_KEY = new Name("S");
+    public static final Name TRANSPARENCY_VALUE = new Name("Transparency");
+    public static final Name GROUP_CS_KEY = new Name("CS");
     /**
      * Defines the boundaries of the physical medium on which the page is
      * intended to be displayed or printed.
@@ -455,6 +460,12 @@ public class Page extends Dictionary {
                     // pass in option group references into parse.
                     if (streams.length > 0) {
                         shapes = cp.parse(streams, this).getShapes();
+                        // record the page-level transparency group (/Group on the
+                        // page dict), normally discarded.  A page that is itself a
+                        // transparency group can be rendered into a shared group
+                        // buffer so its inner groups blend against each other before
+                        // reaching the page backdrop (see Shapes#getPageGroup).
+                        initPageGroup();
                     }
                     // content streams are only needed for parsing; the Shapes built above are what painting uses.
                     // Release each stream's decompressed cache (re-derivable from the still-compressed rawBytes) so
@@ -488,6 +499,32 @@ public class Page extends Dictionary {
             throw new InterruptedException(e.getMessage());
         }
         notifyPageInitializationEnded(inited);
+    }
+
+    /**
+     * Reads the page dictionary's {@code /Group} entry (PDF §11.6.6) and, when it
+     * is a transparency group, records its attributes on the page shapes via
+     * {@link Shapes#setPageGroup}.  Mirrors {@link Form#initGroup}.  No-op when the
+     * page is not a transparency group.
+     */
+    private void initPageGroup() {
+        if (shapes == null) {
+            return;
+        }
+        DictionaryEntries group = library.getDictionary(entries, Form.GROUP_KEY);
+        if (group == null) {
+            return;
+        }
+        Name subtype = library.getName(group, SUBTYPE_KEY);
+        if (subtype != null && !TRANSPARENCY_VALUE.equals(subtype)) {
+            return;
+        }
+        Boolean isolated = library.getBoolean(group, Form.I_KEY);
+        Boolean knockout = library.getBoolean(group, Form.K_KEY);
+        Object cs = library.getObject(group, GROUP_CS_KEY);
+        Name csName = cs instanceof Name ? (Name) cs : null;
+        shapes.setPageGroup(new TransparencyGroup(
+                Boolean.TRUE.equals(isolated), Boolean.TRUE.equals(knockout), csName));
     }
 
     public List<Stream> getContentStreams() {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -18,6 +18,7 @@ package org.icepdf.core.pobjects;
 import org.icepdf.core.events.*;
 import org.icepdf.core.io.SeekableInput;
 import org.icepdf.core.pobjects.annotations.*;
+import org.icepdf.core.pobjects.graphics.BlendComposite;
 import org.icepdf.core.pobjects.graphics.DeviceCMYK;
 import org.icepdf.core.pobjects.graphics.Shapes;
 import org.icepdf.core.pobjects.graphics.TransparencyGroup;
@@ -516,7 +517,7 @@ public class Page extends Dictionary {
     /**
      * Reads the page dictionary's {@code /Group} entry (PDF §11.6.6) and, when it
      * is a transparency group, records its attributes on the page shapes via
-     * {@link Shapes#setPageGroup}.  Mirrors {@link Form#initGroup}.  No-op when the
+     * {@link Shapes#setPageGroup}.  Mirrors {@code Form.initGroup}.  No-op when the
      * page is not a transparency group.
      */
     private void initPageGroup() {
@@ -836,10 +837,19 @@ public class Page extends Dictionary {
             if (savedClip != null) {
                 bg.setClip(savedClip);
             }
+            // The buffer is seeded transparent, so a separable blend over an
+            // empty pixel must reduce to the source colour, not multiply against
+            // 0 and go black.  TRANSPARENT_BACKDROP makes BlendComposite reweight
+            // by backdrop alpha (Cs' = (1-ab)Cs + ab*B(Cb,Cs)); without it a
+            // Multiply group (e.g. 9919.pdf's watch image, pattern_and_CYMK's
+            // shadows) blackens.  978's opaque fills are unaffected (ab=1 -> full
+            // blend, today's behaviour).
             FormDrawCmd.setRenderingIntoPageGroup(true);
+            boolean prevTransparent = BlendComposite.setTransparentBackdrop(true);
             try {
                 shapes.paint(bg);
             } finally {
+                BlendComposite.setTransparentBackdrop(prevTransparent);
                 FormDrawCmd.setRenderingIntoPageGroup(false);
             }
         } finally {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/Page.java
@@ -139,10 +139,11 @@ public class Page extends Dictionary {
     // content into one shared offscreen buffer (seeded transparent) so the page's
     // groups blend against each other before reaching the page backdrop, then
     // composite that buffer over the (white) paper -- pdf.js's "treat non-isolated
-    // as isolated" behaviour.  Default off; broad blast radius (most modern PDFs
-    // carry a page /Group) so opt-in while it is proven on metrics.
+    // as isolated" behaviour.  Default ON, scoped to DeviceCMYK page groups
+    // (isPageGroupBufferCandidate); validated across the CMYK page-group corpus
+    // with no regressions.  Set -Dorg.icepdf.core.pageGroupBuffer=false to opt out.
     private static final boolean PAGE_GROUP_BUFFER =
-            Defs.booleanProperty("org.icepdf.core.pageGroupBuffer", false);
+            Defs.booleanProperty("org.icepdf.core.pageGroupBuffer", true);
 
     public static final Name TYPE = new Name("Page");
     public static final Name ANNOTS_KEY = new Name("Annots");

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
@@ -189,9 +189,9 @@ public final class BlendComposite implements Composite {
         } else if (modeName.equals(LIGHTEN_VALUE)) {
             return new BlendComposite(BlendingMode.LIGHTEN, alpha);
         } else if (modeName.equals(COLOR_DODGE_VALUE)) {
-            return new BlendComposite(BlendingMode.SOFT_DODGE, alpha);
+            return new BlendComposite(BlendingMode.COLOR_DODGE, alpha);
         } else if (modeName.equals(COLOR_BURN_VALUE)) {
-            return new BlendComposite(BlendingMode.SOFT_BURN, alpha);
+            return new BlendComposite(BlendingMode.COLOR_BURN, alpha);
         } else if (modeName.equals(HARD_LIGHT_VALUE)) {
             return new BlendComposite(BlendingMode.HARD_LIGHT, alpha);
         } else if (modeName.equals(SOFT_LIGHT_VALUE)) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
@@ -781,7 +781,13 @@ public final class BlendComposite implements Composite {
                                             255 - ((255 - dst[1]) * (255 - src[1]) >> 7),
                                     dst[2] < 128 ? (dst[2] * src[2]) >> 7 :
                                             255 - ((255 - dst[2]) * (255 - src[2]) >> 7),
-                                    Math.min(255, dst[3])
+                                    // result alpha is the source/backdrop union like every
+                                    // other separable blender; using dst[3] alone dropped the
+                                    // source coverage, so an opaque Overlay group over a
+                                    // transparent backdrop produced zero alpha and vanished
+                                    // (978's Fm5 dark shading -> invisible -> ColorBurn washed
+                                    // the field cyan instead of black).
+                                    Math.min(255, src[3] + dst[3])
                             ); return;
 //                            copy(dst, out); return;
                         }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendComposite.java
@@ -323,20 +323,35 @@ public final class BlendComposite implements Composite {
                     // partial ab -> interpolated (anti-aliased edges, overlap).
                     // `result` holds B(Cb,Cs); reweight the colour in place,
                     // leaving result[3] (the blended alpha).
+                    // colour weight for the backdrop<->blend lerp below.  Normally
+                    // the group constant alpha; inside a group buffer we also fold
+                    // in per-pixel source coverage so a faint (low-alpha) blend
+                    // pixel does not fully overwrite the backdrop.  Ignoring src
+                    // coverage let an Overlay/Multiply of a dark, low-alpha source
+                    // crush an opaque backdrop to black (pattern_and_CYMK shadows).
+                    float colourWeight = alpha;
                     if (transparentBackdrop) {
                         int ab = dstPixel[3];
                         int ia = 255 - ab;
                         result[0] = (srcPixel[0] * ia + result[0] * ab) / 255;
                         result[1] = (srcPixel[1] * ia + result[1] * ab) / 255;
                         result[2] = (srcPixel[2] * ia + result[2] * ab) / 255;
+                        // Interpolate the weight by backdrop opacity so the extremes
+                        // stay exactly as before: over a transparent backdrop (ab=0)
+                        // the source passes through at full coverage (gaps reveal the
+                        // source, unchanged); over an opaque backdrop (ab=255) the
+                        // blend contributes only src[3]/255 (no crush).  An opaque
+                        // source (src[3]=255) yields colourWeight==alpha for any ab,
+                        // so opaque-fill groups (978) are byte-identical.
+                        colourWeight = alpha * (ia + ab * srcPixel[3] / 255f) / 255f;
                     }
 
                     // mixes the result with the opacity
                     dstPixels[x] =
                             ((int) (dstPixel[3] + (result[3] - dstPixel[3]) * alpha) & 0xFF) << 24 |
-                                    ((int) (dstPixel[0] + (result[0] - dstPixel[0]) * alpha) & 0xFF) << 16 |
-                                    ((int) (dstPixel[1] + (result[1] - dstPixel[1]) * alpha) & 0xFF) << 8 |
-                                    (int) (dstPixel[2] + (result[2] - dstPixel[2]) * alpha) & 0xFF;
+                                    ((int) (dstPixel[0] + (result[0] - dstPixel[0]) * colourWeight) & 0xFF) << 16 |
+                                    ((int) (dstPixel[1] + (result[1] - dstPixel[1]) * colourWeight) & 0xFF) << 8 |
+                                    (int) (dstPixel[2] + (result[2] - dstPixel[2]) * colourWeight) & 0xFF;
                 }
                 dstOut.setDataElements(0, y, width, 1, dstPixels);
             }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendingSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendingSpace.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+/**
+ * Supplies the colour-space-specific math for transparency-group compositing.
+ * <p>
+ * The composition <i>flow</i> -- Porter-Duff alpha, the {@code (1-ab)Cs+ab*B}
+ * backdrop weighting, constant-alpha mixing and the &sect;11.4.8 backdrop
+ * removal -- is channel-count-agnostic and lives once in the shared compositor.
+ * Only two things differ between an RGB and a (e.g.) DeviceCMYK group: how a
+ * device pixel maps to/from the working colour channels, and the per-channel
+ * separable blend functions (&sect;11.3.5).  Those are the entire contract of
+ * this strategy, so a new blend space (CMYK, and later spot/DeviceN) is added by
+ * implementing this interface without touching the shared flow -- an RGB change
+ * cannot break CMYK and vice-versa.
+ * <p>
+ * Channel values are doubles in {@code [0,255]} (the 8-bit ink/colour domain;
+ * RGB factored out of the original code in this domain to stay bit-identical, and
+ * CMYK uses the same convention).  A group's content stays in its blend space for
+ * the whole composite; {@link #toSRGB} is applied only once, at the final draw to
+ * the device.
+ *
+ * @see <a href="cmyk-compositing-architecture">GH-501 design notes</a>
+ */
+public interface BlendingSpace {
+
+    /** Number of colour channels (3 for RGB, 4 for CMYK; a value, not hard-coded,
+     *  so spot/DeviceN spaces with N&gt;4 can be added later). */
+    int channelCount();
+
+    /** Unpacks an sRGB device pixel's colour into this space's channels (0..255).
+     *  The pixel's alpha is handled by the flow, not here. */
+    void fromSRGB(int argb, double[] channels);
+
+    /** Packs working colour channels (0..255) plus an 8-bit alpha into an sRGB
+     *  ARGB pixel.  Channels are clamped to [0,255]. */
+    int toSRGB(double[] channels, int alpha);
+
+    /** PDF 32000-1 &sect;11.3.5 separable blend function {@code B(cb, cs)} for a
+     *  single channel, operands and result in {@code [0,255]}. */
+    double separable(BlendComposite.BlendingMode mode, double cb, double cs);
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendingSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/BlendingSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpace.java
@@ -36,15 +36,23 @@ package org.icepdf.core.pobjects.graphics;
  * {@code cb*cs/255 = 0} would wrongly wash it to white.  This is the whole reason a
  * DeviceCMYK group muddied when composited in RGB (GH-501).
  * <p>
- * Device conversion uses the textbook GCR sRGB&harr;CMYK transform, which is
- * exactly invertible for in-gamut colours: {@link #toSRGB}({@link #fromSRGB}(p)) ==
- * p.  That is deliberate -- the isolated group colour {@code Cs} therefore passes
- * through losslessly and <i>only</i> the backdrop interaction (the separable blend
- * against {@code Cb}) changes, keeping this strategy a surgical swap of the blend
- * math rather than a colour shift.  (An ICC-accurate device conversion, and reading
- * the group's <i>true</i> preserved CMYK samples instead of recovering them from
- * sRGB, are the GH-501 Phase 2 follow-ups; see
- * {@code ImageUtility.getCmykSamples}.)
+ * <b>This space must be fed TRUE CMYK ink</b> (the preserved samples from
+ * {@code ImageUtility.getCmykSamples}), not CMYK recovered from sRGB.  The recovery
+ * convenience {@link #fromSRGB} uses a no-black (pure C,M,Y, K=0) transform that
+ * round-trips losslessly, but a verified finding makes clear it is only a stand-in:
+ * subtractive blending of K=0 ink reduces <i>exactly</i> to the additive RGB blend
+ * for every white-preserving mode (Multiply/Screen/Overlay/...), because the
+ * fromSRGB / separable / toSRGB complements cancel.  The black channel is the sole
+ * carrier of genuinely subtractive behaviour, and it cannot be recovered from sRGB
+ * once an image has decoded -- attempting to fabricate it (an earlier GCR
+ * {@code K=1-max(rgb)} variant) shifted {@code pattern_and_CYMK_jpeg.pdf} from its
+ * reference-correct orange to green (Acrobat, Chrome and Firefox all show orange).
+ * <p>
+ * Consequently this strategy is <b>staged, not yet wired</b> into the sRGB-based
+ * {@code FormDrawCmd.composeContribution} path (which stays additive); it becomes
+ * active when the group is composited at the raster level from its preserved CMYK
+ * samples -- the GH-501 Phase 2 raster-renderer step (see the 3a/n finding).  The
+ * {@link #separable} math here is the piece that path consumes.
  *
  * @see RgbBlendingSpace
  * @see BlendingSpace
@@ -62,34 +70,25 @@ public final class CmykBlendingSpace implements BlendingSpace {
     }
 
     /**
-     * sRGB ARGB pixel -> C,M,Y,K ink (0..255) via the GCR transform
-     * {@code K = 1 - max(r,g,b)}, {@code C = (1-r-K)/(1-K)} (and similarly M, Y).
+     * sRGB ARGB pixel -> C,M,Y ink (0..255) with no black generation (K=0):
+     * {@code C = 255 - r} (and similarly M, Y).  Lossless and exactly inverted by
+     * {@link #toSRGB}.  This is a recovery stand-in only -- it carries no real black
+     * channel (see the class note), so blending the result reduces to an additive
+     * RGB blend.  The raster-renderer path supplies true K via the preserved CMYK
+     * samples instead of calling this.
      */
     @Override
     public void fromSRGB(int argb, double[] channels) {
-        double r = ((argb >> 16) & 0xFF) / 255.0;
-        double g = ((argb >> 8) & 0xFF) / 255.0;
-        double b = (argb & 0xFF) / 255.0;
-        double k = 1.0 - Math.max(r, Math.max(g, b));
-        double c, m, y;
-        if (k >= 1.0) {
-            // pure black: no chromatic ink, all key.
-            c = m = y = 0.0;
-        } else {
-            double w = 1.0 - k;
-            c = (1.0 - r - k) / w;
-            m = (1.0 - g - k) / w;
-            y = (1.0 - b - k) / w;
-        }
-        channels[0] = c * 255.0;
-        channels[1] = m * 255.0;
-        channels[2] = y * 255.0;
-        channels[3] = k * 255.0;
+        channels[0] = 255.0 - ((argb >> 16) & 0xFF);
+        channels[1] = 255.0 - ((argb >> 8) & 0xFF);
+        channels[2] = 255.0 - (argb & 0xFF);
+        channels[3] = 0.0;
     }
 
     /**
-     * C,M,Y,K ink (0..255) + 8-bit alpha -> sRGB ARGB, the exact inverse of
-     * {@link #fromSRGB}: {@code r = (1-C)(1-K)} (and similarly g, b).
+     * C,M,Y,K ink (0..255) + 8-bit alpha -> sRGB ARGB: {@code r = (1-C)(1-K)} (and
+     * similarly g, b).  Inverts {@link #fromSRGB} exactly, and is the real sink for
+     * true-sample CMYK (where K is non-zero) at the final convert-to-device step.
      */
     @Override
     public int toSRGB(double[] channels, int alpha) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpace.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+/**
+ * The subtractive (DeviceCMYK) {@link BlendingSpace}: four ink channels and the
+ * PDF 32000-1 &sect;11.3.5 separable blend functions evaluated in CMYK.
+ * <p>
+ * The §11.3.5 blend functions are <i>defined</i> on additive colour values, where
+ * a larger value is a brighter colour.  CMYK is subtractive: a larger value is
+ * <i>more ink</i>, i.e. a darker colour -- the opposite sense.  The spec resolves
+ * this (§11.3.5, note on subtractive spaces) by complementing each colorant before
+ * the blend and complementing the result afterwards.  So a CMYK blend is exactly
+ * the additive blend run on the ink complement:
+ * <pre>
+ *     B_cmyk(cb, cs) = 255 - B_rgb(255 - cb, 255 - cs)
+ * </pre>
+ * which lets this space reuse {@link RgbBlendingSpace}'s already-verified separable
+ * math verbatim instead of re-deriving a parallel set of darkening rules.  A worked
+ * check: {@code Multiply} of full ink over no ink (white) must preserve the ink
+ * (multiply-with-white is identity); the complement form gives
+ * {@code 255 - (0*255/255) = 255}, full ink -- correct, whereas the naive additive
+ * {@code cb*cs/255 = 0} would wrongly wash it to white.  This is the whole reason a
+ * DeviceCMYK group muddied when composited in RGB (GH-501).
+ * <p>
+ * Device conversion uses the textbook GCR sRGB&harr;CMYK transform, which is
+ * exactly invertible for in-gamut colours: {@link #toSRGB}({@link #fromSRGB}(p)) ==
+ * p.  That is deliberate -- the isolated group colour {@code Cs} therefore passes
+ * through losslessly and <i>only</i> the backdrop interaction (the separable blend
+ * against {@code Cb}) changes, keeping this strategy a surgical swap of the blend
+ * math rather than a colour shift.  (An ICC-accurate device conversion, and reading
+ * the group's <i>true</i> preserved CMYK samples instead of recovering them from
+ * sRGB, are the GH-501 Phase 2 follow-ups; see
+ * {@code ImageUtility.getCmykSamples}.)
+ *
+ * @see RgbBlendingSpace
+ * @see BlendingSpace
+ */
+public final class CmykBlendingSpace implements BlendingSpace {
+
+    public static final CmykBlendingSpace INSTANCE = new CmykBlendingSpace();
+
+    private CmykBlendingSpace() {
+    }
+
+    @Override
+    public int channelCount() {
+        return 4;
+    }
+
+    /**
+     * sRGB ARGB pixel -> C,M,Y,K ink (0..255) via the GCR transform
+     * {@code K = 1 - max(r,g,b)}, {@code C = (1-r-K)/(1-K)} (and similarly M, Y).
+     */
+    @Override
+    public void fromSRGB(int argb, double[] channels) {
+        double r = ((argb >> 16) & 0xFF) / 255.0;
+        double g = ((argb >> 8) & 0xFF) / 255.0;
+        double b = (argb & 0xFF) / 255.0;
+        double k = 1.0 - Math.max(r, Math.max(g, b));
+        double c, m, y;
+        if (k >= 1.0) {
+            // pure black: no chromatic ink, all key.
+            c = m = y = 0.0;
+        } else {
+            double w = 1.0 - k;
+            c = (1.0 - r - k) / w;
+            m = (1.0 - g - k) / w;
+            y = (1.0 - b - k) / w;
+        }
+        channels[0] = c * 255.0;
+        channels[1] = m * 255.0;
+        channels[2] = y * 255.0;
+        channels[3] = k * 255.0;
+    }
+
+    /**
+     * C,M,Y,K ink (0..255) + 8-bit alpha -> sRGB ARGB, the exact inverse of
+     * {@link #fromSRGB}: {@code r = (1-C)(1-K)} (and similarly g, b).
+     */
+    @Override
+    public int toSRGB(double[] channels, int alpha) {
+        double c = clamp01(channels[0] / 255.0);
+        double m = clamp01(channels[1] / 255.0);
+        double y = clamp01(channels[2] / 255.0);
+        double k = clamp01(channels[3] / 255.0);
+        int r = channel8((1.0 - c) * (1.0 - k));
+        int g = channel8((1.0 - m) * (1.0 - k));
+        int b = channel8((1.0 - y) * (1.0 - k));
+        return ((alpha & 0xFF) << 24) | (r << 16) | (g << 8) | b;
+    }
+
+    /**
+     * PDF 32000-1 &sect;11.3.5 separable blend in the subtractive domain: the
+     * additive blend ({@link RgbBlendingSpace}) applied to the ink complement, then
+     * complemented back.  Operands and result in {@code [0,255]} ink.
+     */
+    @Override
+    public double separable(BlendComposite.BlendingMode mode, double cb, double cs) {
+        double additive = RgbBlendingSpace.INSTANCE.separable(mode, 255.0 - cb, 255.0 - cs);
+        return 255.0 - additive;
+    }
+
+    private static double clamp01(double v) {
+        return v < 0.0 ? 0.0 : (v > 1.0 ? 1.0 : v);
+    }
+
+    private static int channel8(double unit) {
+        int i = (int) Math.round(unit * 255.0);
+        return i < 0 ? 0 : (i > 255 ? 255 : i);
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositor.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositor.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import org.icepdf.core.pobjects.graphics.RasterOps.IccCmykRasterOp;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+
+/**
+ * Raster-level subtractive compositor for a DeviceCMYK transparency group
+ * (GH-501 Phase 2, step 1).
+ * <p>
+ * The sRGB path in {@code FormDrawCmd.composeContribution} cannot blend a CMYK
+ * group subtractively: once the group's content is decoded to sRGB the black (K)
+ * channel is gone, and recovering CMYK from sRGB collapses straight back to an
+ * additive RGB blend (proven against three reference renderers -- the
+ * sRGB-recovered "subtractive" path fabricated a K channel and shifted
+ * {@code pattern_and_CYMK_jpeg.pdf} orange&rarr;green).  This compositor instead
+ * works from the <b>true</b> preserved CMYK samples
+ * ({@link org.icepdf.core.pobjects.graphics.images.ImageUtility#getCmykSamples}),
+ * so genuine black ink flows into the §11.3.5 blend.
+ * <p>
+ * The flow, per pixel, mirrors {@code composeContribution} but in the ink domain:
+ * <ol>
+ *   <li>source ink {@code Cs} = the true CMYK sample (real K);</li>
+ *   <li>backdrop ink {@code Cb} = the reconstructed page backdrop, recovered from
+ *       sRGB with no black ({@link CmykBlendingSpace#fromSRGB}) -- the backdrop
+ *       came from an additive render, so K=0 is the honest value for it, and the
+ *       fabricated-K hazard never applied to the backdrop, only the source;</li>
+ *   <li>blend {@code B(Cb,Cs)} via {@link CmykBlendingSpace#separable};</li>
+ *   <li>convert the blended ink to sRGB <b>once</b> at the end via
+ *       {@link IccCmykRasterOp} -- the same ICC transform the decoder uses for an
+ *       unblended CMYK image, so a Normal region and a blended region of the same
+ *       image stay colour-consistent.</li>
+ * </ol>
+ * The result is the group's contribution {@code B(Cb,Cs)} at alpha {@code ca*ag},
+ * to be drawn back SRC_OVER over the page (= {@code Cb}), yielding the §11.4.6
+ * result {@code (1-ca*ag)*Cb + ca*ag*B(Cb,Cs)} with no backdrop double-count --
+ * the same draw-back contract as the sRGB path.
+ *
+ * @see CmykBlendingSpace
+ * @see IccCmykRasterOp
+ */
+public final class CmykGroupCompositor {
+
+    private static final CmykBlendingSpace CMYK = CmykBlendingSpace.INSTANCE;
+
+    private CmykGroupCompositor() {
+    }
+
+    /**
+     * Composites a CMYK group contribution at the raster level.  All inputs are
+     * pre-aligned to the {@code w x h} group buffer.
+     *
+     * @param srcInk       interleaved C,M,Y,K ink (length {@code 4*w*h}, 0..255) --
+     *                     the TRUE preserved samples of the group's content.
+     * @param srcAlpha     group coverage {@code ag} per pixel (length {@code w*h},
+     *                     0..255); a pixel with {@code ag==0} contributes nothing.
+     * @param backdropArgb reconstructed page backdrop {@code Cb} (length
+     *                     {@code w*h}, packed ARGB).
+     * @param mode         the group's separable blend mode.
+     * @param ca           the group's constant alpha (0..1).
+     * @param w            buffer width.
+     * @param h            buffer height.
+     * @return the contribution buffer (TYPE_INT_ARGB): colour {@code B(Cb,Cs)} at
+     * alpha {@code ca*ag}, to be drawn back with SRC_OVER.
+     */
+    public static BufferedImage compose(byte[] srcInk, int[] srcAlpha, int[] backdropArgb,
+                                        BlendComposite.BlendingMode mode, float ca,
+                                        int w, int h) {
+        int n = w * h;
+        // Blended ink, interleaved C,M,Y,K -- fed to the ICC convert in one pass.
+        byte[] outInk = new byte[n * 4];
+        int[] outAlpha = new int[n];
+        double[] cs = new double[4], cb = new double[4];
+        for (int i = 0; i < n; i++) {
+            int ag = srcAlpha[i] & 0xFF;
+            if (ag == 0) {
+                continue; // no group contribution -> stays transparent, page shows through
+            }
+            int p = i * 4;
+            cs[0] = srcInk[p] & 0xFF;
+            cs[1] = srcInk[p + 1] & 0xFF;
+            cs[2] = srcInk[p + 2] & 0xFF;
+            cs[3] = srcInk[p + 3] & 0xFF;
+            CMYK.fromSRGB(backdropArgb[i], cb); // Cb ink, K=0 (honest for an sRGB backdrop)
+            outInk[p] = clampInk(CMYK.separable(mode, cb[0], cs[0]));
+            outInk[p + 1] = clampInk(CMYK.separable(mode, cb[1], cs[1]));
+            outInk[p + 2] = clampInk(CMYK.separable(mode, cb[2], cs[2]));
+            outInk[p + 3] = clampInk(CMYK.separable(mode, cb[3], cs[3]));
+            int a = Math.round(ca * ag);
+            outAlpha[i] = a < 0 ? 0 : (a > 255 ? 255 : a);
+        }
+        // Convert the blended ink to sRGB ONCE, through the decoder's ICC transform.
+        BufferedImage rgb = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        Raster srcRaster = Raster.createInterleavedRaster(
+                new DataBufferByte(outInk, outInk.length), w, h, w * 4, 4,
+                new int[]{0, 1, 2, 3}, null);
+        new IccCmykRasterOp(null).filter(srcRaster, rgb.getRaster());
+        // Overlay the group's own alpha (ICC convert emits opaque 0xff): the
+        // contribution carries ca*ag, so SRC_OVER over the page gives §11.4.6.
+        int[] argb = ((java.awt.image.DataBufferInt) rgb.getRaster().getDataBuffer()).getData();
+        for (int i = 0; i < n; i++) {
+            argb[i] = (outAlpha[i] << 24) | (argb[i] & 0x00FFFFFF);
+        }
+        return rgb;
+    }
+
+    private static byte clampInk(double v) {
+        int i = (int) Math.round(v);
+        return (byte) (i < 0 ? 0 : (i > 255 ? 255 : i));
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositor.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the
@@ -20,7 +20,6 @@ import org.icepdf.core.pobjects.graphics.RasterOps.IccCmykRasterOp;
 import java.awt.image.BufferedImage;
 import java.awt.image.DataBufferByte;
 import java.awt.image.Raster;
-import java.awt.image.WritableRaster;
 
 /**
  * Raster-level subtractive compositor for a DeviceCMYK transparency group

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/RgbBlendingSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/RgbBlendingSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/RgbBlendingSpace.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/RgbBlendingSpace.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+/**
+ * The additive (sRGB) {@link BlendingSpace}: three channels, identity device
+ * conversion, and the PDF 32000-1 &sect;11.3.5 separable blend functions
+ * evaluated directly on the RGB channels.  This is the behaviour the transparency
+ * compositor has always used; it is factored out here unchanged so a DeviceCMYK
+ * (subtractive) space can be added alongside it without forking the shared flow.
+ */
+public final class RgbBlendingSpace implements BlendingSpace {
+
+    public static final RgbBlendingSpace INSTANCE = new RgbBlendingSpace();
+
+    private RgbBlendingSpace() {
+    }
+
+    @Override
+    public int channelCount() {
+        return 3;
+    }
+
+    @Override
+    public void fromSRGB(int argb, double[] channels) {
+        channels[0] = (argb >> 16) & 0xFF;
+        channels[1] = (argb >> 8) & 0xFF;
+        channels[2] = argb & 0xFF;
+    }
+
+    @Override
+    public int toSRGB(double[] channels, int alpha) {
+        int r = channel8(channels[0]);
+        int g = channel8(channels[1]);
+        int b = channel8(channels[2]);
+        return ((alpha & 0xFF) << 24) | (r << 16) | (g << 8) | b;
+    }
+
+    private static int channel8(double v) {
+        int i = (int) Math.round(v);
+        return i < 0 ? 0 : (i > 255 ? 255 : i);
+    }
+
+    /**
+     * PDF 32000-1 &sect;11.3.5 separable blend functions {@code B(cb, cs)},
+     * operands and result in {@code [0,255]}.  The 0..255 domain (rather than the
+     * normalised [0,1] the interface notionally prefers) is deliberate: it copies
+     * the prior {@code FormDrawCmd.separableBlend} arithmetic verbatim so the
+     * factored-out path is provably bit-for-bit identical (normalising introduced
+     * a handful of &plusmn;1 ulp rounding differences). A subtractive CMYK space
+     * uses the same 0..255 ink convention.
+     */
+    @Override
+    public double separable(BlendComposite.BlendingMode mode, double cb, double cs) {
+        switch (mode) {
+            case MULTIPLY:
+                return cb * cs / 255.0;
+            case SCREEN:
+                return cb + cs - cb * cs / 255.0;
+            case OVERLAY:
+                return hardLight(cs, cb);          // Overlay(b,s) = HardLight(s,b)
+            case DARKEN:
+                return Math.min(cb, cs);
+            case LIGHTEN:
+                return Math.max(cb, cs);
+            case COLOR_DODGE:
+                if (cb == 0) return 0;
+                if (cs >= 255) return 255;
+                return Math.min(255.0, cb * 255.0 / (255.0 - cs));
+            case COLOR_BURN:
+                if (cb >= 255) return 255;
+                if (cs == 0) return 0;
+                return 255.0 - Math.min(255.0, (255.0 - cb) * 255.0 / cs);
+            case HARD_LIGHT:
+                return hardLight(cb, cs);
+            case SOFT_LIGHT: {
+                double b = cb / 255.0, s = cs / 255.0;
+                double d = b <= 0.25 ? ((16 * b - 12) * b + 4) * b : Math.sqrt(b);
+                double r = s <= 0.5 ? b - (1 - 2 * s) * b * (1 - b) : b + (2 * s - 1) * (d - b);
+                return r * 255.0;
+            }
+            case DIFFERENCE:
+                return Math.abs(cb - cs);
+            case EXCLUSION:
+                return cb + cs - 2 * cb * cs / 255.0;
+            default:
+                return cs;                          // Normal / Compatible
+        }
+    }
+
+    private static double hardLight(double cb, double cs) {
+        // HardLight(Cb,Cs) = Multiply(Cb,2Cs) if Cs<=.5 else Screen(Cb,2Cs-1)
+        if (cs <= 127.5) {
+            return cb * (2 * cs) / 255.0;
+        }
+        double s2 = 2 * cs - 255.0;
+        return cb + s2 - cb * s2 / 255.0;
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
@@ -68,6 +68,10 @@ public class Shapes {
     // the collection of objects listening for page paint events
     private Page parentPage;
 
+    // page-level transparency group (/Group on the page dict), null when the page
+    // is not a transparency group.  Consumed by the page-group buffer compositor.
+    private TransparencyGroup pageGroup;
+
     // text extraction data structure
     private final PageText pageText = new PageText();
 
@@ -94,6 +98,18 @@ public class Shapes {
 
     public void setPageParent(Page parent) {
         parentPage = parent;
+    }
+
+    /**
+     * The page-level transparency group ({@code /Group} on the page dictionary),
+     * or null when the page is not itself a transparency group.
+     */
+    public TransparencyGroup getPageGroup() {
+        return pageGroup;
+    }
+
+    public void setPageGroup(TransparencyGroup pageGroup) {
+        this.pageGroup = pageGroup;
     }
 
     public void add(DrawCmd drawCmd){

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/Shapes.java
@@ -174,13 +174,30 @@ public class Shapes {
      * and clip; this captures {@code base} from it exactly like {@link #paint}.
      */
     public void paintBackdrop(Graphics2D g, int uptoIndex) throws InterruptedException {
+        paintBackdrop(g, uptoIndex, false);
+    }
+
+    /**
+     * As {@link #paintBackdrop(Graphics2D, int)}, but when {@code skipFormGroups}
+     * is true the prior {@link FormDrawCmd} commands (sibling transparency groups)
+     * are NOT replayed.  This yields the page backdrop as it stands ignoring the
+     * other groups in the same transparency stack -- used by the §10 decline gate
+     * so the "is the backdrop blank?" decision is identical for every group in the
+     * stack (otherwise an earlier group's painted content darkens later groups'
+     * backdrops, making the per-group decision order-dependent).
+     */
+    public void paintBackdrop(Graphics2D g, int uptoIndex, boolean skipFormGroups) throws InterruptedException {
         AffineTransform base = new AffineTransform(g.getTransform());
         Shape clip = g.getClip();
         PaintTimer paintTimer = new PaintTimer();
         Shape previousShape = null;
         int max = Math.min(uptoIndex, shapes.size());
         for (int i = 0; i < max; i++) {
-            previousShape = shapes.get(i).paintOperand(g, parentPage,
+            DrawCmd cmd = shapes.get(i);
+            if (skipFormGroups && cmd instanceof FormDrawCmd) {
+                continue;
+            }
+            previousShape = cmd.paintOperand(g, parentPage,
                     previousShape, clip, base, optionalContentState, paintAlpha, paintTimer);
         }
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TransparencyGroup.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TransparencyGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TransparencyGroup.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/TransparencyGroup.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import org.icepdf.core.pobjects.Name;
+
+/**
+ * Immutable description of a transparency group's attributes (PDF §11.6.6).
+ * Used to record the page-level {@code /Group} entry -- a group attribute on the
+ * page dictionary that ICEpdf otherwise discards -- so a compositor can decide
+ * whether the page content should be rendered into a shared transparency-group
+ * buffer rather than painted straight onto the page backdrop.
+ *
+ * @since 7.5
+ */
+public class TransparencyGroup {
+
+    private final boolean isolated;
+    private final boolean knockout;
+    private final Name colorSpace;
+
+    public TransparencyGroup(boolean isolated, boolean knockout, Name colorSpace) {
+        this.isolated = isolated;
+        this.knockout = knockout;
+        this.colorSpace = colorSpace;
+    }
+
+    /** Transparency group {@code /I} (isolated) flag. */
+    public boolean isIsolated() {
+        return isolated;
+    }
+
+    /** Transparency group {@code /K} (knockout) flag. */
+    public boolean isKnockout() {
+        return knockout;
+    }
+
+    /** Group colour-space name ({@code /CS}), may be null. */
+    public Name getColorSpace() {
+        return colorSpace;
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -382,15 +382,24 @@ public class FormDrawCmd extends AbstractDrawCmd {
      * result {@code (1-ca*ag)*Cb + ca*ag*B(Cb,Cs)} -- the group's blend and
      * constant alpha applied to its real backdrop, no double-count.
      */
+    // The colour-space math for group compositing (GH-501).  The composition flow
+    // below is channel-count-agnostic; swapping this strategy is how a DeviceCMYK
+    // group will blend subtractively without forking the flow.  Defaults to the
+    // additive sRGB behaviour the compositor has always used.
+    private static final BlendingSpace blendingSpace = RgbBlendingSpace.INSTANCE;
+
     private static BufferedImage composeContribution(BufferedImage isolated, BufferedImage backdrop,
                                                      Name blend, float ca) {
-        int mode = blendMode(blend);
+        BlendingSpace space = blendingSpace;
+        BlendComposite.BlendingMode mode = toBlendingMode(blend);
         int w = isolated.getWidth(), h = isolated.getHeight();
+        int n = space.channelCount();
         // Reuse the isolated buffer as the output (the contribution replaces it in
         // place) instead of allocating a third full-page buffer per group; the
         // backdrop row is the only other input and is read before the matching
         // isolated pixel is overwritten.
         int[] is = new int[w], b0 = new int[w];
+        double[] cs = new double[n], cb = new double[n], out = new double[n];
         for (int yy = 0; yy < h; yy++) {
             isolated.getRGB(0, yy, w, 1, is, 0, w);
             backdrop.getRGB(0, yy, w, 1, b0, 0, w);
@@ -401,77 +410,36 @@ public class FormDrawCmd extends AbstractDrawCmd {
                     continue;
                 }
                 int outAlpha = (int) Math.round(ca * ag);
-                int c = 0;
-                for (int s = 0; s < 24; s += 8) {
-                    double cs = (is[xx] >> s) & 0xFF;       // isolated group colour
-                    double cb = (b0[xx] >> s) & 0xFF;       // backdrop colour
-                    int v = (int) Math.round(separableBlend(mode, cb, cs));  // B(Cb, Cs)
-                    c |= (v < 0 ? 0 : v > 255 ? 255 : v) << s;
+                if (outAlpha < 0) outAlpha = 0; else if (outAlpha > 255) outAlpha = 255;
+                space.fromSRGB(is[xx], cs);   // isolated group colour Cs
+                space.fromSRGB(b0[xx], cb);   // real backdrop colour Cb
+                for (int c = 0; c < n; c++) {
+                    out[c] = space.separable(mode, cb[c], cs[c]);   // B(Cb, Cs)
                 }
-                is[xx] = ((outAlpha < 0 ? 0 : outAlpha > 255 ? 255 : outAlpha) << 24) | c;
+                is[xx] = space.toSRGB(out, outAlpha);
             }
             isolated.setRGB(0, yy, w, 1, is, 0, w);
         }
         return isolated;
     }
 
-    // separable blend mode codes
-    private static final int B_NORMAL = 0, B_MULTIPLY = 1, B_SCREEN = 2, B_OVERLAY = 3,
-            B_DARKEN = 4, B_LIGHTEN = 5, B_COLOR_DODGE = 6, B_COLOR_BURN = 7,
-            B_HARD_LIGHT = 8, B_SOFT_LIGHT = 9, B_DIFFERENCE = 10, B_EXCLUSION = 11;
-
-    private static int blendMode(Name blend) {
-        if (blend == null) return B_NORMAL;
-        if (BlendComposite.MULTIPLY_VALUE.equals(blend)) return B_MULTIPLY;
-        if (BlendComposite.SCREEN_VALUE.equals(blend)) return B_SCREEN;
-        if (BlendComposite.OVERLAY_VALUE.equals(blend)) return B_OVERLAY;
-        if (BlendComposite.DARKEN_VALUE.equals(blend)) return B_DARKEN;
-        if (BlendComposite.LIGHTEN_VALUE.equals(blend)) return B_LIGHTEN;
-        if (BlendComposite.COLOR_DODGE_VALUE.equals(blend)) return B_COLOR_DODGE;
-        if (BlendComposite.COLOR_BURN_VALUE.equals(blend)) return B_COLOR_BURN;
-        if (BlendComposite.HARD_LIGHT_VALUE.equals(blend)) return B_HARD_LIGHT;
-        if (BlendComposite.SOFT_LIGHT_VALUE.equals(blend)) return B_SOFT_LIGHT;
-        if (BlendComposite.DIFFERENCE_VALUE.equals(blend)) return B_DIFFERENCE;
-        if (BlendComposite.EXCLUSION_VALUE.equals(blend)) return B_EXCLUSION;
-        return B_NORMAL;
-    }
-
-    /** PDF 32000-1 §11.3.5 separable blend functions B(Cb, Cs), channels 0..255. */
-    private static double separableBlend(int mode, double cb, double cs) {
-        switch (mode) {
-            case B_MULTIPLY: return cb * cs / 255.0;
-            case B_SCREEN: return cb + cs - cb * cs / 255.0;
-            case B_OVERLAY: return hardLight(cs, cb);          // Overlay(b,s)=HardLight(s,b)
-            case B_DARKEN: return Math.min(cb, cs);
-            case B_LIGHTEN: return Math.max(cb, cs);
-            case B_COLOR_DODGE:
-                if (cb == 0) return 0;
-                if (cs >= 255) return 255;
-                return Math.min(255.0, cb * 255.0 / (255.0 - cs));
-            case B_COLOR_BURN:
-                if (cb >= 255) return 255;
-                if (cs == 0) return 0;
-                return 255.0 - Math.min(255.0, (255.0 - cb) * 255.0 / cs);
-            case B_HARD_LIGHT: return hardLight(cb, cs);
-            case B_SOFT_LIGHT: {
-                double b = cb / 255.0, s = cs / 255.0;
-                double d = b <= 0.25 ? ((16 * b - 12) * b + 4) * b : Math.sqrt(b);
-                double r = s <= 0.5 ? b - (1 - 2 * s) * b * (1 - b) : b + (2 * s - 1) * (d - b);
-                return r * 255.0;
-            }
-            case B_DIFFERENCE: return Math.abs(cb - cs);
-            case B_EXCLUSION: return cb + cs - 2 * cb * cs / 255.0;
-            default: return cs;                                // Normal/Compatible
-        }
-    }
-
-    private static double hardLight(double cb, double cs) {
-        // HardLight(Cb,Cs) = Multiply(Cb,2Cs) if Cs<=.5 else Screen(Cb,2Cs-1)
-        if (cs <= 127.5) {
-            return cb * (2 * cs) / 255.0;
-        }
-        double s2 = 2 * cs - 255.0;
-        return cb + s2 - cb * s2 / 255.0;
+    /** Maps a PDF blend-mode {@link Name} to the {@link BlendComposite.BlendingMode}
+     *  the {@link BlendingSpace} understands; only the separable modes appear on a
+     *  transparency group, anything else falls back to Normal. */
+    private static BlendComposite.BlendingMode toBlendingMode(Name blend) {
+        if (blend == null) return BlendComposite.BlendingMode.NORMAL;
+        if (BlendComposite.MULTIPLY_VALUE.equals(blend)) return BlendComposite.BlendingMode.MULTIPLY;
+        if (BlendComposite.SCREEN_VALUE.equals(blend)) return BlendComposite.BlendingMode.SCREEN;
+        if (BlendComposite.OVERLAY_VALUE.equals(blend)) return BlendComposite.BlendingMode.OVERLAY;
+        if (BlendComposite.DARKEN_VALUE.equals(blend)) return BlendComposite.BlendingMode.DARKEN;
+        if (BlendComposite.LIGHTEN_VALUE.equals(blend)) return BlendComposite.BlendingMode.LIGHTEN;
+        if (BlendComposite.COLOR_DODGE_VALUE.equals(blend)) return BlendComposite.BlendingMode.COLOR_DODGE;
+        if (BlendComposite.COLOR_BURN_VALUE.equals(blend)) return BlendComposite.BlendingMode.COLOR_BURN;
+        if (BlendComposite.HARD_LIGHT_VALUE.equals(blend)) return BlendComposite.BlendingMode.HARD_LIGHT;
+        if (BlendComposite.SOFT_LIGHT_VALUE.equals(blend)) return BlendComposite.BlendingMode.SOFT_LIGHT;
+        if (BlendComposite.DIFFERENCE_VALUE.equals(blend)) return BlendComposite.BlendingMode.DIFFERENCE;
+        if (BlendComposite.EXCLUSION_VALUE.equals(blend)) return BlendComposite.BlendingMode.EXCLUSION;
+        return BlendComposite.BlendingMode.NORMAL;
     }
 
     private BufferedImage applyMask(Page parentPage, BufferedImage xFormBuffer, SoftMask softMask, SoftMask gsSoftMask,

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -300,6 +300,17 @@ public class FormDrawCmd extends AbstractDrawCmd {
      * readback required.  Returns null if a backdrop can't be built.
      */
     private BufferedImage captureBackdrop(Graphics2D g, AffineTransform base, int w, int h) {
+        return captureBackdrop(g, base, w, h, false);
+    }
+
+    /**
+     * As {@link #captureBackdrop(Graphics2D, AffineTransform, int, int)}, but when
+     * {@code skipFormGroups} is true the sibling transparency groups are excluded
+     * from the replay (see {@link Shapes#paintBackdrop(Graphics2D, int, boolean)}).
+     * Used by the §10 decline gate to evaluate the true page backdrop independent
+     * of the other groups in the same stack.
+     */
+    private BufferedImage captureBackdrop(Graphics2D g, AffineTransform base, int w, int h, boolean skipFormGroups) {
         if (capturingBackdrop.get() || backdropShapes == null || w <= 0 || h <= 0) {
             return null;
         }
@@ -327,7 +338,7 @@ public class FormDrawCmd extends AbstractDrawCmd {
             b.concatenate(g.getTransform().createInverse());
             b.concatenate(base);
             bg.setTransform(b);
-            backdropShapes.paintBackdrop(bg, backdropIndex);
+            backdropShapes.paintBackdrop(bg, backdropIndex, skipFormGroups);
             bg.dispose();
             return backdrop;
         } catch (Exception e) {
@@ -388,8 +399,8 @@ public class FormDrawCmd extends AbstractDrawCmd {
         float caRaw = xForm.getExtGState() != null ? xForm.getExtGState().getNonStrokingAlphConstant() : -1f;
         float ca = (caRaw < 0f || caRaw > 1f) ? 1f : caRaw;
         // Decline §10 only for the precise case it destroys: an OPAQUE lightening
-        // group over an effectively blank (white) reconstructed backdrop.  Such a
-        // blend collapses B(white,Cs) -> white (ColorDodge/Screen/Overlay/ColorBurn/
+        // group over an effectively blank (white) page backdrop.  Such a blend
+        // collapses B(white,Cs) -> white (ColorDodge/Screen/Overlay/ColorBurn/
         // Lighten), erasing fully-opaque content -- 978-9-7315-0059-9_1.pdf is an
         // all-CMYK stack of exactly these.  Falling back to the direct blended path
         // restores the geometry.  Translucent lightening groups (ca < 1, e.g.
@@ -397,10 +408,25 @@ public class FormDrawCmd extends AbstractDrawCmd {
         // §10 -- it renders their soft pastel result correctly, and declining would
         // turn them into harsh dark halos.  Darkening/Normal groups and groups over
         // genuine backdrop content are likewise unaffected.
-        if (ca >= 0.99f && isWhiteWashingBlend(blend) && isBlankBackdrop(backdrop)) {
-            isolated.flush();
-            backdrop.flush();
-            return null;
+        //
+        // The blank test uses a backdrop that EXCLUDES the sibling transparency
+        // groups (skipFormGroups): every group in the same stack then sees the
+        // same true page backdrop, so the decision is stack-wide and consistent
+        // rather than order-dependent.  Without this, an earlier group's painted
+        // rings darken later groups' backdrops below the blank threshold, so those
+        // re-engage §10 and wash out (978 recovers only partially).
+        if (ca >= 0.99f && isWhiteWashingBlend(blend)) {
+            BufferedImage gateBackdrop =
+                    captureBackdrop(g, base, isolated.getWidth(), isolated.getHeight(), true);
+            boolean blankPage = gateBackdrop == null || isBlankBackdrop(gateBackdrop);
+            if (gateBackdrop != null) {
+                gateBackdrop.flush();
+            }
+            if (blankPage) {
+                isolated.flush();
+                backdrop.flush();
+                return null;
+            }
         }
         // True-ink subtractive path when CMYK samples were captured; otherwise the
         // additive sRGB path (unchanged for RGB/ICC groups and any CMYK group whose

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -71,6 +71,12 @@ public class FormDrawCmd extends AbstractDrawCmd {
     public static int MAX_SCALED_FORM_SIZE =
             Defs.sysPropertyInt("org.icepdf.core.maxScaledFormSize", 16384);
 
+    // GH-501 step 2: raster-level subtractive compositing of DeviceCMYK groups from
+    // true preserved samples.  On by default; -Dorg.icepdf.core.cmyk.subtractive=false
+    // forces the additive sRGB path (A/B comparison and safety kill-switch).
+    private static final boolean cmykSubtractiveEnabled =
+            Defs.sysPropertyBoolean("org.icepdf.core.cmyk.subtractive", true);
+
     static {
         // decide if large images will be scaled
         disableXObjectSMask =
@@ -356,11 +362,20 @@ public class FormDrawCmd extends AbstractDrawCmd {
     private BufferedImage compositeOverBackdrop(Page parentPage, Form xForm, RenderingHints hints,
                                                 boolean normalBM, Graphics2D g, AffineTransform base) {
         boolean prevBackdrop = BlendComposite.setTransparentBackdrop(true);
+        // GH-501 step 2: for a DeviceCMYK group, preserve true CMYK samples and
+        // capture them aligned to the group buffer so the blend can run
+        // subtractively from real ink instead of the lossy sRGB.
+        boolean cmykGroup = cmykSubtractiveEnabled && isCmykGroup(xForm);
+        boolean prevPreserve = cmykGroup && ImageUtility.setPreserveCmyk(true);
+        capturedInk = null;
         BufferedImage isolated;
         try {
-            isolated = createBufferXObject(parentPage, xForm, null, hints, normalBM);
+            isolated = createBufferXObject(parentPage, xForm, null, hints, normalBM, cmykGroup);
         } finally {
             BlendComposite.setTransparentBackdrop(prevBackdrop);
+            if (cmykGroup) {
+                ImageUtility.setPreserveCmyk(prevPreserve);
+            }
         }
         BufferedImage backdrop = captureBackdrop(g, base, isolated.getWidth(), isolated.getHeight());
         if (backdrop == null) {
@@ -369,9 +384,74 @@ public class FormDrawCmd extends AbstractDrawCmd {
         Name blend = xForm.getExtGState() != null ? xForm.getExtGState().getBlendingMode() : null;
         float caRaw = xForm.getExtGState() != null ? xForm.getExtGState().getNonStrokingAlphConstant() : -1f;
         float ca = (caRaw < 0f || caRaw > 1f) ? 1f : caRaw;
-        BufferedImage result = composeContribution(isolated, backdrop, blend, ca);
-        backdrop.flush(); // transient -- contribution is now in the isolated buffer
+        // True-ink subtractive path when CMYK samples were captured; otherwise the
+        // additive sRGB path (unchanged for RGB/ICC groups and any CMYK group whose
+        // image decoded before preservation was enabled).
+        BufferedImage result = (capturedInk != null && capturedInk.isCaptured())
+                ? composeCmykContribution(isolated, capturedInk, backdrop, blend, ca)
+                : composeContribution(isolated, backdrop, blend, ca);
+        backdrop.flush(); // transient -- contribution is now in the result buffer
         return result;
+    }
+
+    /** A DeviceCMYK transparency group (the raster-level subtractive path's scope;
+     *  ICCBased-CMYK groups are left to the additive path for now). */
+    private static boolean isCmykGroup(Form xForm) {
+        if (xForm.getGroup() == null) {
+            return false;
+        }
+        Object cs = xForm.getLibrary().getObject(xForm.getGroup(), new Name("CS"));
+        return cs instanceof Name && ((Name) cs).equals(DeviceCMYK.DEVICECMYK_KEY);
+    }
+
+    /**
+     * §11.3.5 subtractive compositing from TRUE CMYK ink (GH-501 step 2).  Builds
+     * the per-pixel source ink from the captured samples where a CMYK image landed
+     * (the real K), falling back to the sRGB-recovered pure-CMY ink elsewhere (K=0,
+     * which blends identically to the additive path), then hands off to
+     * {@link CmykGroupCompositor}.  Returns the group contribution to draw back
+     * SRC_OVER -- the same contract as {@link #composeContribution}.
+     */
+    // GH-501 step 2 diagnostic: number of groups composited via the true-ink
+    // subtractive path (so a test can confirm the path engaged).
+    public static volatile int cmykSubtractiveComposites = 0;
+
+    private BufferedImage composeCmykContribution(BufferedImage isolated, ImageUtility.CmykInkSink sink,
+                                                  BufferedImage backdrop, Name blend, float ca) {
+        cmykSubtractiveComposites++;
+        int w = isolated.getWidth(), h = isolated.getHeight(), n = w * h;
+        byte[] srcInk = new byte[n * 4];
+        int[] srcAlpha = new int[n];
+        int[] backdropArgb = new int[n];
+        int[] isoRow = new int[w];
+        int[] bRow = new int[w];
+        java.awt.image.WritableRaster ink = sink.getInk();
+        java.awt.image.WritableRaster cov = sink.getCoverage();
+        for (int yy = 0; yy < h; yy++) {
+            isolated.getRGB(0, yy, w, 1, isoRow, 0, w);
+            backdrop.getRGB(0, yy, w, 1, bRow, 0, w);
+            for (int xx = 0; xx < w; xx++) {
+                int i = yy * w + xx;
+                int argb = isoRow[xx];
+                srcAlpha[i] = argb >>> 24;
+                backdropArgb[i] = bRow[xx];
+                int p = i * 4;
+                if ((cov.getSample(xx, yy, 0) & 0xFF) > 127) {
+                    srcInk[p] = (byte) ink.getSample(xx, yy, 0);
+                    srcInk[p + 1] = (byte) ink.getSample(xx, yy, 1);
+                    srcInk[p + 2] = (byte) ink.getSample(xx, yy, 2);
+                    srcInk[p + 3] = (byte) ink.getSample(xx, yy, 3);
+                } else {
+                    // no captured ink here -> sRGB-recovered pure-CMY (K=0)
+                    srcInk[p] = (byte) (255 - ((argb >> 16) & 0xFF));
+                    srcInk[p + 1] = (byte) (255 - ((argb >> 8) & 0xFF));
+                    srcInk[p + 2] = (byte) (255 - (argb & 0xFF));
+                    srcInk[p + 3] = 0;
+                }
+            }
+        }
+        return CmykGroupCompositor.compose(srcInk, srcAlpha, backdropArgb,
+                toBlendingMode(blend), ca, w, h);
     }
 
     /**
@@ -486,6 +566,17 @@ public class FormDrawCmd extends AbstractDrawCmd {
      */
     private BufferedImage createBufferXObject(Page parentPage, Form xForm, SoftMask softMask,
                                               RenderingHints renderingHints, boolean isMask) {
+        return createBufferXObject(parentPage, xForm, softMask, renderingHints, isMask, false);
+    }
+
+    // GH-501 step 2: the ink sink captured during the most recent capturing
+    // createBufferXObject call (true CMYK samples blitted aligned to the group
+    // buffer), consumed by compositeOverBackdrop for subtractive compositing.
+    private ImageUtility.CmykInkSink capturedInk;
+
+    private BufferedImage createBufferXObject(Page parentPage, Form xForm, SoftMask softMask,
+                                              RenderingHints renderingHints, boolean isMask,
+                                              boolean captureCmykInk) {
         Rectangle2D bBox = xForm.getBBox();
         int width = (int) bBox.getWidth();
         int height = (int) bBox.getHeight();
@@ -606,7 +697,16 @@ public class FormDrawCmd extends AbstractDrawCmd {
                     canvas.translate(-x, -y);
                     canvas.setClip(bBox.getBounds2D());
                 }
-                xFormShapes.paint(canvas);
+                if (captureCmykInk) {
+                    ImageUtility.beginCmykInkCapture(bufferWidth, bufferHeight);
+                }
+                try {
+                    xFormShapes.paint(canvas);
+                } finally {
+                    if (captureCmykInk) {
+                        capturedInk = ImageUtility.endCmykInkCapture();
+                    }
+                }
                 xFormShapes.setPageParent(null);
             }
         } catch (InterruptedException e) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -180,7 +180,24 @@ public class FormDrawCmd extends AbstractDrawCmd {
             boolean previousTransparentBackdrop = isolatedGroup
                     && BlendComposite.setTransparentBackdrop(true);
             try {
-                if (!hasMask && !annotationAppearance.get() && !renderingIntoPageGroup.get()
+                // Inside the page-group buffer §10 is normally bypassed so a
+                // separable (non-Normal) group blends against the live accumulating
+                // buffer.  But a NON-isolated NORMAL group has no blend to interact
+                // with the backdrop at draw-back, so rendering it isolated (over the
+                // transparent seed) yields its bare, un-composited content -- a light
+                // gradient that then washes the page (P100002589 turtle divider band,
+                // forms 46/58).  Such groups still need §10's backdrop-aware
+                // compositing, so keep it for Normal blends even inside the buffer.
+                // Only a separable (non-Normal) group blend interacts with the
+                // backdrop at draw-back (its BlendComposite reads the accumulated
+                // buffer as the blend destination); for those the §10 reconstruction
+                // is redundant inside the page-group buffer and is bypassed.  A
+                // Normal / no-blend group draws back with AlphaComposite, which just
+                // overlays its isolated content -- so it still needs §10's real
+                // backdrop compositing or it washes the page (turtle forms 46/58).
+                boolean separableGroupBlend = g.getComposite() instanceof BlendComposite;
+                boolean pageGroupBypass = renderingIntoPageGroup.get() && separableGroupBlend;
+                if (!hasMask && !annotationAppearance.get() && !pageGroupBypass
                         && backdropShapes != null
                         && isBackdropCompositeCandidate(xForm)) {
                     // §10 backdrop-aware compositing: render the group over its

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -186,9 +186,12 @@ public class FormDrawCmd extends AbstractDrawCmd {
                     // real page backdrop (reconstructed by replaying the stack),
                     // then remove the backdrop so the page is not composited
                     // twice.  Replaces the legacy white-fill backdrop proxy.
+                    // Returns null when it declines (blank/white backdrop -- see
+                    // isBlankBackdrop); fall back to the direct blended path.
                     xFormBuffer = compositeOverBackdrop(parentPage, xForm, renderingHints, normalBM, g, base);
                     usedBackdropComposite = xFormBuffer != null;
-                } else {
+                }
+                if (xFormBuffer == null) {
                     xFormBuffer = createBufferXObject(parentPage, xForm, null, renderingHints, normalBM);
                 }
             } finally {
@@ -384,6 +387,21 @@ public class FormDrawCmd extends AbstractDrawCmd {
         Name blend = xForm.getExtGState() != null ? xForm.getExtGState().getBlendingMode() : null;
         float caRaw = xForm.getExtGState() != null ? xForm.getExtGState().getNonStrokingAlphConstant() : -1f;
         float ca = (caRaw < 0f || caRaw > 1f) ? 1f : caRaw;
+        // Decline §10 only for the precise case it destroys: an OPAQUE lightening
+        // group over an effectively blank (white) reconstructed backdrop.  Such a
+        // blend collapses B(white,Cs) -> white (ColorDodge/Screen/Overlay/ColorBurn/
+        // Lighten), erasing fully-opaque content -- 978-9-7315-0059-9_1.pdf is an
+        // all-CMYK stack of exactly these.  Falling back to the direct blended path
+        // restores the geometry.  Translucent lightening groups (ca < 1, e.g.
+        // transparency_design.pdf's Overlay/ColorDodge at ca .5-.71) are left to
+        // §10 -- it renders their soft pastel result correctly, and declining would
+        // turn them into harsh dark halos.  Darkening/Normal groups and groups over
+        // genuine backdrop content are likewise unaffected.
+        if (ca >= 0.99f && isWhiteWashingBlend(blend) && isBlankBackdrop(backdrop)) {
+            isolated.flush();
+            backdrop.flush();
+            return null;
+        }
         // True-ink subtractive path when CMYK samples were captured; otherwise the
         // additive sRGB path (unchanged for RGB/ICC groups and any CMYK group whose
         // image decoded before preservation was enabled).
@@ -392,6 +410,50 @@ public class FormDrawCmd extends AbstractDrawCmd {
                 : composeContribution(isolated, backdrop, blend, ca);
         backdrop.flush(); // transient -- contribution is now in the result buffer
         return result;
+    }
+
+    // A reconstructed backdrop whose mean luminance is at/above this (0-255) is
+    // treated as effectively blank white paper -- there is no meaningful content
+    // behind the group to composite against, and a lightening blend over it would
+    // only wash the group out.  Mean luminance (not a non-white pixel count) is
+    // used deliberately: it stays near-white as sparse group content accumulates
+    // into later groups' backdrops, so the decline is stable across the stack
+    // rather than order-dependent.  A genuine colour/gradient backdrop sits far
+    // below this.
+    private static final double BLANK_BACKDROP_MIN_MEAN_LUM =
+            Defs.doubleProperty("org.icepdf.core.blankBackdropMeanLum", 245d);
+
+    /** True when {@code backdrop} is effectively uniform white paper (mean
+     *  luminance at/above {@link #BLANK_BACKDROP_MIN_MEAN_LUM}), i.e. the group
+     *  sits over no meaningful reconstructed content. */
+    private static boolean isBlankBackdrop(BufferedImage backdrop) {
+        int w = backdrop.getWidth(), h = backdrop.getHeight();
+        long total = (long) w * h;
+        if (total == 0) {
+            return true;
+        }
+        double sumLum = 0;
+        int[] row = new int[w];
+        for (int y = 0; y < h; y++) {
+            backdrop.getRGB(0, y, w, 1, row, 0, w);
+            for (int p : row) {
+                sumLum += 0.299 * ((p >> 16) & 0xff) + 0.587 * ((p >> 8) & 0xff) + 0.114 * (p & 0xff);
+            }
+        }
+        return sumLum / total >= BLANK_BACKDROP_MIN_MEAN_LUM;
+    }
+
+    /** True for blend modes that collapse to white when the backdrop is white --
+     *  B(white, Cs) ~ white.  Over a blank backdrop these erase opaque group
+     *  content, so §10 is declined for them (see {@link #compositeOverBackdrop}).
+     *  ColorBurn is included: ColorBurn(1, Cs) = 1 - min(1, 0/Cs) = 1. */
+    private static boolean isWhiteWashingBlend(Name blend) {
+        return blend != null && (
+                blend.equals(BlendComposite.COLOR_DODGE_VALUE)
+                        || blend.equals(BlendComposite.SCREEN_VALUE)
+                        || blend.equals(BlendComposite.COLOR_BURN_VALUE)
+                        || blend.equals(BlendComposite.OVERLAY_VALUE)
+                        || blend.equals(BlendComposite.LIGHTEN_VALUE));
     }
 
     /** A DeviceCMYK transparency group (the raster-level subtractive path's scope;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -180,7 +180,8 @@ public class FormDrawCmd extends AbstractDrawCmd {
             boolean previousTransparentBackdrop = isolatedGroup
                     && BlendComposite.setTransparentBackdrop(true);
             try {
-                if (!hasMask && !annotationAppearance.get() && backdropShapes != null
+                if (!hasMask && !annotationAppearance.get() && !renderingIntoPageGroup.get()
+                        && backdropShapes != null
                         && isBackdropCompositeCandidate(xForm)) {
                     // §10 backdrop-aware compositing: render the group over its
                     // real page backdrop (reconstructed by replaying the stack),
@@ -289,6 +290,22 @@ public class FormDrawCmd extends AbstractDrawCmd {
     /** Toggle the annotation-appearance backdrop bypass (see field). */
     public static void setAnnotationAppearance(boolean painting) {
         annotationAppearance.set(painting);
+    }
+
+    // Set while the page content is being rendered into a page-level transparency
+    // group buffer (Page.paintPageContent, -Dorg.icepdf.core.pageGroupBuffer).
+    // Inside that buffer the groups must blend against the live accumulating
+    // buffer pixels (the direct blended path), so the §10 backdrop-composite and
+    // its decline gate -- which reconstruct a separate white-seeded backdrop --
+    // must be bypassed: the buffer IS the backdrop, reconstruction is redundant
+    // and wrong there.  This is what lets a darkening group (e.g. a ColorBurn
+    // fill) darken the accumulated content instead of washing over white.
+    private static final ThreadLocal<Boolean> renderingIntoPageGroup =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    /** Toggle the page-group-buffer §10 bypass (see field). */
+    public static void setRenderingIntoPageGroup(boolean rendering) {
+        renderingIntoPageGroup.set(rendering);
     }
 
     /**

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -369,7 +369,7 @@ public class FormDrawCmd extends AbstractDrawCmd {
         Name blend = xForm.getExtGState() != null ? xForm.getExtGState().getBlendingMode() : null;
         float caRaw = xForm.getExtGState() != null ? xForm.getExtGState().getNonStrokingAlphConstant() : -1f;
         float ca = (caRaw < 0f || caRaw > 1f) ? 1f : caRaw;
-        BufferedImage result = composeContribution(isolated, backdrop, blend, ca, blendingSpaceFor(xForm));
+        BufferedImage result = composeContribution(isolated, backdrop, blend, ca);
         backdrop.flush(); // transient -- contribution is now in the isolated buffer
         return result;
     }
@@ -382,28 +382,22 @@ public class FormDrawCmd extends AbstractDrawCmd {
      * result {@code (1-ca*ag)*Cb + ca*ag*B(Cb,Cs)} -- the group's blend and
      * constant alpha applied to its real backdrop, no double-count.
      */
-    // The colour-space math for group compositing (GH-501).  The composition flow
-    // below is channel-count-agnostic; swapping this strategy is how a DeviceCMYK
-    // group blends subtractively without forking the flow -- an RGB group keeps the
-    // additive sRGB behaviour the compositor has always used, a DeviceCMYK group
-    // gets the §11.3.5 ink-complement blend (see CmykBlendingSpace), and a colour
-    // change in one cannot reach the other.
-    private static BlendingSpace blendingSpaceFor(Form xForm) {
-        if (xForm.getGroup() == null) {
-            return RgbBlendingSpace.INSTANCE;
-        }
-        Object cs = xForm.getLibrary().getObject(xForm.getGroup(), new Name("CS"));
-        if (cs instanceof Name && ((Name) cs).equals(DeviceCMYK.DEVICECMYK_KEY)) {
-            return CmykBlendingSpace.INSTANCE;
-        }
-        if (cs instanceof ICCBased && ((ICCBased) cs).getNumComponents() == 4) {
-            return CmykBlendingSpace.INSTANCE;
-        }
-        return RgbBlendingSpace.INSTANCE;
-    }
+    // The colour-space math for group compositing (GH-501).  composeContribution
+    // works on the group's *sRGB* isolated buffer, and a DeviceCMYK group cannot be
+    // blended subtractively from there: once the content is decoded to sRGB the
+    // black (K) channel is gone, and recovering CMYK from sRGB collapses the
+    // chromatic channels straight back to an RGB blend -- proven against three
+    // reference renderers, where the sRGB-recovered "subtractive" path fabricated a
+    // K channel and shifted pattern_and_CYMK_jpeg.pdf orange->green (Acrobat/Chrome/
+    // Firefox all show orange).  So this path stays additive; genuine subtractive
+    // blending needs the *true* preserved CMYK samples (ImageUtility.getCmykSamples)
+    // composited at the raster level (the 3a/n finding), which is the next step.
+    // CmykBlendingSpace holds the §11.3.5 ink-complement math, staged for that path.
+    private static final BlendingSpace blendingSpace = RgbBlendingSpace.INSTANCE;
 
     private static BufferedImage composeContribution(BufferedImage isolated, BufferedImage backdrop,
-                                                     Name blend, float ca, BlendingSpace space) {
+                                                     Name blend, float ca) {
+        BlendingSpace space = blendingSpace;
         BlendComposite.BlendingMode mode = toBlendingMode(blend);
         int w = isolated.getWidth(), h = isolated.getHeight();
         int n = space.channelCount();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -77,6 +77,11 @@ public class FormDrawCmd extends AbstractDrawCmd {
     private static final boolean cmykSubtractiveEnabled =
             Defs.sysPropertyBoolean("org.icepdf.core.cmyk.subtractive", true);
 
+    // Prototype (§5.2): also treat isolated/knockout groups as buffer-requiring in
+    // requiresOffscreenBuffer.  Off by default while we measure corpus impact.
+    private static final boolean isolationAwareRouting =
+            Defs.sysPropertyBoolean("org.icepdf.core.isolationAwareRouting", false);
+
     static {
         // decide if large images will be scaled
         disableXObjectSMask =
@@ -84,6 +89,94 @@ public class FormDrawCmd extends AbstractDrawCmd {
                         false);
 
         MAX_IMAGE_SIZE = Defs.sysPropertyInt("org.icepdf.core.maxSmaskImageSize", MAX_IMAGE_SIZE);
+    }
+
+    /**
+     * Decides whether a transparency-group form must be rasterised into an
+     * offscreen buffer ({@link FormDrawCmd}) or can be painted inline as plain
+     * shapes ({@link ShapesDrawCmd}).
+     * <p>
+     * A buffer is required only when the group carries a <i>group effect</i>
+     * that cannot be reproduced by painting its shapes straight onto the page:
+     * <ul>
+     *   <li>a soft mask (the mask must be read back from a raster),</li>
+     *   <li>a non-Normal blend mode applied to the group as a unit, or</li>
+     *   <li>a group constant alpha in the open interval (0,1), which applies to
+     *       the <i>composited</i> group and therefore needs it composited first.</li>
+     * </ul>
+     * Groups with none of these — including plain Normal, fully-opaque groups —
+     * composite identically whether painted inline or via a buffer (Porter-Duff
+     * <i>over</i> is associative), so they are painted inline; this also avoids
+     * the resolution loss of buffering through an affine transform.
+     * <p>
+     * Size handling: a group is only buffered if it fits the offscreen-buffer
+     * budget.  Groups within {@link #MAX_IMAGE_SIZE} buffer 1:1.  A larger
+     * <i>blend-only</i> (no soft mask) group is down-scaled into the buffer, but
+     * only up to {@link #MAX_SCALED_FORM_SIZE}; beyond that the bbox is treated
+     * as an unbounded {@code +-Short.MAX_VALUE} sentinel (real content small and
+     * clipped elsewhere) that would collapse if scaled, so it stays inline.
+     * Soft-mask groups need a 1:1 buffer and are never down-scaled.
+     * <p>
+     * Behaviour-preserving refactor of the previous inline
+     * {@code withinMaxSize}/{@code hasGroupEffect}/{@code oversizedBlendOnly}
+     * predicate; see {@code TRANSPARENCY-GROUP-BLENDING-DESIGN.md}.
+     *
+     * @param form transparency-group form being placed by a {@code Do}.
+     * @return true if the group must be rasterised to a buffer.
+     */
+    public static boolean requiresOffscreenBuffer(Form form) {
+        ExtGState extGState = form.getExtGState();
+        if (extGState == null) {
+            return false;
+        }
+        double formWidth = form.getBBox().getWidth();
+        double formHeight = form.getBBox().getHeight();
+        // degenerate / sub-pixel groups: nothing meaningful to buffer.
+        if (formWidth <= 1 || formHeight <= 1) {
+            return false;
+        }
+        boolean hasSoftMask = extGState.getSMask() != null;
+        Name blendingMode = extGState.getBlendingMode();
+        boolean hasBlend = blendingMode != null
+                && !blendingMode.equals(BlendComposite.NORMAL_VALUE);
+        float ca = extGState.getNonStrokingAlphConstant();
+        boolean hasPartialAlpha = ca > 0 && ca < 1;
+        // Prototype (§5.2): an isolated group needs a transparent backdrop and a
+        // knockout group needs its initial backdrop preserved -- both of which
+        // only a buffer provides.  These flags are otherwise parsed but never
+        // consulted in routing.  Gated off by default while corpus impact is
+        // measured (a fully-opaque/all-Normal isolated group renders the same
+        // inline, so this over-buffers until refined to require inner
+        // transparency).
+        boolean needsIsolation = isolationAwareRouting
+                && (form.isIsolated() || form.isKnockOut());
+        // No group effect -> inline; painting the shapes SRC_OVER onto the page
+        // is identical to compositing them to a buffer first.
+        if (!(hasSoftMask || hasBlend || hasPartialAlpha || needsIsolation)) {
+            return false;
+        }
+        // A sentinel/extreme bbox (typically +-Short.MAX_VALUE) would collapse if
+        // scaled into a buffer, so such forms stay inline regardless of effect.
+        boolean realisticallySized = formWidth < MAX_SCALED_FORM_SIZE
+                && formHeight < MAX_SCALED_FORM_SIZE;
+        if (!realisticallySized) {
+            return false;
+        }
+        // "Within budget" mirrors createBufferXObject's AREA clamp, not a
+        // per-dimension cap: a group whose area fits MAX_IMAGE_SIZE^2 is
+        // rasterised 1:1, so it can always be buffered -- including an
+        // oversized-but-thin SMask group (e.g. WhiteGradient.pdf's 1867x2079
+        // white-gradient fade, height just over 2000) that the old per-dimension
+        // gate dropped to inline, silently discarding its luminosity mask.
+        long area = (long) formWidth * (long) formHeight;
+        long maxArea = (long) MAX_IMAGE_SIZE * MAX_IMAGE_SIZE;
+        if (area <= maxArea) {
+            return true;
+        }
+        // Over the area budget the buffer must be down-scaled.  Proven safe for
+        // blend-only groups; SMask groups are still excluded here because a
+        // down-scaled luminosity mask is not yet validated.
+        return !hasSoftMask && hasBlend;
     }
 
     public FormDrawCmd(Form xForm) {

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -369,7 +369,7 @@ public class FormDrawCmd extends AbstractDrawCmd {
         Name blend = xForm.getExtGState() != null ? xForm.getExtGState().getBlendingMode() : null;
         float caRaw = xForm.getExtGState() != null ? xForm.getExtGState().getNonStrokingAlphConstant() : -1f;
         float ca = (caRaw < 0f || caRaw > 1f) ? 1f : caRaw;
-        BufferedImage result = composeContribution(isolated, backdrop, blend, ca);
+        BufferedImage result = composeContribution(isolated, backdrop, blend, ca, blendingSpaceFor(xForm));
         backdrop.flush(); // transient -- contribution is now in the isolated buffer
         return result;
     }
@@ -384,13 +384,26 @@ public class FormDrawCmd extends AbstractDrawCmd {
      */
     // The colour-space math for group compositing (GH-501).  The composition flow
     // below is channel-count-agnostic; swapping this strategy is how a DeviceCMYK
-    // group will blend subtractively without forking the flow.  Defaults to the
-    // additive sRGB behaviour the compositor has always used.
-    private static final BlendingSpace blendingSpace = RgbBlendingSpace.INSTANCE;
+    // group blends subtractively without forking the flow -- an RGB group keeps the
+    // additive sRGB behaviour the compositor has always used, a DeviceCMYK group
+    // gets the §11.3.5 ink-complement blend (see CmykBlendingSpace), and a colour
+    // change in one cannot reach the other.
+    private static BlendingSpace blendingSpaceFor(Form xForm) {
+        if (xForm.getGroup() == null) {
+            return RgbBlendingSpace.INSTANCE;
+        }
+        Object cs = xForm.getLibrary().getObject(xForm.getGroup(), new Name("CS"));
+        if (cs instanceof Name && ((Name) cs).equals(DeviceCMYK.DEVICECMYK_KEY)) {
+            return CmykBlendingSpace.INSTANCE;
+        }
+        if (cs instanceof ICCBased && ((ICCBased) cs).getNumComponents() == 4) {
+            return CmykBlendingSpace.INSTANCE;
+        }
+        return RgbBlendingSpace.INSTANCE;
+    }
 
     private static BufferedImage composeContribution(BufferedImage isolated, BufferedImage backdrop,
-                                                     Name blend, float ca) {
-        BlendingSpace space = blendingSpace;
+                                                     Name blend, float ca, BlendingSpace space) {
         BlendComposite.BlendingMode mode = toBlendingMode(blend);
         int w = isolated.getWidth(), h = isolated.getHeight();
         int n = space.channelCount();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -310,7 +310,7 @@ public class FormDrawCmd extends AbstractDrawCmd {
     }
 
     // Set while the page content is being rendered into a page-level transparency
-    // group buffer (Page.paintPageContent, -Dorg.icepdf.core.pageGroupBuffer).
+    // group buffer (Page.paintPageGroupBuffered, for DeviceCMYK page groups).
     // Inside that buffer the groups must blend against the live accumulating
     // buffer pixels (the direct blended path), so the §10 backdrop-composite and
     // its decline gate -- which reconstruct a separate white-seeded backdrop --

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/GroupDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/GroupDrawCmd.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics.commands;
+
+import org.icepdf.core.pobjects.Name;
+import org.icepdf.core.pobjects.Page;
+import org.icepdf.core.pobjects.graphics.OptionalContentState;
+import org.icepdf.core.pobjects.graphics.PaintTimer;
+
+import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Lightweight, inert marker delimiting the start and end of a transparency
+ * group on the {@link org.icepdf.core.pobjects.graphics.Shapes} stack.
+ * <br>
+ * ICEpdf has historically carried no explicit group boundaries -- a buffered
+ * group is a single {@link FormDrawCmd} wrapping the group's own sub-shapes, and
+ * the page-level group (the page dictionary's {@code /Group} entry) had no
+ * representation at all.  These markers make the boundaries explicit so a
+ * compositor can identify a contiguous run of group content (e.g. the page
+ * transparency group, or a sibling-group run) and render it into a shared buffer.
+ * <br>
+ * {@link #paintOperand} is intentionally a no-op: a marker paints nothing and
+ * does not alter the current shape, so the default {@link
+ * org.icepdf.core.pobjects.graphics.Shapes#paint} loop is unaffected whether or
+ * not any consumer reads the markers.  The marker simply carries the group's
+ * attributes ({@code isolated}, {@code knockout}, colour-space name, blend mode,
+ * and bounding box) for whatever compositor chooses to act on them.
+ *
+ * @since 7.5
+ */
+public class GroupDrawCmd extends AbstractDrawCmd {
+
+    private final boolean start;
+    private final boolean isolated;
+    private final boolean knockout;
+    private final Name csName;
+    private final Name blend;
+    private final Rectangle2D bBox;
+
+    /**
+     * @param start    true for a group-start marker, false for a group-end marker.
+     * @param isolated transparency group {@code /I} flag.
+     * @param knockout transparency group {@code /K} flag.
+     * @param csName   group colour-space name (e.g. DeviceCMYK), may be null.
+     * @param blend    blend mode applied to the group, may be null.
+     * @param bBox     group bounding box in the parent space, may be null.
+     */
+    public GroupDrawCmd(boolean start, boolean isolated, boolean knockout,
+                        Name csName, Name blend, Rectangle2D bBox) {
+        this.start = start;
+        this.isolated = isolated;
+        this.knockout = knockout;
+        this.csName = csName;
+        this.blend = blend;
+        this.bBox = bBox;
+    }
+
+    public boolean isStart() {
+        return start;
+    }
+
+    public boolean isIsolated() {
+        return isolated;
+    }
+
+    public boolean isKnockout() {
+        return knockout;
+    }
+
+    public Name getCsName() {
+        return csName;
+    }
+
+    public Name getBlend() {
+        return blend;
+    }
+
+    public Rectangle2D getbBox() {
+        return bBox;
+    }
+
+    /**
+     * No-op: a marker paints nothing and leaves the current shape unchanged.
+     */
+    @Override
+    public Shape paintOperand(Graphics2D g, Page parentPage, Shape currentShape,
+                              Shape clip, AffineTransform base,
+                              OptionalContentState optionalContentState,
+                              boolean paintAlpha, PaintTimer paintTimer) {
+        return currentShape;
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/GroupDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/GroupDrawCmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageStream.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageStream.java
@@ -133,6 +133,11 @@ public class ImageStream extends Stream {
         if (decodedImage == null) {
             decodedImage = new RawDecoder(this, graphicsState).decode();
         }
+        // GH-501 step 2: the decoder output may carry preserved TRUE CMYK samples
+        // (keyed by this object); mask processing below replaces decodedImage with a
+        // new BufferedImage, so remember the decoder output to re-key the samples to
+        // the final image that actually gets drawn.
+        BufferedImage rawDecoded = decodedImage;
         if (decodedImage != null) {
             if (imageParams.isImageMask()) {
                 decodedImage = ImageUtility.applyExplicitMask(decodedImage, graphicsState.getFillColor());
@@ -155,6 +160,9 @@ public class ImageStream extends Stream {
 //            if (maskDecoder != null || smaskDecoder != null)
 //                ImageUtility.displayImage(decodedImage, "Final " + pObjectReference.toString());
         }
+        // associate any preserved CMYK samples with this stable stream key so the
+        // draw-time ink capture finds them regardless of downstream mask/scale.
+        ImageUtility.associateCmykStream(this, rawDecoded);
         return decodedImage;
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
@@ -44,6 +44,47 @@ public class ImageUtility {
     static final Logger logger =
             Logger.getLogger(ImageUtility.class.getName());
 
+    // GH-501 Phase 2: a DeviceCMYK transparency group must blend in CMYK, but a
+    // CMYK image is decoded straight to sRGB (via an ICC profile / the convoluted
+    // CMYKRasterOp) and the true 4-channel CMYK is then gone.  When a CMYK group is
+    // being rasterised the compositor sets this flag; convertCmykToRgb then stashes
+    // the post-decode CMYK raster keyed by the sRGB image it produced, so the group
+    // buffer can recover the real CMYK samples instead of the unrecoverable sRGB.
+    // Off by default -> zero cost/behaviour change on the normal path.  Global
+    // (not thread-local): image decoding can run on pooled worker threads, so a
+    // thread-scoped flag set by the rendering thread would never reach the decoder.
+    private static volatile boolean PRESERVE_CMYK = false;
+    private static final java.util.Map<BufferedImage, Raster> CMYK_SAMPLES =
+            java.util.Collections.synchronizedMap(new java.util.WeakHashMap<>());
+
+    /** Toggles CMYK-sample preservation; returns the prior value so callers can
+     *  restore it.  Global because decoding may happen off the render thread. */
+    public static boolean setPreserveCmyk(boolean preserve) {
+        boolean previous = PRESERVE_CMYK;
+        PRESERVE_CMYK = preserve;
+        return previous;
+    }
+
+    /** The true CMYK raster a CMYK image decoded from, or null if it wasn't a CMYK
+     *  image or preservation was off when it decoded. */
+    public static Raster getCmykSamples(BufferedImage rgbImage) {
+        return CMYK_SAMPLES.get(rgbImage);
+    }
+
+    /** Number of preserved CMYK rasters currently retained (diagnostic). */
+    public static int cmykSampleCount() {
+        return CMYK_SAMPLES.size();
+    }
+
+    private static void preserveCmyk(BufferedImage rgbImage, Raster cmykRaster) {
+        if (PRESERVE_CMYK && cmykRaster != null) {
+            // Copy: the decoder may reuse/mutate the source raster after we return.
+            WritableRaster copy = cmykRaster.createCompatibleWritableRaster();
+            copy.setRect(cmykRaster);
+            CMYK_SAMPLES.put(rgbImage, copy);
+        }
+    }
+
     static final int[] GRAY_1_BIT_INDEX_TO_RGB_REVERSED = new int[]{
             0xFFFFFFFF,
             0xFF000000
@@ -966,6 +1007,8 @@ public class ImageUtility {
             CMYKRasterOp cmykRasterOp = new CMYKRasterOp(null);
             cmykRasterOp.filter(cmykRaster, rgbRaster);
         }
+        // GH-501: keep the true CMYK samples (post-decode) for CMYK group blending.
+        preserveCmyk(rgbImage, cmykRaster);
         return rgbImage;
     }
 
@@ -1009,6 +1052,8 @@ public class ImageUtility {
             CMYKRasterOp cmykRasterOp = new CMYKRasterOp(null);
             cmykRasterOp.filter(ycckRaster, rgbRaster);
         }
+        // GH-501: keep the true CMYK samples (post-YCCK->CMYK) for CMYK group blending.
+        preserveCmyk(rgbImage, ycckRaster);
         return rgbImage;
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
@@ -83,6 +83,44 @@ public class ImageUtility {
         }
     }
 
+    /** Drop all preserved CMYK samples (diagnostic: reset between probe runs). */
+    public static void clearCmykSamples() {
+        CMYK_SAMPLES.clear();
+    }
+
+    /**
+     * Diagnostic K-channel (band 3) summary across every currently preserved CMYK
+     * raster: {@code {images, totalPixels, pixelsWithKgt8, maxK}}.  Used to answer
+     * the GH-501 question "does this file carry genuine black ink?" -- a group whose
+     * CMYK content is all K=0 blends identically in CMYK and RGB, so the raster-level
+     * subtractive path can only matter where maxK &gt; 0 / pixelsWithKgt8 &gt; 0.
+     */
+    public static long[] cmykKSummary() {
+        long images = 0, totalPixels = 0, pixelsKgt8 = 0, maxK = 0;
+        synchronized (CMYK_SAMPLES) {
+            for (Raster r : CMYK_SAMPLES.values()) {
+                if (r == null || r.getNumBands() < 4) {
+                    continue;
+                }
+                images++;
+                int w = r.getWidth(), h = r.getHeight();
+                for (int y = 0; y < h; y++) {
+                    for (int x = 0; x < w; x++) {
+                        int k = r.getSample(x, y, 3) & 0xFF;
+                        totalPixels++;
+                        if (k > 8) {
+                            pixelsKgt8++;
+                        }
+                        if (k > maxK) {
+                            maxK = k;
+                        }
+                    }
+                }
+            }
+        }
+        return new long[]{images, totalPixels, pixelsKgt8, maxK};
+    }
+
     /** A translucent CMYK (C,M,Y,K + alpha) image over the DeviceCMYK ICC colour
      *  space -- the render target for a DeviceCMYK transparency group, so its
      *  content stays in CMYK (GH-501 Phase 2).  Java2D rasterises into it; a CMYK

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
@@ -76,6 +76,13 @@ public class ImageUtility {
         return CMYK_SAMPLES.size();
     }
 
+    /** Any one preserved CMYK raster (diagnostic / verification). */
+    public static Raster anyPreservedCmyk() {
+        synchronized (CMYK_SAMPLES) {
+            return CMYK_SAMPLES.isEmpty() ? null : CMYK_SAMPLES.values().iterator().next();
+        }
+    }
+
     private static void preserveCmyk(BufferedImage rgbImage, Raster cmykRaster) {
         if (PRESERVE_CMYK && cmykRaster != null) {
             // Copy: the decoder may reuse/mutate the source raster after we return.
@@ -83,6 +90,25 @@ public class ImageUtility {
             copy.setRect(cmykRaster);
             CMYK_SAMPLES.put(rgbImage, copy);
         }
+    }
+
+    /** Whether CMYK preservation is currently active (lets a per-pixel decoder such
+     *  as RawDecoder skip building the capture buffer when off). */
+    public static boolean isPreserveCmyk() {
+        return PRESERVE_CMYK;
+    }
+
+    /** Preserve an interleaved C,M,Y,K byte buffer (4 bands, 0..255) a per-pixel
+     *  decoder built alongside the sRGB image -- the raw FlateDecode CMYK path,
+     *  which converts sample-by-sample with no intermediate CMYK raster. */
+    public static void preserveCmykBytes(BufferedImage rgbImage, byte[] interleavedCmyk, int width, int height) {
+        if (!PRESERVE_CMYK || interleavedCmyk == null) {
+            return;
+        }
+        DataBufferByte db = new DataBufferByte(interleavedCmyk, interleavedCmyk.length);
+        WritableRaster wr = Raster.createInterleavedRaster(
+                db, width, height, width * 4, 4, new int[]{0, 1, 2, 3}, null);
+        CMYK_SAMPLES.put(rgbImage, wr);
     }
 
     static final int[] GRAY_1_BIT_INDEX_TO_RGB_REVERSED = new int[]{
@@ -960,6 +986,11 @@ public class ImageUtility {
         // apply colour space
         PColorSpaceRasterOp pColorSpaceRasterOp = new PColorSpaceRasterOp(colorSpace, null);
         pColorSpaceRasterOp.filter(colourRaster, rgbRaster);
+        // GH-501: raw (FlateDecode) DeviceCMYK images reach RGB through this generic
+        // path, not convertCmykToRgb -- keep their true CMYK samples too.
+        if (colorSpace instanceof DeviceCMYK) {
+            preserveCmyk(rgbImage, colourRaster);
+        }
         return rgbImage;
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
@@ -150,6 +150,30 @@ public class ImageUtility {
         return new BufferedImage(cm, wr, false, null);
     }
 
+    // Preserved CMYK samples keyed by the stable ImageStream (not the produced
+    // BufferedImage, which mask/scale/proxy stages replace downstream).  This is
+    // the key the draw-time ink capture looks up.
+    private static final java.util.Map<Object, Raster> CMYK_BY_STREAM =
+            java.util.Collections.synchronizedMap(new java.util.WeakHashMap<>());
+
+    /** Associate any CMYK samples preserved for {@code decoderImage} (the decoder
+     *  output) with the stable {@code streamKey}, so the draw-time ink capture can
+     *  find them no matter how many mask/scale stages replace the image. */
+    public static void associateCmykStream(Object streamKey, BufferedImage decoderImage) {
+        if (streamKey == null || decoderImage == null) {
+            return;
+        }
+        Raster r = CMYK_SAMPLES.get(decoderImage);
+        if (r != null) {
+            CMYK_BY_STREAM.put(streamKey, r);
+        }
+    }
+
+    /** Preserved CMYK samples for an image XObject, by its stable stream key. */
+    public static Raster getCmykSamplesForStream(Object streamKey) {
+        return streamKey == null ? null : CMYK_BY_STREAM.get(streamKey);
+    }
+
     private static void preserveCmyk(BufferedImage rgbImage, Raster cmykRaster) {
         if (PRESERVE_CMYK && cmykRaster != null) {
             // Copy: the decoder may reuse/mutate the source raster after we return.
@@ -176,6 +200,105 @@ public class ImageUtility {
         WritableRaster wr = Raster.createInterleavedRaster(
                 db, width, height, width * 4, 4, new int[]{0, 1, 2, 3}, null);
         CMYK_SAMPLES.put(rgbImage, wr);
+    }
+
+    // ----- GH-501 Phase 2 step 2: raster-level CMYK ink capture --------------
+    // A DeviceCMYK transparency group is rasterised to an sRGB buffer by Java2D
+    // (FormDrawCmd.createBufferXObject), which destroys the true CMYK so the group
+    // cannot be blended subtractively.  While that buffer is being painted we also
+    // blit each CMYK image's TRUE preserved samples into a parallel CMYK ink raster
+    // -- aligned for free by reading the canvas transform at the exact draw moment,
+    // so the ink lands pixel-identical to where Java2D placed the sRGB image (the
+    // 3a/n finding: blit the raster, never colour-managed drawImage).  The group
+    // compositor then blends from this ink (real K) instead of the lossy sRGB.
+
+    /** Captures TRUE CMYK ink into a group-buffer-sized raster during a form paint. */
+    public static final class CmykInkSink {
+        final WritableRaster ink;      // 4-band byte C,M,Y,K, group buffer dimensions
+        final WritableRaster coverage; // 1-band byte, 255 where a CMYK image landed
+        final int w, h;
+        boolean captured;
+
+        CmykInkSink(int w, int h) {
+            this.w = w;
+            this.h = h;
+            this.ink = Raster.createInterleavedRaster(
+                    DataBuffer.TYPE_BYTE, w, h, 4, new Point(0, 0));
+            this.coverage = Raster.createInterleavedRaster(
+                    DataBuffer.TYPE_BYTE, w, h, 1, new Point(0, 0));
+        }
+
+        public WritableRaster getInk() {
+            return ink;
+        }
+
+        public WritableRaster getCoverage() {
+            return coverage;
+        }
+
+        public boolean isCaptured() {
+            return captured;
+        }
+    }
+
+    private static final ThreadLocal<CmykInkSink> INK_SINK = new ThreadLocal<>();
+
+    /** Begins CMYK ink capture for a {@code w x h} group buffer on this thread. */
+    public static CmykInkSink beginCmykInkCapture(int w, int h) {
+        CmykInkSink sink = new CmykInkSink(w, h);
+        INK_SINK.set(sink);
+        return sink;
+    }
+
+    /** Ends CMYK ink capture and returns the sink (may be empty if no CMYK image
+     *  with preserved samples was drawn). */
+    public static CmykInkSink endCmykInkCapture() {
+        CmykInkSink sink = INK_SINK.get();
+        INK_SINK.remove();
+        return sink;
+    }
+
+    /**
+     * If a {@link CmykInkSink} is active and {@code drawn} has preserved CMYK
+     * samples, blit those true samples into the ink raster under the same
+     * transform Java2D just used to draw the sRGB image -- {@code g.getTransform()}
+     * composed with the {@code drawImage(img, ax, ay, aw, ah)} source->user box --
+     * so the ink is pixel-aligned with the sRGB buffer.  No-op when no sink is
+     * active (the normal render path) or the image isn't a preserved CMYK image.
+     */
+    public static void captureCmykInk(Object streamKey, Graphics2D g,
+                                      int ax, int ay, int aw, int ah) {
+        CmykInkSink sink = INK_SINK.get();
+        if (sink == null) {
+            return;
+        }
+        Raster cmyk = getCmykSamplesForStream(streamKey);
+        if (cmyk == null || cmyk.getNumBands() < 4) {
+            return;
+        }
+        int srcW = cmyk.getWidth(), srcH = cmyk.getHeight();
+        if (srcW <= 0 || srcH <= 0 || aw <= 0 || ah <= 0) {
+            return;
+        }
+        try {
+            // image pixel (px,py) -> user (ax + px*aw/srcW, ay + py*ah/srcH) -> buffer
+            AffineTransform m = new AffineTransform(g.getTransform());
+            m.translate(ax, ay);
+            m.scale(aw / (double) srcW, ah / (double) srcH);
+            AffineTransformOp op = new AffineTransformOp(m, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
+            op.filter(cmyk, sink.ink);
+            // mark coverage: blit an all-255 single-band raster through the same map.
+            WritableRaster ones = Raster.createInterleavedRaster(
+                    DataBuffer.TYPE_BYTE, srcW, srcH, 1, new Point(0, 0));
+            byte[] ob = ((DataBufferByte) ones.getDataBuffer()).getData();
+            Arrays.fill(ob, (byte) 0xFF);
+            op.filter(ones, sink.coverage);
+            sink.captured = true;
+        } catch (Exception e) {
+            // a singular/oversized transform just means no subtractive capture for
+            // this image; the compositor falls back to the additive sRGB path.
+            logger.fine("CMYK ink capture skipped: " + e);
+        }
     }
 
     static final int[] GRAY_1_BIT_INDEX_TO_RGB_REVERSED = new int[]{

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/ImageUtility.java
@@ -83,6 +83,35 @@ public class ImageUtility {
         }
     }
 
+    /** A translucent CMYK (C,M,Y,K + alpha) image over the DeviceCMYK ICC colour
+     *  space -- the render target for a DeviceCMYK transparency group, so its
+     *  content stays in CMYK (GH-501 Phase 2).  Java2D rasterises into it; a CMYK
+     *  source ({@link #wrapCmyk}) drawn in shares this colour space so the samples
+     *  are copied, not re-converted through sRGB. */
+    public static BufferedImage createCmykImage(int width, int height) {
+        ColorSpace cs = DeviceCMYK.getIccCmykColorSpace();
+        ComponentColorModel cm = new ComponentColorModel(
+                cs, true, false, ColorModel.TRANSLUCENT, DataBuffer.TYPE_BYTE);
+        WritableRaster wr = cm.createCompatibleWritableRaster(width, height);
+        return new BufferedImage(cm, wr, false, null);
+    }
+
+    /** Wraps a preserved 4-band CMYK raster as an opaque CMYK {@link BufferedImage}
+     *  (same ICC colour space as {@link #createCmykImage}) so it can be drawn into
+     *  a CMYK group buffer without an sRGB round-trip. */
+    public static BufferedImage wrapCmyk(Raster cmykRaster) {
+        ColorSpace cs = DeviceCMYK.getIccCmykColorSpace();
+        ComponentColorModel cm = new ComponentColorModel(
+                cs, false, false, ColorModel.OPAQUE, DataBuffer.TYPE_BYTE);
+        WritableRaster wr = cmykRaster instanceof WritableRaster
+                ? (WritableRaster) cmykRaster
+                : cmykRaster.createCompatibleWritableRaster();
+        if (!(cmykRaster instanceof WritableRaster)) {
+            ((WritableRaster) wr).setRect(cmykRaster);
+        }
+        return new BufferedImage(cm, wr, false, null);
+    }
+
     private static void preserveCmyk(BufferedImage rgbImage, Raster cmykRaster) {
         if (PRESERVE_CMYK && cmykRaster != null) {
             // Copy: the decoder may reuse/mutate the source raster after we return.

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/RawDecoder.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/RawDecoder.java
@@ -81,6 +81,15 @@ public class RawDecoder extends AbstractImageDecoder {
         // too, bit by painful bit.
         BufferedImage bim = ImageUtility.createTranslucentCompatibleImage(width, height);
 
+        // GH-501: when a CMYK group is being rasterised, capture the true CMYK
+        // samples alongside the sRGB image so the group can blend in CMYK.  This
+        // per-pixel decoder is the raw FlateDecode path (no intermediate CMYK
+        // raster); cmykCapture is null (no cost) unless preservation is on for an
+        // 8-bit DeviceCMYK image.
+        byte[] cmykCapture = (ImageUtility.isPreserveCmyk() && bitsPerComponent == 8
+                && colorSpaceCompCount == 4 && colorSpace instanceof DeviceCMYK)
+                ? new byte[width * height * 4] : null;
+
         // create the buffer and get the first series of bytes from the cached
         // stream
         // get the full image data.
@@ -171,6 +180,15 @@ public class RawDecoder extends AbstractImageDecoder {
                                     f[i] = maxColourValue - f[i];
                                 }
                             }
+                            if (cmykCapture != null) {
+                                // f holds the decoded C,M,Y,K samples (0..255) -- the
+                                // true CMYK, before colorSpace.getColor() flattens to sRGB.
+                                int idx = (y * width + x) * 4;
+                                cmykCapture[idx] = (byte) f[0];
+                                cmykCapture[idx + 1] = (byte) f[1];
+                                cmykCapture[idx + 2] = (byte) f[2];
+                                cmykCapture[idx + 3] = (byte) f[3];
+                            }
                             imageBits[x] = convertSample(colorSpace, f, ff, maxColourValue, lastF, lastRgb);
                         }
                         // else just set pixel with the default values
@@ -188,6 +206,10 @@ public class RawDecoder extends AbstractImageDecoder {
             in.close();
         } catch (IOException e) {
             logger.log(Level.FINE, "Error parsing image.", e);
+        }
+
+        if (cmykCapture != null) {
+            ImageUtility.preserveCmykBytes(bim, cmykCapture, width, height);
         }
 
         return bim;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReference.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/images/references/ImageReference.java
@@ -121,6 +121,10 @@ public abstract class ImageReference implements Callable<BufferedImage> {
         if (image != null) {
             try {
                 aG.drawImage(image, aX, aY, aW, aH, null);
+                // GH-501 step 2: if a CMYK group is being rasterised, blit this
+                // image's TRUE preserved CMYK samples into the ink sink, aligned to
+                // the transform just used here (no-op on the normal render path).
+                ImageUtility.captureCmykInk(imageStream, aG, aX, aY, aW, aH);
             } catch (OutOfMemoryError e) {
                 // Java2D sizes the destination raster to the transformed image
                 // bounds, so re-scaling the source cannot shrink it (and a

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
@@ -51,9 +51,6 @@ public abstract class AbstractContentParser {
             Logger.getLogger(AbstractContentParser.class.getName());
 
     private static final boolean disableTransparencyGroups;
-    // Prototype (§5.2): also treat isolated/knockout groups as buffer-requiring.
-    // Off by default while we measure corpus impact.
-    private static final boolean isolationAwareRouting;
     private static final boolean enabledOverPrint;
     private static final boolean enabledFontFallback;
 
@@ -69,10 +66,6 @@ public abstract class AbstractContentParser {
         // decide if large images will be scaled
         disableTransparencyGroups =
                 Defs.sysPropertyBoolean("org.icepdf.core.disableTransparencyGroup",
-                        false);
-
-        isolationAwareRouting =
-                Defs.sysPropertyBoolean("org.icepdf.core.isolationAwareRouting",
                         false);
 
         // decide if basic over print support will be enabled.
@@ -594,7 +587,7 @@ public abstract class AbstractContentParser {
                 shapes.add(new GroupDrawCmd(true, formXObject.isIsolated(), formXObject.isKnockOut(),
                         groupCs instanceof Name ? (Name) groupCs : null, groupBlend, formXObject.getBBox()));
             }
-            if (!disableTransparencyGroups && requiresOffscreenBuffer(formXObject)) {
+            if (!disableTransparencyGroups && FormDrawCmd.requiresOffscreenBuffer(formXObject)) {
                 // add the hold form for further processing.
                 FormDrawCmd formDrawCmd = new FormDrawCmd(formXObject);
                 shapes.add(formDrawCmd);
@@ -699,95 +692,6 @@ public abstract class AbstractContentParser {
             }
         }
         return graphicState;
-    }
-
-    /**
-     * Decides whether a transparency-group form must be rasterised into an
-     * offscreen buffer ({@link FormDrawCmd}) or can be painted inline as plain
-     * shapes ({@link ShapesDrawCmd}).
-     * <p>
-     * A buffer is required only when the group carries a <i>group effect</i>
-     * that cannot be reproduced by painting its shapes straight onto the page:
-     * <ul>
-     *   <li>a soft mask (the mask must be read back from a raster),</li>
-     *   <li>a non-Normal blend mode applied to the group as a unit, or</li>
-     *   <li>a group constant alpha in the open interval (0,1), which applies to
-     *       the <i>composited</i> group and therefore needs it composited first.</li>
-     * </ul>
-     * Groups with none of these — including plain Normal, fully-opaque groups —
-     * composite identically whether painted inline or via a buffer (Porter-Duff
-     * <i>over</i> is associative), so they are painted inline; this also avoids
-     * the resolution loss of buffering through an affine transform.
-     * <p>
-     * Size handling: a group is only buffered if it fits the offscreen-buffer
-     * budget.  Groups within {@link FormDrawCmd#MAX_IMAGE_SIZE} buffer 1:1.  A
-     * larger <i>blend-only</i> (no soft mask) group is down-scaled into the
-     * buffer by {@link FormDrawCmd}, but only up to
-     * {@link FormDrawCmd#MAX_SCALED_FORM_SIZE}; beyond that the bbox is treated
-     * as an unbounded {@code +-Short.MAX_VALUE} sentinel (real content small and
-     * clipped elsewhere) that would collapse if scaled, so it stays inline.
-     * Soft-mask groups need a 1:1 buffer and are never down-scaled.
-     * <p>
-     * Behaviour-preserving refactor of the previous inline
-     * {@code withinMaxSize}/{@code hasGroupEffect}/{@code oversizedBlendOnly}
-     * predicate; see {@code TRANSPARENCY-GROUP-BLENDING-DESIGN.md}.
-     *
-     * @param form transparency-group form being placed by a {@code Do}.
-     * @return true if the group must be rasterised to a buffer.
-     */
-    protected static boolean requiresOffscreenBuffer(Form form) {
-        ExtGState extGState = form.getExtGState();
-        if (extGState == null) {
-            return false;
-        }
-        double formWidth = form.getBBox().getWidth();
-        double formHeight = form.getBBox().getHeight();
-        // degenerate / sub-pixel groups: nothing meaningful to buffer.
-        if (formWidth <= 1 || formHeight <= 1) {
-            return false;
-        }
-        boolean hasSoftMask = extGState.getSMask() != null;
-        Name blendingMode = extGState.getBlendingMode();
-        boolean hasBlend = blendingMode != null
-                && !blendingMode.equals(BlendComposite.NORMAL_VALUE);
-        float ca = extGState.getNonStrokingAlphConstant();
-        boolean hasPartialAlpha = ca > 0 && ca < 1;
-        // Prototype (§5.2): an isolated group needs a transparent backdrop and a
-        // knockout group needs its initial backdrop preserved -- both of which
-        // only a buffer provides.  These flags are otherwise parsed but never
-        // consulted in routing.  Gated off by default while corpus impact is
-        // measured (a fully-opaque/all-Normal isolated group renders the same
-        // inline, so this over-buffers until refined to require inner
-        // transparency).
-        boolean needsIsolation = isolationAwareRouting
-                && (form.isIsolated() || form.isKnockOut());
-        // No group effect -> inline; painting the shapes SRC_OVER onto the page
-        // is identical to compositing them to a buffer first.
-        if (!(hasSoftMask || hasBlend || hasPartialAlpha || needsIsolation)) {
-            return false;
-        }
-        // A sentinel/extreme bbox (typically +-Short.MAX_VALUE) would collapse if
-        // scaled into a buffer, so such forms stay inline regardless of effect.
-        boolean realisticallySized = formWidth < FormDrawCmd.MAX_SCALED_FORM_SIZE
-                && formHeight < FormDrawCmd.MAX_SCALED_FORM_SIZE;
-        if (!realisticallySized) {
-            return false;
-        }
-        // "Within budget" mirrors createBufferXObject's AREA clamp, not a
-        // per-dimension cap: a group whose area fits MAX_IMAGE_SIZE^2 is
-        // rasterised 1:1, so it can always be buffered -- including an
-        // oversized-but-thin SMask group (e.g. WhiteGradient.pdf's 1867x2079
-        // white-gradient fade, height just over 2000) that the old per-dimension
-        // gate dropped to inline, silently discarding its luminosity mask.
-        long area = (long) formWidth * (long) formHeight;
-        long maxArea = (long) FormDrawCmd.MAX_IMAGE_SIZE * FormDrawCmd.MAX_IMAGE_SIZE;
-        if (area <= maxArea) {
-            return true;
-        }
-        // Over the area budget the buffer must be down-scaled.  Proven safe for
-        // blend-only groups; SMask groups are still excluded here because a
-        // down-scaled luminosity mask is not yet validated.
-        return !hasSoftMask && hasBlend;
     }
 
     protected static void consume_d(GraphicsState graphicState, Stack<Object> stack, Shapes shapes) {

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
@@ -98,6 +98,9 @@ public abstract class AbstractContentParser {
     private static final float OVERPAINT_ALPHA = 0.4f;
 
     private static final ClipDrawCmd clipDrawCmd = new ClipDrawCmd();
+
+    // transparency group colour-space key (/CS), for group-boundary markers.
+    private static final Name GROUP_CS_KEY = new Name("CS");
     private static final NoClipDrawCmd noClipDrawCmd = new NoClipDrawCmd();
 
     protected GraphicsState graphicState;
@@ -579,6 +582,18 @@ public abstract class AbstractContentParser {
             // shapes straight onto the page; otherwise it is painted inline
             // (ShapesDrawCmd), which also avoids the quality loss of buffering
             // through an affine transform.  See classifyTransparencyGroup.
+            // Inert group-boundary markers delimit the group's emission on the
+            // stack, carrying its attributes for a compositor (page-group buffer /
+            // scoped-run buffer).  GroupDrawCmd paints nothing, so the default
+            // paint loop is unaffected.
+            boolean emitGroupMarkers = formXObject.isTransparencyGroup();
+            if (emitGroupMarkers) {
+                Object groupCs = formXObject.getLibrary().getObject(formXObject.getGroup(), GROUP_CS_KEY);
+                Name groupBlend = formXObject.getExtGState() != null
+                        ? formXObject.getExtGState().getBlendingMode() : null;
+                shapes.add(new GroupDrawCmd(true, formXObject.isIsolated(), formXObject.isKnockOut(),
+                        groupCs instanceof Name ? (Name) groupCs : null, groupBlend, formXObject.getBBox()));
+            }
             if (!disableTransparencyGroups && requiresOffscreenBuffer(formXObject)) {
                 // add the hold form for further processing.
                 FormDrawCmd formDrawCmd = new FormDrawCmd(formXObject);
@@ -598,6 +613,10 @@ public abstract class AbstractContentParser {
                 }
             } else {
                 shapes.add(new ShapesDrawCmd(formXObject.getShapes()));
+            }
+            if (emitGroupMarkers) {
+                shapes.add(new GroupDrawCmd(false, formXObject.isIsolated(), formXObject.isKnockOut(),
+                        null, null, formXObject.getBBox()));
             }
             // update text sprites with geometric path state
             if (formXObject.getShapes() != null &&

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpaceTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpaceTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpaceTest.java
@@ -105,4 +105,54 @@ public class CmykBlendingSpaceTest {
     public void hasFourChannels() {
         assertEquals(4, CMYK.channelCount());
     }
+
+    /** The sRGB recovery carries NO black channel (K=0): a real black channel is
+     *  unrecoverable from sRGB and must come from the preserved CMYK samples. */
+    @Test
+    public void fromSRGBGeneratesNoBlack() {
+        double[] ch = new double[4];
+        for (int argb : new int[]{0xFF7F3D12, 0xFF000000, 0xFF8040C0}) {
+            CMYK.fromSRGB(argb, ch);
+            assertEquals(0.0, ch[3], 1e-9, "fromSRGB must not fabricate a K channel");
+        }
+    }
+
+    /** Why subtractive routing is DEFERRED on the sRGB path: blending sRGB-recovered
+     *  CMYK (K=0) through this space is identical to a plain RGB blend for every
+     *  white-preserving mode -- the complements cancel, so there is no subtractive
+     *  gain to be had from sRGB, only the risk of a fabricated-K colour shift.  This
+     *  is the property that lets composeContribution stay additive without loss. */
+    @Test
+    public void k0RecoveryEqualsRgbForWhitePreservingModes() {
+        BlendComposite.BlendingMode[] whitePreserving = {
+                BlendComposite.BlendingMode.MULTIPLY,
+                BlendComposite.BlendingMode.SCREEN,
+                BlendComposite.BlendingMode.OVERLAY,
+                BlendComposite.BlendingMode.DARKEN,
+                BlendComposite.BlendingMode.LIGHTEN,
+                BlendComposite.BlendingMode.HARD_LIGHT,
+        };
+        int[] colours = {0xFFFFA500, 0xFFC86432, 0xFF6496C8, 0xFFFFFFFF, 0xFF000000, 0xFFB43CC8};
+        double[] cs = new double[4], cb = new double[4], rs = new double[3], rb = new double[3];
+        double[] outC = new double[4], outR = new double[3];
+        for (BlendComposite.BlendingMode mode : whitePreserving) {
+            for (int b : colours) {
+                for (int s : colours) {
+                    // CMYK(K=0) path
+                    CMYK.fromSRGB(s, cs);
+                    CMYK.fromSRGB(b, cb);
+                    for (int c = 0; c < 4; c++) outC[c] = CMYK.separable(mode, cb[c], cs[c]);
+                    int viaCmyk = CMYK.toSRGB(outC, 0xFF) & 0xFFFFFF;
+                    // RGB path
+                    RGB.fromSRGB(s, rs);
+                    RGB.fromSRGB(b, rb);
+                    for (int c = 0; c < 3; c++) outR[c] = RGB.separable(mode, rb[c], rs[c]);
+                    int viaRgb = RGB.toSRGB(outR, 0xFF) & 0xFFFFFF;
+                    assertEquals(viaRgb, viaCmyk,
+                            () -> String.format("%s blend diverged: rgb=%06X cmyk=%06X",
+                                    mode, viaRgb, viaCmyk));
+                }
+            }
+        }
+    }
 }

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpaceTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykBlendingSpaceTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the subtractive-blend contract of {@link CmykBlendingSpace} (GH-501): the
+ * §11.3.5 blend math run on the ink complement, and a device conversion that
+ * round-trips losslessly so the isolated group colour survives the composite.
+ */
+public class CmykBlendingSpaceTest {
+
+    private static final CmykBlendingSpace CMYK = CmykBlendingSpace.INSTANCE;
+    private static final RgbBlendingSpace RGB = RgbBlendingSpace.INSTANCE;
+
+    /** The round-trip must be the identity for in-gamut colours, so an isolated
+     *  group colour Cs is unchanged and only the backdrop blend alters a pixel. */
+    @Test
+    public void srgbRoundTripIsLossless() {
+        int[] samples = {
+                0xFFFFFFFF, // white
+                0xFF000000, // black
+                0xFFFF0000, // red
+                0xFF00FF00, // green
+                0xFF0000FF, // blue
+                0xFF7F3D12, // an arbitrary mid colour
+                0xFF12AB9C,
+        };
+        double[] ch = new double[4];
+        for (int argb : samples) {
+            CMYK.fromSRGB(argb, ch);
+            int back = CMYK.toSRGB(ch, 0xFF);
+            assertEquals(argb & 0xFFFFFF, back & 0xFFFFFF,
+                    () -> String.format("round-trip lost colour: %06X -> %06X",
+                            argb & 0xFFFFFF, back & 0xFFFFFF));
+        }
+    }
+
+    /** Multiply with white (no ink) is the identity in CMYK: full ink stays full
+     *  ink.  The naive additive form (cb*cs/255) would wrongly wash it to zero --
+     *  this is the bug that muddied DeviceCMYK groups blended in RGB. */
+    @Test
+    public void multiplyWithWhitePreservesInk() {
+        double fullInk = 255.0, noInk = 0.0;
+        assertEquals(fullInk,
+                CMYK.separable(BlendComposite.BlendingMode.MULTIPLY, fullInk, noInk), 1e-9);
+        assertEquals(fullInk,
+                CMYK.separable(BlendComposite.BlendingMode.MULTIPLY, noInk, fullInk), 1e-9);
+    }
+
+    /** Multiply of two inked colorants darkens (adds ink) rather than lightening. */
+    @Test
+    public void multiplyDarkensInCmyk() {
+        double half = 127.5;
+        double result = CMYK.separable(BlendComposite.BlendingMode.MULTIPLY, half, half);
+        // additive multiply of the complements (127.5*127.5/255 = 63.75), complemented
+        // back to 191.25 ink -- strictly MORE ink than either operand.
+        assertEquals(191.25, result, 1e-9);
+        assertTrue(result > half, "subtractive multiply must increase ink (darken)");
+    }
+
+    /** Darken in a subtractive space picks the colour with MORE ink (the darker
+     *  one), i.e. the max ink -- the complement of additive Darken's min. */
+    @Test
+    public void darkenSelectsMoreInk() {
+        double lo = 40, hi = 200;
+        assertEquals(hi, CMYK.separable(BlendComposite.BlendingMode.DARKEN, lo, hi), 1e-9);
+        assertEquals(hi, CMYK.separable(BlendComposite.BlendingMode.DARKEN, hi, lo), 1e-9);
+    }
+
+    /** Every separable mode must satisfy the complement relationship to the
+     *  verified additive math, so CmykBlendingSpace never re-derives blend rules. */
+    @Test
+    public void separableIsComplementOfAdditive() {
+        double[] operands = {0, 40, 127.5, 200, 255};
+        for (BlendComposite.BlendingMode mode : BlendComposite.BlendingMode.values()) {
+            for (double cb : operands) {
+                for (double cs : operands) {
+                    double expected = 255.0 - RGB.separable(mode, 255.0 - cb, 255.0 - cs);
+                    assertEquals(expected, CMYK.separable(mode, cb, cs), 1e-9,
+                            () -> "mode " + mode + " broke the complement identity");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void hasFourChannels() {
+        assertEquals(4, CMYK.channelCount());
+    }
+}

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositorTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositorTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykGroupCompositorTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import org.icepdf.core.pobjects.graphics.RasterOps.IccCmykRasterOp;
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.DataBufferByte;
+import java.awt.image.DataBufferInt;
+import java.awt.image.Raster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the raster-level subtractive contract of {@link CmykGroupCompositor}
+ * (GH-501 Phase 2, step 1): genuine black ink survives the blend, the final
+ * convert matches the decoder's ICC transform, and the contribution carries the
+ * group alpha {@code ca*ag}.
+ */
+public class CmykGroupCompositorTest {
+
+    /** ICC sRGB of an interleaved CMYK ink buffer, the reference the compositor
+     *  must match for a no-op blend (Multiply over white). */
+    private static int[] iccRgb(byte[] ink, int w, int h) {
+        BufferedImage rgb = new BufferedImage(w, h, BufferedImage.TYPE_INT_ARGB);
+        Raster src = Raster.createInterleavedRaster(
+                new DataBufferByte(ink, ink.length), w, h, w * 4, 4,
+                new int[]{0, 1, 2, 3}, null);
+        new IccCmykRasterOp(null).filter(src, rgb.getRaster());
+        return ((DataBufferInt) rgb.getRaster().getDataBuffer()).getData().clone();
+    }
+
+    /** Multiply over a white (no-ink) backdrop is the identity in CMYK, so the
+     *  blended ink equals the source ink and the result must equal a direct ICC
+     *  convert of that ink -- proving the K channel flows through untouched. */
+    @Test
+    public void multiplyOverWhiteMatchesIccConvertIncludingBlack() {
+        int w = 4, h = 1;
+        byte[] ink = new byte[]{
+                // C   M    Y    K
+                (byte) 0, (byte) 0, (byte) 0, (byte) 255,      // pure black ink
+                (byte) 0, (byte) 0, (byte) 200, (byte) 30,     // inky orange with some K
+                (byte) 255, (byte) 0, (byte) 0, (byte) 0,      // cyan, no K
+                (byte) 40, (byte) 60, (byte) 10, (byte) 120,   // muddy mid with K
+        };
+        int[] alpha = {255, 255, 255, 255};
+        int[] backdrop = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+
+        BufferedImage out = CmykGroupCompositor.compose(
+                ink, alpha, backdrop, BlendComposite.BlendingMode.MULTIPLY, 1f, w, h);
+        int[] got = ((DataBufferInt) out.getRaster().getDataBuffer()).getData();
+        int[] expected = iccRgb(ink, w, h);
+
+        for (int i = 0; i < w; i++) {
+            assertEquals(expected[i] & 0xFFFFFF, got[i] & 0xFFFFFF,
+                    () -> "Multiply-over-white must equal the unblended ICC convert (K preserved)");
+            assertEquals(0xFF, got[i] >>> 24, "full ca*ag -> opaque contribution");
+        }
+        // The pure-black-ink pixel must actually be (near) black, not washed to a
+        // colour -- this is the property the sRGB path could never deliver.
+        int black = got[0];
+        assertTrue(((black >> 16) & 0xFF) < 60 && ((black >> 8) & 0xFF) < 60 && (black & 0xFF) < 60,
+                () -> String.format("K=255 ink must stay dark, got %06X", black & 0xFFFFFF));
+    }
+
+    /** The contribution alpha is round(ca*ag); ag==0 contributes nothing. */
+    @Test
+    public void contributionAlphaIsCaTimesAg() {
+        int w = 3, h = 1;
+        byte[] ink = new byte[]{
+                10, 20, 30, 40,
+                10, 20, 30, 40,
+                10, 20, 30, 40,
+        };
+        int[] alpha = {255, 128, 0};
+        int[] backdrop = {0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF};
+        BufferedImage out = CmykGroupCompositor.compose(
+                ink, alpha, backdrop, BlendComposite.BlendingMode.MULTIPLY, 0.5f, w, h);
+        int[] got = ((DataBufferInt) out.getRaster().getDataBuffer()).getData();
+        assertEquals(128, got[0] >>> 24, "ca=0.5 * ag=255 -> 128");
+        assertEquals(64, got[1] >>> 24, "ca=0.5 * ag=128 -> 64");
+        assertEquals(0, got[2] >>> 24, "ag=0 -> no contribution");
+    }
+}

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykSampleProbeTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykSampleProbeTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import org.icepdf.core.pobjects.Document;
+import org.icepdf.core.pobjects.Page;
+import org.icepdf.core.pobjects.graphics.images.ImageUtility;
+import org.icepdf.core.util.GraphicsRenderingHints;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * GH-501 strategic probe (not a unit test -- opt-in via {@code -Dcmyk.probe=1}).
+ * Renders page 0 of each corpus PDF with CMYK-sample preservation ON and reports
+ * the K-channel (black ink) statistics of the preserved DeviceCMYK samples.
+ * <p>
+ * Answers: does the blending corpus carry genuine black ink?  Subtractive blending
+ * equals additive RGB for K=0 content (see {@link CmykBlendingSpace}), so the
+ * raster-level subtractive path only has a payoff target where {@code maxK > 0}.
+ * Point it at directories with {@code -Dcmyk.probe.dirs=/a:/b}.
+ */
+@EnabledIfSystemProperty(named = "cmyk.probe", matches = "1")
+public class CmykSampleProbeTest {
+
+    /** Run headless via Gradle:  ./gradlew :core:core-awt:cmykProbe [-Pcmyk.probe.dirs=/a:/b] */
+    public static void main(String[] args) {
+        new CmykSampleProbeTest().probeCmykBlackInk();
+    }
+
+    @Test
+    public void probeCmykBlackInk() {
+        String dirs = System.getProperty("cmyk.probe.dirs",
+                "/home/pcorless/dev/pdf-qa/graphics/blending"
+                        + ":/home/pcorless/dev/pdf-qa/graphics/blending/Multiply"
+                        + ":/home/pcorless/dev/pdf-qa/graphics/blending/overlay"
+                        + ":/home/pcorless/dev/pdf-qa/graphics/blending/screen");
+        List<File> pdfs = new ArrayList<>();
+        for (String d : dirs.split(":")) {
+            File dir = new File(d);
+            File[] files = dir.listFiles((f, n) -> n.toLowerCase().endsWith(".pdf"));
+            if (files != null) {
+                Arrays.sort(files);
+                pdfs.addAll(Arrays.asList(files));
+            }
+        }
+        System.out.println("\n==== GH-501 CMYK black-ink probe : " + pdfs.size() + " files ====");
+        System.out.printf("%-52s %7s %12s %12s %5s%n",
+                "file", "images", "pixels", "K>8 px", "maxK");
+        List<String> withBlack = new ArrayList<>();
+        for (File pdf : pdfs) {
+            boolean prev = ImageUtility.setPreserveCmyk(true);
+            ImageUtility.clearCmykSamples();
+            Document doc = null;
+            try {
+                doc = new Document();
+                doc.setFile(pdf.getAbsolutePath());
+                if (doc.getNumberOfPages() > 0) {
+                    Page page = doc.getPageTree().getPage(0);
+                    page.init();
+                    org.icepdf.core.pobjects.PDimension sz =
+                            page.getSize(Page.BOUNDARY_CROPBOX, 0f, 1f);
+                    int w = Math.max(1, Math.min(2000, (int) sz.getWidth()));
+                    int h = Math.max(1, Math.min(2000, (int) sz.getHeight()));
+                    BufferedImage img = new BufferedImage(w, h, BufferedImage.TYPE_INT_RGB);
+                    Graphics2D g = img.createGraphics();
+                    page.paint(g, GraphicsRenderingHints.PRINT, Page.BOUNDARY_CROPBOX, 0f, 1f);
+                    g.dispose();
+                    img.flush();
+                }
+                long[] s = ImageUtility.cmykKSummary();
+                String name = pdf.getName();
+                if (name.length() > 50) name = name.substring(0, 49) + "~";
+                System.out.printf("%-52s %7d %12d %12d %5d%n", name, s[0], s[1], s[2], s[3]);
+                if (s[3] > 0) {
+                    withBlack.add(String.format("%s  (maxK=%d, K>8 px=%d)", pdf.getName(), s[3], s[2]));
+                }
+            } catch (Exception e) {
+                System.out.printf("%-52s  ERROR %s%n", pdf.getName(), e);
+            } finally {
+                if (doc != null) doc.dispose();
+                ImageUtility.clearCmykSamples();
+                ImageUtility.setPreserveCmyk(prev);
+            }
+        }
+        System.out.println("\n---- files with genuine black ink (raster-path payoff targets) ----");
+        if (withBlack.isEmpty()) {
+            System.out.println("  NONE: every preserved CMYK image is K=0 -> subtractive == additive for this corpus.");
+        } else {
+            withBlack.forEach(s -> System.out.println("  " + s));
+        }
+        System.out.println("==== end probe ====\n");
+    }
+}

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykSampleProbeTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/CmykSampleProbeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2019 ICEsoft Technologies Canada Corp.
+ * Copyright 2026 Patrick Corless
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the
@@ -22,7 +22,7 @@ import org.icepdf.core.util.GraphicsRenderingHints;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-import java.awt.Graphics2D;
+import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.util.ArrayList;


### PR DESCRIPTION
## GH-50: CMYK-correct transparency-group compositing & backdrop handling

Banged pretty hard against this wall over the years and mains some very measurable gains using claude to accelerate the work. Still not perfect but some very measurable gains in render quality. 

Builds on the merged GH-495 rendering work to fix transparency-group blending in CMYK documents and tighten §10 backdrop compositing. Adds a proper blending-space abstraction so groups composite in the document's real colour space instead of being forced through sRGB.

### Blending-space seam (GH-501 Phase 1–2)
- New `BlendingSpace` abstraction with `RgbBlendingSpace` and `CmykBlendingSpace` implementations — group compositing now routes through the space that matches the content, instead of collapsing everything to sRGB.
- Preserve **true CMYK samples** end-to-end: at image decode, across the raw FlateDecode image path, and into the group compositor — so black-ink (true-K) content blends correctly rather than round-tripping through RGB.
- New `CmykGroupCompositor` for raster-level CMYK group blends; per-group subtractive routing gated by a CMYK black-ink probe against the corpus.

### Page-level transparency groups (GH-501 Phase A–B)
- Transparency-group foundation: group markers + page `/Group` detection (inert Phase A), then a flag-gated page-level CMYK group buffer (Phase B), seeded with a transparent backdrop.
- Buffer defaulted **on** and the opt-out flag removed once validated.
- §10 backdrop compositing retained for Normal groups painted into the page buffer.

### Blend-mode correctness fixes
- Fix `Overlay` result alpha (was dropping source coverage).
- Map `ColorDodge`/`ColorBurn` to their spec blenders rather than `SoftDodge`/`SoftBurn`.
- Weight group-buffer blends by per-pixel source coverage.
- Make the §10 backdrop-composite **decline gate stack-aware** (group-excluded backdrop) and decline it for opaque white-washing blends over a blank backdrop.

### Tests & build
- New `CmykBlendingSpaceTest`, `CmykGroupCompositorTest`, `CmykSampleProbeTest`.
- Gradle parallel-build fix.

### New files
`BlendingSpace`, `RgbBlendingSpace`, `CmykBlendingSpace`, `CmykGroupCompositor`, `TransparencyGroup`, `GroupDrawCmd` (+ the three CMYK tests).
