### PR TITLE
GH-506 shading enhancements

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/MeshShadingPaint.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/MeshShadingPaint.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Patrick Corless
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import java.awt.Paint;
+import java.awt.PaintContext;
+import java.awt.Rectangle;
+import java.awt.RenderingHints;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.ColorModel;
+import java.awt.image.DataBufferInt;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+import java.util.List;
+
+/**
+ * A {@link Paint} that renders a Gouraud-shaded triangle mesh, the common
+ * rasterisation target for PDF shading types 4-7 (free-form and lattice-form
+ * Gouraud triangle meshes, and Coons/tensor patch meshes tessellated into
+ * triangles).
+ * <p>
+ * Java2D has no native mesh paint, so each triangle is rasterised directly with
+ * barycentric (Gouraud) colour interpolation.  The triangles are supplied in the
+ * shading's own coordinate space; {@link #createContext} concatenates the live
+ * device transform with the shading-to-user transform (the pattern
+ * {@code Matrix}, identity for a bare {@code sh}) and rasterises every triangle
+ * once into an ARGB buffer sized to the requested device bounds.  Pixels not
+ * covered by any patch stay transparent so the surrounding content shows through.
+ *
+ * @since 7.5
+ */
+public class MeshShadingPaint implements Paint {
+
+    /**
+     * A single mesh triangle: three vertices in shading space, each with an
+     * sRGB colour (packed ARGB).  Colours are interpolated across the triangle.
+     */
+    public static final class Triangle {
+        final float x0, y0, x1, y1, x2, y2;
+        final int c0, c1, c2;
+
+        public Triangle(float x0, float y0, int c0,
+                        float x1, float y1, int c1,
+                        float x2, float y2, int c2) {
+            this.x0 = x0;
+            this.y0 = y0;
+            this.c0 = c0;
+            this.x1 = x1;
+            this.y1 = y1;
+            this.c1 = c1;
+            this.x2 = x2;
+            this.y2 = y2;
+            this.c2 = c2;
+        }
+    }
+
+    private final List<Triangle> triangles;
+    private final AffineTransform shadingToUser;
+
+    /**
+     * @param triangles    mesh triangles in shading space (may be empty).
+     * @param shadingToUser maps shading space to user space (the pattern
+     *                      {@code Matrix}); may be {@code null} for a bare
+     *                      {@code sh} shading, where shading space is user space.
+     */
+    public MeshShadingPaint(List<Triangle> triangles, AffineTransform shadingToUser) {
+        this.triangles = triangles;
+        this.shadingToUser = shadingToUser;
+    }
+
+    @Override
+    public int getTransparency() {
+        return TRANSLUCENT;
+    }
+
+    @Override
+    public PaintContext createContext(ColorModel cm, Rectangle deviceBounds,
+                                      Rectangle2D userBounds, AffineTransform xform,
+                                      RenderingHints hints) {
+        AffineTransform full = new AffineTransform(xform);
+        if (shadingToUser != null) {
+            full.concatenate(shadingToUser);
+        }
+        return new MeshPaintContext(triangles, full, deviceBounds);
+    }
+
+    /**
+     * Rasterises the triangle mesh into an ARGB buffer covering the device
+     * bounds once, then serves tiles from it.
+     */
+    private static final class MeshPaintContext implements PaintContext {
+
+        private final int[] buffer;
+        private final int imgW, imgH;
+        private final int originX, originY;
+
+        MeshPaintContext(List<Triangle> triangles, AffineTransform full, Rectangle deviceBounds) {
+            originX = deviceBounds.x;
+            originY = deviceBounds.y;
+            imgW = Math.max(1, deviceBounds.width);
+            imgH = Math.max(1, deviceBounds.height);
+            buffer = new int[imgW * imgH];
+            double[] pts = new double[6];
+            for (Triangle t : triangles) {
+                pts[0] = t.x0;
+                pts[1] = t.y0;
+                pts[2] = t.x1;
+                pts[3] = t.y1;
+                pts[4] = t.x2;
+                pts[5] = t.y2;
+                full.transform(pts, 0, pts, 0, 3);
+                rasterize(pts, t.c0, t.c1, t.c2);
+            }
+        }
+
+        /**
+         * Scanline-fills one device-space triangle with barycentric colour
+         * interpolation.  Shared triangle edges carry identical colours, so
+         * overwriting on the seam is harmless.
+         */
+        private void rasterize(double[] p, int c0, int c1, int c2) {
+            double x0 = p[0] - originX, y0 = p[1] - originY;
+            double x1 = p[2] - originX, y1 = p[3] - originY;
+            double x2 = p[4] - originX, y2 = p[5] - originY;
+
+            double det = (y1 - y2) * (x0 - x2) + (x2 - x1) * (y0 - y2);
+            if (Math.abs(det) < 1e-9) {
+                return; // degenerate sliver
+            }
+            int minX = (int) Math.floor(Math.min(x0, Math.min(x1, x2)));
+            int maxX = (int) Math.ceil(Math.max(x0, Math.max(x1, x2)));
+            int minY = (int) Math.floor(Math.min(y0, Math.min(y1, y2)));
+            int maxY = (int) Math.ceil(Math.max(y0, Math.max(y1, y2)));
+            if (minX < 0) minX = 0;
+            if (minY < 0) minY = 0;
+            if (maxX > imgW - 1) maxX = imgW - 1;
+            if (maxY > imgH - 1) maxY = imgH - 1;
+
+            int a0 = (c0 >>> 24) & 0xff, r0 = (c0 >> 16) & 0xff, g0 = (c0 >> 8) & 0xff, b0 = c0 & 0xff;
+            int a1 = (c1 >>> 24) & 0xff, r1 = (c1 >> 16) & 0xff, g1 = (c1 >> 8) & 0xff, b1 = c1 & 0xff;
+            int a2 = (c2 >>> 24) & 0xff, r2 = (c2 >> 16) & 0xff, g2 = (c2 >> 8) & 0xff, b2 = c2 & 0xff;
+
+            double invDet = 1.0 / det;
+            for (int y = minY; y <= maxY; y++) {
+                double py = y + 0.5;
+                int row = y * imgW;
+                for (int x = minX; x <= maxX; x++) {
+                    double px = x + 0.5;
+                    double l0 = ((y1 - y2) * (px - x2) + (x2 - x1) * (py - y2)) * invDet;
+                    double l1 = ((y2 - y0) * (px - x2) + (x0 - x2) * (py - y2)) * invDet;
+                    double l2 = 1.0 - l0 - l1;
+                    // small negative tolerance so shared edges don't leave gaps
+                    if (l0 < -0.001 || l1 < -0.001 || l2 < -0.001) {
+                        continue;
+                    }
+                    int a = (int) (l0 * a0 + l1 * a1 + l2 * a2 + 0.5);
+                    int r = (int) (l0 * r0 + l1 * r1 + l2 * r2 + 0.5);
+                    int g = (int) (l0 * g0 + l1 * g1 + l2 * g2 + 0.5);
+                    int b = (int) (l0 * b0 + l1 * b1 + l2 * b2 + 0.5);
+                    buffer[row + x] = (a << 24) | (r << 16) | (g << 8) | b;
+                }
+            }
+        }
+
+        @Override
+        public ColorModel getColorModel() {
+            return ColorModel.getRGBdefault();
+        }
+
+        @Override
+        public Raster getRaster(int x, int y, int w, int h) {
+            WritableRaster raster = getColorModel().createCompatibleWritableRaster(w, h);
+            int[] tile = ((DataBufferInt) raster.getDataBuffer()).getData();
+            for (int j = 0; j < h; j++) {
+                int sy = y + j - originY;
+                if (sy < 0 || sy >= imgH) {
+                    continue;
+                }
+                int srcRow = sy * imgW;
+                int dstRow = j * w;
+                for (int i = 0; i < w; i++) {
+                    int sx = x + i - originX;
+                    if (sx < 0 || sx >= imgW) {
+                        continue;
+                    }
+                    tile[dstRow + i] = buffer[srcRow + sx];
+                }
+            }
+            return raster;
+        }
+
+        @Override
+        public void dispose() {
+        }
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
@@ -116,7 +116,9 @@ public abstract class ShadingMeshPattern extends ShadingPattern implements Patte
 
         java.util.List<Number> decodeVec = (java.util.List<Number>) library.getObject(shadingDictionary, ImageParams.DECODE_KEY);
 
-        float maxValue = bitsPerCoordinate < 32 ? (float) ((1 << bitsPerCoordinate) - 1) : (float) 2.3283064365386963e-10; // 2^-32;
+        // 2^bitsPerCoordinate - 1, computed with a long so the common 32-bit
+        // case (4294967295) does not overflow an int.
+        float maxValue = (float) ((1L << bitsPerCoordinate) - 1);
         for (int i = 0; i <= DECODE_Y_MAX; ) {
             float Dmin = decodeVec.get(i).floatValue();
             float Dmax = decodeVec.get(i + 1).floatValue();
@@ -150,14 +152,16 @@ public abstract class ShadingMeshPattern extends ShadingPattern implements Patte
      * @throws IOException bit stream issue.
      */
     protected Point2D.Float readCoord() throws IOException {
-        float x = vertexBitStream.getBits(bitsPerCoordinate);
-        float y = vertexBitStream.getBits(bitsPerCoordinate);
+        // Coordinates can be up to 32 bits; getBits(32) returns a signed int, so
+        // treat the raw sample as unsigned before decoding.
+        long rawX = vertexBitStream.getBits(bitsPerCoordinate) & 0xFFFFFFFFL;
+        long rawY = vertexBitStream.getBits(bitsPerCoordinate) & 0xFFFFFFFFL;
         // Map the raw sample into the Decode range.  processDecode stored the
         // interval minimum in decode[*_MIN] and the per-unit slope
-        // (Dmax-Dmin)/2^bits-1 in decode[*_MAX], so the decoded value is
+        // (Dmax-Dmin)/(2^bits-1) in decode[*_MAX], so the decoded value is
         // Dmin + raw * slope.
-        x = decode[DECODE_X_MIN] + x * decode[DECODE_X_MAX];
-        y = decode[DECODE_Y_MIN] + y * decode[DECODE_Y_MAX];
+        float x = decode[DECODE_X_MIN] + rawX * decode[DECODE_X_MAX];
+        float y = decode[DECODE_Y_MIN] + rawY * decode[DECODE_Y_MAX];
         return new Point2D.Float(x, y);
     }
 

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
@@ -24,8 +24,11 @@ import org.icepdf.core.pobjects.graphics.images.ImageParams;
 import org.icepdf.core.util.Library;
 
 import java.awt.*;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.NoninvertibleTransformException;
 import java.awt.geom.Point2D;
 import java.io.IOException;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
@@ -149,9 +152,12 @@ public abstract class ShadingMeshPattern extends ShadingPattern implements Patte
     protected Point2D.Float readCoord() throws IOException {
         float x = vertexBitStream.getBits(bitsPerCoordinate);
         float y = vertexBitStream.getBits(bitsPerCoordinate);
-        // normalize components to decode array
-        x *= decode[DECODE_X_MAX] - decode[DECODE_X_MIN] + decode[DECODE_X_MIN];
-        y *= decode[DECODE_Y_MAX] - decode[DECODE_Y_MIN] + decode[DECODE_Y_MIN];
+        // Map the raw sample into the Decode range.  processDecode stored the
+        // interval minimum in decode[*_MIN] and the per-unit slope
+        // (Dmax-Dmin)/2^bits-1 in decode[*_MAX], so the decoded value is
+        // Dmin + raw * slope.
+        x = decode[DECODE_X_MIN] + x * decode[DECODE_X_MAX];
+        y = decode[DECODE_Y_MIN] + y * decode[DECODE_Y_MAX];
         return new Point2D.Float(x, y);
     }
 
@@ -167,15 +173,15 @@ public abstract class ShadingMeshPattern extends ShadingPattern implements Patte
         if (function == null) {
             primitives = new float[colorSpaceCompCount];
             for (int i = 0, j = 4; i < colorSpaceCompCount; i++, j += 2) {
-                primitives[i] = vertexBitStream.getBits(bitsPerComponent);
-                // normalize
-                primitives[i] *= decode[j + 1] - decode[j] + decode[j];
+                float raw = vertexBitStream.getBits(bitsPerComponent);
+                // normalize: Cmin + raw * slope (see readCoord)
+                primitives[i] = decode[j] + raw * decode[j + 1];
             }
             return colorSpace.getColor(primitives, true);
         } else {
-            float value = vertexBitStream.getBits(bitsPerComponent);
-            // normalize
-            value *= (decode[5] - decode[4]) + decode[4];
+            float raw = vertexBitStream.getBits(bitsPerComponent);
+            // normalize: Cmin + raw * slope
+            float value = decode[4] + raw * decode[5];
             primitives = new float[]{value};
             float[] output = calculateValues(primitives);
             if (output != null) {
@@ -183,5 +189,139 @@ public abstract class ShadingMeshPattern extends ShadingPattern implements Patte
             }
         }
         return null;
+    }
+
+    // ---- shared mesh rendering helpers (types 4-7) ----------------------------
+
+    /** Number of subdivisions per patch edge when tessellating a Bézier patch. */
+    protected static final int PATCH_SUBDIVISIONS = 10;
+
+    /**
+     * Wraps a tessellated triangle list in a {@link MeshShadingPaint}, anchoring
+     * a shading <b>pattern</b> to its default coordinate system.  A shading
+     * pattern's {@code Matrix} maps shading space to the page's default user
+     * space and is independent of the fill-time CTM (PDF 32000-1 §8.7.3.1); the
+     * paint runs under the live {@code base·CTM}, so the CTM is cancelled
+     * ({@code base·CTM · CTM⁻¹·Matrix == base·Matrix}).
+     * <p>
+     * A mesh painted by the {@code sh} operator instead lives in the current
+     * user space -- its coordinates are relative to the live CTM, which must
+     * apply in full -- and carries no {@code /PatternType}.  Anchoring it would
+     * cancel that CTM and push the mesh off the fill region, so the raw matrix
+     * (identity for {@code sh}) is used unchanged.
+     *
+     * @param triangles     tessellated mesh triangles in shading space.
+     * @param graphicsState graphics state at the fill (for the fill-time CTM).
+     * @return a paint that Gouraud-rasterises the mesh.
+     */
+    protected MeshShadingPaint buildMeshPaint(List<MeshShadingPaint.Triangle> triangles,
+                                              GraphicsState graphicsState) {
+        AffineTransform shadingToUser = matrix;
+        if (patternType == PATTERN_TYPE_SHADING
+                && graphicsState != null && graphicsState.getCTM() != null) {
+            try {
+                AffineTransform anchored = graphicsState.getCTM().createInverse();
+                anchored.concatenate(matrix);
+                shadingToUser = anchored;
+            } catch (NoninvertibleTransformException e) {
+                // degenerate CTM; fall back to the raw matrix.
+            }
+        }
+        return new MeshShadingPaint(triangles, shadingToUser);
+    }
+
+    /**
+     * Tessellates one bicubic Bézier patch (a 4x4 control grid) into triangles,
+     * sampling the surface on a {@link #PATCH_SUBDIVISIONS} grid and blending the
+     * four corner colours bilinearly.  Corner colours are given in ARGB at the
+     * grid corners {@code (0,0),(0,3),(3,3),(3,0)}.  Shared by Coons (type 6, its
+     * four interior points derived) and tensor (type 7) patches.
+     */
+    protected static void tessellatePatch(Point2D.Float[][] p, int[] corners,
+                                          List<MeshShadingPaint.Triangle> out) {
+        int n = PATCH_SUBDIVISIONS;
+        int stride = n + 1;
+        float[] gx = new float[stride * stride];
+        float[] gy = new float[stride * stride];
+        int[] gc = new int[stride * stride];
+        for (int iu = 0; iu <= n; iu++) {
+            double u = (double) iu / n;
+            double[] bu = bernstein(u);
+            for (int iv = 0; iv <= n; iv++) {
+                double v = (double) iv / n;
+                double[] bv = bernstein(v);
+                double sx = 0, sy = 0;
+                for (int i = 0; i < 4; i++) {
+                    for (int j = 0; j < 4; j++) {
+                        double w = bu[i] * bv[j];
+                        sx += w * p[i][j].x;
+                        sy += w * p[i][j].y;
+                    }
+                }
+                int idx = iu * stride + iv;
+                gx[idx] = (float) sx;
+                gy[idx] = (float) sy;
+                gc[idx] = bilerpColor(corners, u, v);
+            }
+        }
+        for (int iu = 0; iu < n; iu++) {
+            for (int iv = 0; iv < n; iv++) {
+                int a = iu * stride + iv;
+                int b = a + 1;
+                int c = a + stride;
+                int d = c + 1;
+                out.add(new MeshShadingPaint.Triangle(
+                        gx[a], gy[a], gc[a], gx[b], gy[b], gc[b], gx[c], gy[c], gc[c]));
+                out.add(new MeshShadingPaint.Triangle(
+                        gx[b], gy[b], gc[b], gx[d], gy[d], gc[d], gx[c], gy[c], gc[c]));
+            }
+        }
+    }
+
+    /** Cubic Bernstein basis {@code [B0,B1,B2,B3]} at parameter t. */
+    protected static double[] bernstein(double t) {
+        double mt = 1 - t;
+        return new double[]{mt * mt * mt, 3 * t * mt * mt, 3 * t * t * mt, t * t * t};
+    }
+
+    /**
+     * Bilinear blend of four ARGB corner colours; corners map to
+     * {@code (u,v)} in {@code {0,1}²}: c0 at (0,0), c1 at (0,1), c2 at (1,1),
+     * c3 at (1,0).
+     */
+    protected static int bilerpColor(int[] c, double u, double v) {
+        double w0 = (1 - u) * (1 - v);
+        double w1 = (1 - u) * v;
+        double w2 = u * v;
+        double w3 = u * (1 - v);
+        int a = blendChannel(c, 24, w0, w1, w2, w3);
+        int r = blendChannel(c, 16, w0, w1, w2, w3);
+        int g = blendChannel(c, 8, w0, w1, w2, w3);
+        int b = blendChannel(c, 0, w0, w1, w2, w3);
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+
+    private static int blendChannel(int[] c, int shift, double w0, double w1, double w2, double w3) {
+        double val = ((c[0] >>> shift) & 0xff) * w0 + ((c[1] >>> shift) & 0xff) * w1
+                + ((c[2] >>> shift) & 0xff) * w2 + ((c[3] >>> shift) & 0xff) * w3;
+        int v = (int) (val + 0.5);
+        return v < 0 ? 0 : Math.min(v, 255);
+    }
+
+    /** Packs a colour to ARGB, treating {@code null} as fully transparent. */
+    protected static int colorArgb(Color color) {
+        return color != null ? color.getRGB() : 0;
+    }
+
+    /**
+     * Appends a single flat-shaded/Gouraud triangle (three vertices, each with
+     * an ARGB colour) to the mesh.  Used by the Gouraud triangle mesh types
+     * (4 and 5) which supply triangle vertices directly.
+     */
+    protected static void addTriangle(List<MeshShadingPaint.Triangle> out,
+                                      Point2D.Float p0, int c0,
+                                      Point2D.Float p1, int c1,
+                                      Point2D.Float p2, int c2) {
+        out.add(new MeshShadingPaint.Triangle(p0.x, p0.y, c0, p1.x, p1.y, c1, p2.x, p2.y, c2));
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingMeshPattern.java
@@ -221,7 +221,7 @@ public abstract class ShadingMeshPattern extends ShadingPattern implements Patte
     protected MeshShadingPaint buildMeshPaint(List<MeshShadingPaint.Triangle> triangles,
                                               GraphicsState graphicsState) {
         AffineTransform shadingToUser = matrix;
-        if (patternType == PATTERN_TYPE_SHADING
+        if (patternType == Pattern.PATTERN_TYPE_SHADING
                 && graphicsState != null && graphicsState.getCTM() != null) {
             try {
                 AffineTransform anchored = graphicsState.getCTM().createInverse();

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType4Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType4Pattern.java
@@ -19,16 +19,22 @@ import org.icepdf.core.pobjects.DictionaryEntries;
 import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.util.Library;
 
-import java.awt.*;
+import java.awt.Paint;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * Free-form Gouraud-shaded Triangle Meshes support.
+ * Free-form Gouraud-shaded triangle mesh (PDF 32000-1 §8.7.4.5.5, shading
+ * type 4).
  * <p>
- * Note: currently only parsing data and returning the first colour of the first vertex.
+ * Each vertex carries an edge flag, a coordinate, and a colour.  A flag of 0
+ * begins a new triangle (completed by the next two flag-0 vertices); a flag of 1
+ * reuses the previous triangle's second and third vertices (vb, vc) plus the new
+ * vertex; a flag of 2 reuses the first and third (va, vc) plus the new vertex.
+ * Triangles are Gouraud-rasterised by a {@link MeshShadingPaint}.
  *
  * @since 6.2
  */
@@ -37,30 +43,68 @@ public class ShadingType4Pattern extends ShadingMeshPattern {
     private static final Logger logger =
             Logger.getLogger(ShadingType4Pattern.class.getName());
 
-    private ArrayList<Color> colorComponents = new ArrayList<>();
+    private MeshShadingPaint meshPaint;
 
     public ShadingType4Pattern(Library l, DictionaryEntries h, Stream meshDataStream) {
         super(l, h, meshDataStream);
     }
 
     public synchronized void init(GraphicsState graphicsState) {
-
-        ArrayList<Integer> vertexEdgeFlag = new ArrayList<>();
-        ArrayList<Point2D.Float> coordinates = new ArrayList<>();
-        colorComponents = new ArrayList<>();
+        if (inited) {
+            return;
+        }
+        List<MeshShadingPaint.Triangle> triangles = new ArrayList<>();
+        Point2D.Float va = null, vb = null, vc = null;
+        int ca = 0, cb = 0, cc = 0;
         try {
             while (vertexBitStream.available() > 0) {
-                vertexEdgeFlag.add(readFlag());
-                coordinates.add(readCoord());
-                colorComponents.add(readColor());
+                int flag = readFlag() & 0x03;
+                Point2D.Float p = readCoord();
+                int c = colorArgb(readColor());
+                if (flag == 0) {
+                    // Start a new triangle: this vertex plus the next two (which
+                    // shall also be flag 0) form it.
+                    va = p;
+                    ca = c;
+                    if (vertexBitStream.available() <= 0) {
+                        break;
+                    }
+                    readFlag();
+                    vb = readCoord();
+                    cb = colorArgb(readColor());
+                    if (vertexBitStream.available() <= 0) {
+                        break;
+                    }
+                    readFlag();
+                    vc = readCoord();
+                    cc = colorArgb(readColor());
+                } else if (flag == 1) {
+                    // Share edge vb-vc of the previous triangle.
+                    va = vb;
+                    ca = cb;
+                    vb = vc;
+                    cb = cc;
+                    vc = p;
+                    cc = c;
+                } else {
+                    // flag == 2: share edge va-vc of the previous triangle.
+                    vb = vc;
+                    cb = cc;
+                    vc = p;
+                    cc = c;
+                }
+                if (va != null && vb != null && vc != null) {
+                    addTriangle(triangles, va, ca, vb, cb, vc, cc);
+                }
             }
         } catch (IOException e) {
             logger.warning("Error parsing Shading type 4 pattern vertices.");
         }
+        meshPaint = buildMeshPaint(triangles, graphicsState);
+        inited = true;
     }
 
     public Paint getPaint() {
-        return colorComponents.get(0);
+        return meshPaint;
     }
-
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType5Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType5Pattern.java
@@ -16,19 +16,24 @@
 package org.icepdf.core.pobjects.graphics;
 
 import org.icepdf.core.pobjects.DictionaryEntries;
+import org.icepdf.core.pobjects.Name;
 import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.util.Library;
 
-import java.awt.*;
+import java.awt.Paint;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * Lattice-Form Gouraud-shaded Triangle Meshes support.
+ * Lattice-form Gouraud-shaded triangle mesh (PDF 32000-1 §8.7.4.5.6, shading
+ * type 5).
  * <p>
- * Note: currently only parsing data and returning the first colour of the first vertex.
+ * Vertices carry no edge flags; they are read row by row, {@code VerticesPerRow}
+ * per row.  Each cell between two adjacent rows is split into two triangles,
+ * Gouraud-rasterised by a {@link MeshShadingPaint}.
  *
  * @since 6.2
  */
@@ -37,26 +42,57 @@ public class ShadingType5Pattern extends ShadingMeshPattern {
     private static final Logger logger =
             Logger.getLogger(ShadingType5Pattern.class.getName());
 
-    private ArrayList<Color> colorComponents = new ArrayList<>();
+    public static final Name VERTICES_PER_ROW_KEY = new Name("VerticesPerRow");
+
+    private MeshShadingPaint meshPaint;
 
     public ShadingType5Pattern(Library l, DictionaryEntries h, Stream meshDataStream) {
         super(l, h, meshDataStream);
     }
 
     public synchronized void init(GraphicsState graphicsState) {
-        ArrayList<Point2D.Float> coordinates = new ArrayList<>();
-        colorComponents = new ArrayList<>();
+        if (inited) {
+            return;
+        }
+        List<MeshShadingPaint.Triangle> triangles = new ArrayList<>();
+        int perRow = library.getInt(shadingDictionary, VERTICES_PER_ROW_KEY);
         try {
-            while (vertexBitStream.available() > 0) {
-                coordinates.add(readCoord());
-                colorComponents.add(readColor());
+            if (perRow >= 2) {
+                List<Point2D.Float> coords = new ArrayList<>();
+                List<Integer> colors = new ArrayList<>();
+                while (vertexBitStream.available() > 0) {
+                    coords.add(readCoord());
+                    colors.add(colorArgb(readColor()));
+                }
+                int rows = coords.size() / perRow;
+                // Two triangles per lattice cell between adjacent rows/columns.
+                for (int r = 0; r < rows - 1; r++) {
+                    for (int col = 0; col < perRow - 1; col++) {
+                        int i00 = r * perRow + col;
+                        int i01 = i00 + 1;
+                        int i10 = i00 + perRow;
+                        int i11 = i10 + 1;
+                        addTriangle(triangles,
+                                coords.get(i00), colors.get(i00),
+                                coords.get(i01), colors.get(i01),
+                                coords.get(i10), colors.get(i10));
+                        addTriangle(triangles,
+                                coords.get(i01), colors.get(i01),
+                                coords.get(i11), colors.get(i11),
+                                coords.get(i10), colors.get(i10));
+                    }
+                }
+            } else {
+                logger.warning("Shading type 5: invalid VerticesPerRow " + perRow);
             }
         } catch (IOException e) {
             logger.warning("Error parsing Shading type 5 pattern vertices.");
         }
+        meshPaint = buildMeshPaint(triangles, graphicsState);
+        inited = true;
     }
 
     public Paint getPaint() {
-        return colorComponents.get(0);
+        return meshPaint;
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType6Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType6Pattern.java
@@ -19,50 +19,145 @@ import org.icepdf.core.pobjects.DictionaryEntries;
 import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.util.Library;
 
-import java.awt.*;
+import java.awt.Paint;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * Coons Patch Meshes support.
+ * Coons Patch Mesh (PDF 32000-1 §8.7.4.5.7, shading type 6).
  * <p>
- * Note: currently only parsing data and returning the first colour of the first vertex.
+ * A Coons patch is bounded by four cubic Bézier curves (12 control points); the
+ * surface interior is defined by a bilinear blend of the boundary curves.  This
+ * is the special case of a tensor-product patch (type 7) whose four interior
+ * control points are derived from the boundary, so a Coons patch is converted to
+ * a 4x4 tensor control grid and tessellated with the shared
+ * {@link #tessellatePatch} path.
+ * <p>
+ * Patches with edge flag 0 supply all 12 points and 4 corner colours; flags 1-3
+ * share one edge (4 points + 2 colours) with the previous patch.
  *
  * @since 6.2
  */
-public class ShadingType6Pattern  extends ShadingMeshPattern {
+public class ShadingType6Pattern extends ShadingMeshPattern {
 
     private static final Logger logger =
             Logger.getLogger(ShadingType6Pattern.class.getName());
 
-    private ArrayList<Color> colorComponents = new ArrayList<>();
+    // Read order of the 12 Coons boundary control points, as (row, col) into the
+    // 4x4 grid p[row][col] (PDF 32000-1 Figure 45): the boundary clockwise from
+    // the (0,0) corner.  The four interior points (1,1)(1,2)(2,2)(2,1) are
+    // derived from the boundary in coonsInterior().
+    private static final int[][] COONS_ORDER = {
+            {0, 0}, {0, 1}, {0, 2}, {0, 3},
+            {1, 3}, {2, 3}, {3, 3},
+            {3, 2}, {3, 1}, {3, 0},
+            {2, 0}, {1, 0}
+    };
+
+    private MeshShadingPaint meshPaint;
 
     public ShadingType6Pattern(Library l, DictionaryEntries h, Stream meshDataStream) {
         super(l, h, meshDataStream);
     }
 
     public synchronized void init(GraphicsState graphicsState) {
-        ArrayList<Point2D.Float> coordinates = new ArrayList<>();
-        colorComponents = new ArrayList<>();
+        if (inited) {
+            return;
+        }
+        List<MeshShadingPaint.Triangle> triangles = new ArrayList<>();
+        Point2D.Float[] prevPoints = null;
+        int[] prevColors = null;
         try {
             while (vertexBitStream.available() > 0) {
-                int flag = readFlag();
-                // read control points.
-                for (int i = 0, ii = (flag != 0 ? 8 : 12); i < ii; i++) {
-                    coordinates.add(readCoord());
+                int flag = readFlag() & 0x03;
+                Point2D.Float[] points = new Point2D.Float[12];
+                int[] colors = new int[4];
+                if (flag == 0) {
+                    for (int i = 0; i < 12; i++) {
+                        points[i] = readCoord();
+                    }
+                    for (int i = 0; i < 4; i++) {
+                        colors[i] = colorArgb(readColor());
+                    }
+                } else {
+                    if (prevPoints == null) {
+                        logger.warning("Shading type 6: shared patch with no predecessor.");
+                        break;
+                    }
+                    int[] edge = sharedEdgeIndices(flag);
+                    for (int i = 0; i < 4; i++) {
+                        points[i] = prevPoints[edge[i]];
+                    }
+                    colors[0] = prevColors[edge[4]];
+                    colors[1] = prevColors[edge[5]];
+                    for (int i = 4; i < 12; i++) {
+                        points[i] = readCoord();
+                    }
+                    colors[2] = colorArgb(readColor());
+                    colors[3] = colorArgb(readColor());
                 }
-                for (int i = 0, ii = (flag != 0 ? 2 : 4); i < ii; i++) {
-                    colorComponents.add(readColor());
+                Point2D.Float[][] grid = new Point2D.Float[4][4];
+                for (int i = 0; i < 12; i++) {
+                    grid[COONS_ORDER[i][0]][COONS_ORDER[i][1]] = points[i];
                 }
+                coonsInterior(grid);
+                tessellatePatch(grid, colors, triangles);
+                prevPoints = points;
+                prevColors = colors;
             }
         } catch (IOException e) {
             logger.warning("Error parsing Shading type 6 pattern vertices.");
         }
+        meshPaint = buildMeshPaint(triangles, graphicsState);
+        inited = true;
+    }
+
+    /**
+     * Derives the four interior tensor control points of a Coons patch from its
+     * boundary, so the bicubic evaluator reproduces the Coons surface (PDF
+     * 32000-1 §8.7.4.5.7).  Each interior point is expressed relative to its
+     * nearest corner.
+     */
+    private static void coonsInterior(Point2D.Float[][] p) {
+        p[1][1] = combine(p[0][0], p[0][1], p[1][0], p[0][3], p[3][0], p[1][3], p[3][1], p[3][3]);
+        p[1][2] = combine(p[0][3], p[0][2], p[1][3], p[0][0], p[3][3], p[1][0], p[3][2], p[3][0]);
+        p[2][1] = combine(p[3][0], p[2][0], p[3][1], p[0][0], p[3][3], p[0][1], p[2][3], p[0][3]);
+        p[2][2] = combine(p[3][3], p[3][2], p[2][3], p[3][0], p[0][3], p[2][0], p[0][2], p[0][0]);
+    }
+
+    /**
+     * Interior control point = (-4·corner + 6·(e1+e2) - 2·(f1+f2) + 3·(g1+g2)
+     * - opposite) / 9, the Coons-to-tensor conversion where {@code corner} is
+     * the nearest corner, {@code e*} its two adjacent boundary points, {@code f*}
+     * the far corners along each edge, {@code g*} the boundary points adjacent to
+     * the opposite corner, and {@code opposite} the diagonally opposite corner.
+     */
+    private static Point2D.Float combine(Point2D.Float corner, Point2D.Float e1, Point2D.Float e2,
+                                         Point2D.Float f1, Point2D.Float f2, Point2D.Float g1,
+                                         Point2D.Float g2, Point2D.Float opposite) {
+        float x = (-4 * corner.x + 6 * (e1.x + e2.x) - 2 * (f1.x + f2.x)
+                + 3 * (g1.x + g2.x) - opposite.x) / 9f;
+        float y = (-4 * corner.y + 6 * (e1.y + e2.y) - 2 * (f1.y + f2.y)
+                + 3 * (g1.y + g2.y) - opposite.y) / 9f;
+        return new Point2D.Float(x, y);
+    }
+
+    /** Shared-edge point/colour indices for edge flags 1-3 (see type 7). */
+    private static int[] sharedEdgeIndices(int flag) {
+        switch (flag) {
+            case 1:
+                return new int[]{3, 4, 5, 6, 1, 2};
+            case 2:
+                return new int[]{6, 7, 8, 9, 2, 3};
+            default: // 3
+                return new int[]{9, 10, 11, 0, 3, 0};
+        }
     }
 
     public Paint getPaint() {
-        return colorComponents.get(0);
+        return meshPaint;
     }
 }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType7Pattern.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/ShadingType7Pattern.java
@@ -19,16 +19,26 @@ import org.icepdf.core.pobjects.DictionaryEntries;
 import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.util.Library;
 
-import java.awt.*;
+import java.awt.Paint;
 import java.awt.geom.Point2D;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 /**
- * Tensor-Product Patch Meshes support.
+ * Tensor-Product Patch Mesh (PDF 32000-1 §8.7.4.5.8, shading type 7).
  * <p>
- * Note: currently only parsing data and returning the first colour of the first vertex.
+ * Each patch is a bicubic Bézier surface defined by 16 control points -- the 12
+ * boundary points of a Coons patch (type 6) plus 4 interior points that give
+ * finer control over the surface.  The mesh stream is a run of patches; the
+ * first (edge flag 0) supplies all 16 points and 4 corner colours, while a patch
+ * with flag 1-3 shares one edge (4 control points + 2 colours) with the previous
+ * patch and reads the remaining 12 points + 2 colours.
+ * <p>
+ * The surface is tessellated into a grid of triangles (corner colours
+ * interpolated bilinearly) and handed to a {@link MeshShadingPaint} for Gouraud
+ * rasterisation.
  *
  * @since 6.2
  */
@@ -37,32 +47,102 @@ public class ShadingType7Pattern extends ShadingMeshPattern {
     private static final Logger logger =
             Logger.getLogger(ShadingType7Pattern.class.getName());
 
-    private ArrayList<Color> colorComponents = new ArrayList<>();
+    // Read order of the 16 tensor control points, as (row, col) into the 4x4
+    // control grid p[row][col] (PDF 32000-1 Figure 46): the 12 boundary points
+    // clockwise from the (0,0) corner, then the 4 interior points.
+    private static final int[][] TENSOR_ORDER = {
+            {0, 0}, {0, 1}, {0, 2}, {0, 3},
+            {1, 3}, {2, 3}, {3, 3},
+            {3, 2}, {3, 1}, {3, 0},
+            {2, 0}, {1, 0},
+            {1, 1}, {1, 2}, {2, 2}, {2, 1}
+    };
+
+    private MeshShadingPaint meshPaint;
 
     public ShadingType7Pattern(Library l, DictionaryEntries h, Stream meshDataStream) {
         super(l, h, meshDataStream);
     }
 
     public synchronized void init(GraphicsState graphicsState) {
-        ArrayList<Point2D.Float> coordinates = new ArrayList<>();
-        colorComponents = new ArrayList<>();
+        if (inited) {
+            return;
+        }
+        List<MeshShadingPaint.Triangle> triangles = new ArrayList<>();
+        // Previous patch kept in the linear read order so a shared edge can be
+        // pulled by index (edges span points 0-3 / 3-6 / 6-9 / 9-0).
+        Point2D.Float[] prevPoints = null;
+        int[] prevColors = null;
         try {
             while (vertexBitStream.available() > 0) {
-                int flag = readFlag();
-                // read control points.
-                for (int i = 0, ii = (flag != 0 ? 12 : 16); i < ii; i++) {
-                    coordinates.add(readCoord());
+                int flag = readFlag() & 0x03;
+                Point2D.Float[] points = new Point2D.Float[16];
+                int[] colors = new int[4];
+                if (flag == 0) {
+                    for (int i = 0; i < 16; i++) {
+                        points[i] = readCoord();
+                    }
+                    for (int i = 0; i < 4; i++) {
+                        colors[i] = colorArgb(readColor());
+                    }
+                } else {
+                    if (prevPoints == null) {
+                        logger.warning("Shading type 7: shared patch with no predecessor.");
+                        break;
+                    }
+                    // A shared patch reuses one edge of the previous patch as its
+                    // first edge (points 0-3, colours 0-1) and reads the other
+                    // 12 points and 2 colours.
+                    int[] edge = sharedEdgeIndices(flag);
+                    for (int i = 0; i < 4; i++) {
+                        points[i] = prevPoints[edge[i]];
+                    }
+                    colors[0] = prevColors[edge[4]];
+                    colors[1] = prevColors[edge[5]];
+                    for (int i = 4; i < 16; i++) {
+                        points[i] = readCoord();
+                    }
+                    colors[2] = colorArgb(readColor());
+                    colors[3] = colorArgb(readColor());
                 }
-                for (int i = 0, ii = (flag != 0 ? 2 : 4); i < ii; i++) {
-                    colorComponents.add(readColor());
+                Point2D.Float[][] grid = new Point2D.Float[4][4];
+                for (int i = 0; i < 16; i++) {
+                    grid[TENSOR_ORDER[i][0]][TENSOR_ORDER[i][1]] = points[i];
                 }
+                tessellatePatch(grid, colors, triangles);
+                prevPoints = points;
+                prevColors = colors;
             }
         } catch (IOException e) {
             logger.warning("Error parsing Shading type 7 pattern vertices.");
         }
+        meshPaint = buildMeshPaint(triangles, graphicsState);
+        inited = true;
+    }
+
+    /**
+     * Maps an edge flag (1-3) to the previous patch's shared control points and
+     * colours, in the linear read order.  Returns {@code [p0,p1,p2,p3,c0,c1]}
+     * where the four point indices form the shared edge and the two colour
+     * indices are its endpoint corners.
+     * <ul>
+     *   <li>flag 1: previous edge from corner 1 to corner 2 (points 3-6, colours 1-2)</li>
+     *   <li>flag 2: previous edge from corner 2 to corner 3 (points 6-9, colours 2-3)</li>
+     *   <li>flag 3: previous edge from corner 3 to corner 0 (points 9,10,11,0, colours 3-0)</li>
+     * </ul>
+     */
+    private static int[] sharedEdgeIndices(int flag) {
+        switch (flag) {
+            case 1:
+                return new int[]{3, 4, 5, 6, 1, 2};
+            case 2:
+                return new int[]{6, 7, 8, 9, 2, 3};
+            default: // 3
+                return new int[]{9, 10, 11, 0, 3, 0};
+        }
     }
 
     public Paint getPaint() {
-        return colorComponents.get(1);
+        return meshPaint;
     }
 }

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/MeshShadingPaintTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/MeshShadingPaintTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2026 Patrick Corless
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.PaintContext;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.image.ColorModel;
+import java.awt.image.Raster;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the Gouraud triangle rasteriser behind mesh shading types 4-7.  A single
+ * triangle with three corner colours must interpolate barycentrically inside its
+ * area and leave pixels outside it transparent, so the surrounding page shows
+ * through where the mesh does not cover.
+ */
+public class MeshShadingPaintTest {
+
+    private static int argb(int a, int r, int g, int b) {
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+
+    private static int[] rasterAt(MeshShadingPaint paint, Rectangle bounds) {
+        PaintContext ctx = paint.createContext(ColorModel.getRGBdefault(), bounds,
+                bounds, new AffineTransform(), null);
+        Raster raster = ctx.getRaster(bounds.x, bounds.y, bounds.width, bounds.height);
+        int[] px = new int[bounds.width * bounds.height * 4];
+        raster.getPixels(bounds.x, bounds.y, bounds.width, bounds.height, px);
+        // pack to argb for convenience
+        int[] out = new int[bounds.width * bounds.height];
+        for (int i = 0; i < out.length; i++) {
+            out[i] = argb(px[i * 4 + 3], px[i * 4], px[i * 4 + 1], px[i * 4 + 2]);
+        }
+        return out;
+    }
+
+    /**
+     * A right triangle filling the lower-left half of a 10x10 tile: the corner
+     * vertices carry their exact colours, and a pixel outside the triangle stays
+     * transparent.
+     */
+    @Test
+    public void interpolatesInsideAndLeavesOutsideTransparent() {
+        int red = argb(255, 255, 0, 0);
+        int green = argb(255, 0, 255, 0);
+        int blue = argb(255, 0, 0, 255);
+        MeshShadingPaint.Triangle t = new MeshShadingPaint.Triangle(
+                0.5f, 0.5f, red, 9.5f, 0.5f, green, 0.5f, 9.5f, blue);
+        MeshShadingPaint paint = new MeshShadingPaint(List.of(t), null);
+        Rectangle bounds = new Rectangle(0, 0, 10, 10);
+
+        int[] px = rasterAt(paint, bounds);
+
+        // vertex pixels take (essentially) their own colour
+        assertEquals(red, px[0 * 10 + 0], "vertex 0 must be its colour");
+        // the far corner (9,9) lies outside the lower-left triangle -> transparent
+        assertEquals(0, px[9 * 10 + 9], "a pixel outside the triangle must be transparent");
+        // an interior pixel is an opaque blend of the three corners
+        int mid = px[3 * 10 + 3];
+        assertEquals(255, (mid >>> 24) & 0xff, "covered pixel must be opaque");
+        assertTrue(((mid >> 16) & 0xff) > 0 && (mid & 0xff) > 0,
+                "interior pixel must blend multiple corner colours");
+    }
+
+    /**
+     * A uniform-colour triangle produces that flat colour everywhere it covers
+     * (degenerate Gouraud case), confirming the barycentric weights sum to one.
+     */
+    @Test
+    public void uniformColourFillsFlat() {
+        int grey = argb(255, 128, 128, 128);
+        MeshShadingPaint.Triangle t = new MeshShadingPaint.Triangle(
+                0.5f, 0.5f, grey, 9.5f, 0.5f, grey, 0.5f, 9.5f, grey);
+        MeshShadingPaint paint = new MeshShadingPaint(List.of(t), null);
+        Rectangle bounds = new Rectangle(0, 0, 10, 10);
+
+        int[] px = rasterAt(paint, bounds);
+        int covered = Arrays.stream(px).filter(p -> ((p >>> 24) & 0xff) != 0).findFirst().orElse(0);
+        assertEquals(grey, covered, "a uniform triangle must fill its flat colour");
+    }
+}


### PR DESCRIPTION
Implements rendering for PDF mesh shadings (types 4–7), which previously only parsed their data and filled a single flat colour.

## What's added
- **MeshShadingPaint** — a `Paint`/`PaintContext` that rasterises a triangle list with barycentric (Gouraud) colour interpolation into an ARGB buffer over the fill's device bounds; uncovered pixels stay transparent.
- **Type 7 (tensor patch)** — parses patches (flag 0 full, 1–3 shared edge), assembles the 4×4 control grid, evaluates the bicubic Bézier surface, and tessellates to triangles with bilinear corner-colour blending.
- **Type 6 (Coons patch)** — derives the four interior control points from the boundary and reuses the tensor tessellation.
- **Types 4/5 (free-form / lattice Gouraud triangle meshes)** — build triangles directly.
- **ShadingMeshPattern** — fixes the `Decode` normalisation (coords/colours dropped the interval minimum) and the 32-bit coordinate decode (`maxValue` and signed `getBits(32)`); hosts the shared tessellation/rasterisation helpers.

Anchoring follows the sh-vs-pattern rule: a shading pattern (scn, PatternType 2) cancels the fill-time CTM; a bare `sh` mesh keeps it.

## Validation
- **Type 7** pixel-identical to pdftoppm on both UPMC ApptCard files (scn + sh paths) and the Java Magazine cover (Duke), bar edge anti-aliasing.
- **Type 6** renders the Adobe opera-mask artwork correctly (32-bit coords).
- Adds `MeshShadingPaintTest`; full core suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
