### PR TITLE
GH-501 implement knockout transparency groups (/Group /K true)

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/KnockoutComposite.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/KnockoutComposite.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 Patrick Corless
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import java.awt.*;
+import java.awt.image.ColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
+import java.awt.image.WritableRaster;
+
+/**
+ * Composites one element of a <i>knockout</i> transparency group
+ * (PDF 32000-1 §11.4.5.5, {@code /Group << /K true >>}).
+ * <p>
+ * In a knockout group every element composites with the group's <i>initial</i>
+ * backdrop rather than with the accumulated result of the elements before it, so
+ * a later element completely replaces earlier siblings wherever it has coverage.
+ * Inside the group's (transparent) buffer an element's composite against that
+ * initial backdrop is simply the element itself, which makes this composite a
+ * coverage-weighted replace:
+ * <pre>
+ *     dst = lerp(dst, src, coverage)
+ * </pre>
+ * -- replacing colour <b>and</b> alpha, where SRC_OVER would have added them.
+ * That difference is the whole point: a stack of semi-transparent siblings drawn
+ * SRC_OVER accumulates as {@code 1 - prod(1 - a_i)} and saturates, while a
+ * knockout stack shows only the topmost covering element at its own alpha.  The
+ * anchor case is an Illustrator blend -- ~200 nested ellipses whose constant
+ * alpha ramps 0.005 to 1.0 (Duke's nose highlight, Java Magazine Sept/Oct 2016
+ * p3/p61): accumulated it is a flat saturated disc, knocked out it is a smooth
+ * dome.
+ * <p>
+ * <b>Coverage vs alpha.</b> The source is the element's rasterised buffer, whose
+ * alpha already carries both the element's constant alpha and its anti-aliased
+ * edge coverage.  Replacing wherever {@code alpha > 0} would let a feathered edge
+ * hard-replace an opaque sibling, so {@code elementAlpha} (the constant alpha
+ * baked into the buffer, measured as its peak) is divided back out to recover
+ * coverage; the interior then replaces exactly and only the edges feather.
+ */
+public class KnockoutComposite implements Composite {
+
+    // Constant alpha already baked into the source buffer, used to separate the
+    // element's own alpha from its per-pixel coverage.  1.0 when unknown.
+    private final float elementAlpha;
+    // Additional constant alpha to apply to the source, mirroring
+    // AlphaComposite's alpha (the group ca, when it was not already baked in).
+    private final float extraAlpha;
+
+    /**
+     * @param elementAlpha constant alpha baked into the source buffer (its peak
+     *                     alpha), in 0..1; pass 1 when unknown.
+     * @param extraAlpha   further constant alpha to apply to the source, in 0..1.
+     */
+    public KnockoutComposite(float elementAlpha, float extraAlpha) {
+        this.elementAlpha = clamp(elementAlpha);
+        this.extraAlpha = clamp(extraAlpha);
+    }
+
+    private static float clamp(float v) {
+        return v < 0f ? 0f : (v > 1f ? 1f : v);
+    }
+
+    public float getElementAlpha() {
+        return elementAlpha;
+    }
+
+    public float getExtraAlpha() {
+        return extraAlpha;
+    }
+
+    @Override
+    public String toString() {
+        return "Knockout element=" + elementAlpha + " extra=" + extraAlpha;
+    }
+
+    @Override
+    public CompositeContext createContext(ColorModel srcColorModel, ColorModel dstColorModel,
+                                          RenderingHints hints) {
+        return new KnockoutContext(elementAlpha, extraAlpha);
+    }
+
+    private static final class KnockoutContext implements CompositeContext {
+
+        private final float elementAlpha;
+        private final float extraAlpha;
+
+        private KnockoutContext(float elementAlpha, float extraAlpha) {
+            this.elementAlpha = elementAlpha;
+            this.extraAlpha = extraAlpha;
+        }
+
+        public void dispose() {
+        }
+
+        public void compose(Raster src, Raster dstIn, WritableRaster dstOut) {
+            if (src.getSampleModel().getDataType() != DataBuffer.TYPE_INT ||
+                    dstIn.getSampleModel().getDataType() != DataBuffer.TYPE_INT ||
+                    dstOut.getSampleModel().getDataType() != DataBuffer.TYPE_INT) {
+                throw new IllegalStateException("Source and destination must store pixels as INT.");
+            }
+            int width = Math.min(src.getWidth(), dstIn.getWidth());
+            int height = Math.min(src.getHeight(), dstIn.getHeight());
+            int[] srcPixels = new int[width];
+            int[] dstPixels = new int[width];
+            for (int y = 0; y < height; y++) {
+                src.getDataElements(0, y, width, 1, srcPixels);
+                dstIn.getDataElements(0, y, width, 1, dstPixels);
+                for (int x = 0; x < width; x++) {
+                    int sp = srcPixels[x];
+                    float srcAlpha = ((sp >> 24) & 0xFF) / 255f;
+                    // Coverage and alpha are separate questions.  Coverage decides
+                    // WHERE this element knocks out and comes from the source's own
+                    // alpha with any constant alpha already baked into it divided
+                    // back out; the resulting alpha is what it knocks out WITH.
+                    // Keeping them apart is what lets a fully transparent element
+                    // (ca 0) still knock out -- it replaces what is underneath with
+                    // nothing, punching a hole, which is exactly what the PDF
+                    // 32000-1 figure's ca=0 circle demonstrates.
+                    float coverage = elementAlpha > 0f ? srcAlpha / elementAlpha : srcAlpha;
+                    if (coverage <= 0f) {
+                        // no coverage: the element does not knock out here.
+                        continue;
+                    }
+                    if (coverage > 1f) {
+                        coverage = 1f;
+                    }
+                    float sa = srcAlpha * extraAlpha;
+                    int dp = dstPixels[x];
+                    int da = (dp >>> 24) & 0xFF;
+                    // The element's composite against the group's transparent
+                    // initial backdrop is the element itself: its colour at its
+                    // own alpha, which replaces the destination under coverage.
+                    int sAlpha = Math.round(sa * 255f);
+                    dstPixels[x] =
+                            (lerp(da, sAlpha, coverage) & 0xFF) << 24 |
+                                    (lerp((dp >> 16) & 0xFF, (sp >> 16) & 0xFF, coverage) & 0xFF) << 16 |
+                                    (lerp((dp >> 8) & 0xFF, (sp >> 8) & 0xFF, coverage) & 0xFF) << 8 |
+                                    (lerp(dp & 0xFF, sp & 0xFF, coverage) & 0xFF);
+                }
+                dstOut.setDataElements(0, y, width, 1, dstPixels);
+            }
+        }
+
+        private static int lerp(int from, int to, float t) {
+            return Math.round(from + (to - from) * t);
+        }
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/AlphaDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/AlphaDrawCmd.java
@@ -16,6 +16,7 @@
 package org.icepdf.core.pobjects.graphics.commands;
 
 import org.icepdf.core.pobjects.Page;
+import org.icepdf.core.pobjects.graphics.KnockoutComposite;
 import org.icepdf.core.pobjects.graphics.OptionalContentState;
 import org.icepdf.core.pobjects.graphics.PaintTimer;
 
@@ -41,7 +42,20 @@ public class AlphaDrawCmd extends AbstractDrawCmd {
                               boolean paintAlpha, PaintTimer paintTimer) {
 
         if (paintAlpha) {
-            g.setComposite(alphaComposite);
+            // Inside a knockout group every element composites with the group's
+            // INITIAL backdrop, so a painting operation replaces what earlier
+            // elements left rather than compositing over it (§11.4.5.5).  The
+            // constant alpha still applies -- it becomes the replacing element's
+            // own alpha -- so the alpha travels as KnockoutComposite's extra
+            // alpha and the source's own coverage (anti-aliased edges) is what
+            // decides how much is replaced.  Outside a knockout group this is
+            // just the AlphaComposite it has always been.
+            if (FormDrawCmd.isPaintingKnockoutGroup()
+                    && alphaComposite.getRule() == AlphaComposite.SRC_OVER) {
+                g.setComposite(new KnockoutComposite(1f, alphaComposite.getAlpha()));
+            } else {
+                g.setComposite(alphaComposite);
+            }
         }
 
         return currentShape;

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/FormDrawCmd.java
@@ -118,6 +118,56 @@ public class FormDrawCmd extends AbstractDrawCmd {
     }
 
     /**
+     * The area clamp {@code createBufferXObject} applies, as a routing predicate:
+     * a group this size can be rasterised into a buffer rather than collapsing a
+     * sentinel bbox into it.
+     */
+    private static boolean withinBufferBudget(double formWidth, double formHeight) {
+        if (formWidth >= MAX_SCALED_FORM_SIZE || formHeight >= MAX_SCALED_FORM_SIZE) {
+            return false;
+        }
+        long area = (long) formWidth * (long) formHeight;
+        return area <= (long) MAX_IMAGE_SIZE * MAX_IMAGE_SIZE;
+    }
+
+    /**
+     * True when a knockout group's own contents can actually render differently
+     * knocked out -- i.e. it holds at least one element that is not fully opaque.
+     * <p>
+     * Knocking out replaces the elements underneath instead of compositing over
+     * them, and for an <b>opaque</b> element those are the same thing, so a group
+     * of opaque elements is unaffected.  Buffering it anyway would not be free:
+     * a non-isolated group rendered into its own (transparent) buffer loses the
+     * page backdrop that its content blends against, which lightens content that
+     * used to blend with the page (opera-mask hair, shadding-2-3-6.pdf).  So the
+     * buffer is taken only where knockout can change the result -- the stacked
+     * semi-transparent blends knockout exists for.
+     */
+    private static boolean knockoutChangesResult(Form form) {
+        Shapes shapes = form.getShapes();
+        if (shapes == null) {
+            return false;
+        }
+        for (DrawCmd cmd : shapes.getShapes()) {
+            if (cmd instanceof FormDrawCmd) {
+                ExtGState elementState = ((FormDrawCmd) cmd).xForm.getExtGState();
+                if (elementState != null && isPartial(elementState.getNonStrokingAlphConstant())) {
+                    return true;
+                }
+            } else if (cmd instanceof AlphaDrawCmd) {
+                if (isPartial(((AlphaDrawCmd) cmd).getAlphaComposite().getAlpha())) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static boolean isPartial(float alpha) {
+        return alpha > 0f && alpha < 1f;
+    }
+
+    /**
      * Decides whether a transparency-group form must be rasterised into an
      * offscreen buffer ({@link FormDrawCmd}) or can be painted inline as plain
      * shapes ({@link ShapesDrawCmd}).
@@ -152,14 +202,19 @@ public class FormDrawCmd extends AbstractDrawCmd {
      */
     public static boolean requiresOffscreenBuffer(Form form) {
         ExtGState extGState = form.getExtGState();
-        if (extGState == null) {
-            return false;
-        }
         double formWidth = form.getBBox().getWidth();
         double formHeight = form.getBBox().getHeight();
         // degenerate / sub-pixel groups: nothing meaningful to buffer.
         if (formWidth <= 1 || formHeight <= 1) {
             return false;
+        }
+        // A knockout group's effect comes from its OWN contents, not from the
+        // graphics state at the `Do` -- the PDF 32000-1 figure's groups are
+        // placed with a bare `Do` and no `gs` at all -- so this is decided before
+        // the ExtGState is consulted.
+        boolean isKnockout = form.isKnockOut() && knockoutChangesResult(form);
+        if (extGState == null) {
+            return isKnockout && withinBufferBudget(formWidth, formHeight);
         }
         boolean hasSoftMask = extGState.getSMask() != null;
         Name blendingMode = extGState.getBlendingMode();
@@ -176,9 +231,14 @@ public class FormDrawCmd extends AbstractDrawCmd {
         // transparency).
         boolean needsIsolation = isolationAwareRouting
                 && (form.isIsolated() || form.isKnockOut());
+        // isKnockout (decided above): a knockout group needs a surface of its own,
+        // since its elements composite against the group's INITIAL backdrop and so
+        // must be able to replace one another there.  Painted inline they compose
+        // against each other instead and a stack of semi-transparent siblings
+        // accumulates to opaque (Duke's nose, Java Magazine p3/p61).
         // No group effect -> inline; painting the shapes SRC_OVER onto the page
         // is identical to compositing them to a buffer first.
-        if (!(hasSoftMask || hasBlend || hasPartialAlpha || needsIsolation)) {
+        if (!(hasSoftMask || hasBlend || hasPartialAlpha || needsIsolation || isKnockout)) {
             return false;
         }
         // A sentinel/extreme bbox (typically +-Short.MAX_VALUE) would collapse if
@@ -274,6 +334,10 @@ public class FormDrawCmd extends AbstractDrawCmd {
                               Shape clip, AffineTransform base,
                               OptionalContentState optionalContentState,
                               boolean paintAlpha, PaintTimer paintTimer) {
+        // Whether THIS form is an element of a knockout group.  Read before the
+        // buffer build below, which re-scopes the flag for this form's own
+        // children.
+        boolean knockedOutElement = paintingKnockoutGroup.get();
         if (optionalContentState.isVisible() && !xFormBufferBuilt) {
             synchronized (this) {
                 if (!xFormBufferBuilt) {
@@ -297,7 +361,8 @@ public class FormDrawCmd extends AbstractDrawCmd {
                     SoftMask formSoftMask = null;
                     SoftMask softMask = null;
 
-                    if (xForm.getGraphicsState().getExtGState().getSMask() != null) {
+                    if (xForm.getGraphicsState().getExtGState() != null
+                            && xForm.getGraphicsState().getExtGState().getSMask() != null) {
                         softMask = xForm.getGraphicsState().getExtGState().getSMask();
                         // A luminosity/alpha mask group form often carries an empty
                         // /Resources and resolves its XObjects (e.g. a pre-rendered
@@ -316,7 +381,10 @@ public class FormDrawCmd extends AbstractDrawCmd {
                             y = (int) softMask.getG().getBBox().getY();
                         }
                     }
-                    if (xForm.getExtGState().getSMask() != null) {
+                    // A knockout group can be placed by a bare `Do` with no `gs`
+                    // at all, so the form's ExtGState may be absent here -- it is
+                    // no longer a precondition of reaching this path.
+                    if (xForm.getExtGState() != null && xForm.getExtGState().getSMask() != null) {
                         formSoftMask = xForm.getExtGState().getSMask();
                         formSoftMask.setParentResources(xForm.getLeafResources());
                         boolean isShading = formSoftMask.getG().getResources().isShading();
@@ -495,6 +563,42 @@ public class FormDrawCmd extends AbstractDrawCmd {
                 }
             }
         }
+        // A group placed by a bare `Do` has no constant alpha of its own (there is
+        // no `gs`), so its buffer is blitted straight.  Without this it inherits
+        // whatever composite the previously painted form happened to leave on the
+        // Graphics2D -- a form's inner `gs` is not restored at its end, and the
+        // page's own alpha bookkeeping (setAlpha's de-dup) never sees it, so a
+        // preceding group ending on `ca 0` made this one vanish entirely
+        // (transparent_groups.pdf, bottom-left panel).  Inline groups always
+        // re-assert alpha before each fill, which is why only a buffered group's
+        // single draw-back is exposed to the leak.
+        if (xForm.getExtGState() == null && xFormBuffer != null && savedComposite == null) {
+            savedComposite = g.getComposite();
+            g.setComposite(java.awt.AlphaComposite.SrcOver);
+        }
+        // An element of a knockout group composites against the group's initial
+        // backdrop, not against the siblings already in the group buffer, so it
+        // REPLACES them where it has coverage instead of composing over them
+        // (§11.4.5.5).  The buffer's peak alpha is the element's own constant
+        // alpha, which KnockoutComposite divides back out to recover anti-aliased
+        // edge coverage; any draw-back alpha still outstanding (i.e. one the ca
+        // heuristic above did not fold away) is carried as the extra alpha.
+        if (knockedOutElement && xFormBuffer != null) {
+            float extra = 1f;
+            java.awt.Composite current = g.getComposite();
+            if (current instanceof java.awt.AlphaComposite
+                    && ((java.awt.AlphaComposite) current).getRule() == java.awt.AlphaComposite.SRC_OVER) {
+                extra = ((java.awt.AlphaComposite) current).getAlpha();
+            } else if (current instanceof KnockoutComposite) {
+                // an element-level alpha already converted to a knockout by
+                // AlphaDrawCmd; keep its constant alpha for this group's blit.
+                extra = ((KnockoutComposite) current).getExtraAlpha();
+            }
+            if (savedComposite == null) {
+                savedComposite = current;
+            }
+            g.setComposite(new KnockoutComposite(bufferPeakAlpha(xFormBuffer) / 255f, extra));
+        }
         if (formScale != 1.0) {
             // buffer was rasterised at a reduced size; scale it back up to the
             // group's full footprint so the blend composites over the page at
@@ -528,6 +632,44 @@ public class FormDrawCmd extends AbstractDrawCmd {
             }
         }
         return peak;
+    }
+
+    // Set while the shapes of a KNOCKOUT transparency group are being painted into
+    // that group's buffer, so each element drawn there knows to replace its
+    // siblings rather than compose over them (§11.4.5.5).  Scoped by
+    // createBufferXObject, which sets it to the group's own /K for the duration of
+    // the paint and restores it after -- so the flag always describes the immediate
+    // parent group, never an ancestor.
+    private static final ThreadLocal<Boolean> paintingKnockoutGroup =
+            ThreadLocal.withInitial(() -> Boolean.FALSE);
+
+    /**
+     * True while the contents of a knockout transparency group are being painted
+     * into that group's buffer, i.e. while the caller is one of the group's
+     * elements.
+     */
+    static boolean isPaintingKnockoutGroup() {
+        return paintingKnockoutGroup.get();
+    }
+
+    /**
+     * Leaves the current knockout-group scope, returning the previous value for
+     * {@link #restoreKnockoutScope}.  Used where a nested group paints its own
+     * contents onto the same surface (an inline {@link ShapesDrawCmd}): those
+     * contents are not elements of the enclosing knockout group and must not
+     * knock each other out.
+     */
+    static boolean suspendKnockoutScope() {
+        boolean previous = paintingKnockoutGroup.get();
+        paintingKnockoutGroup.set(Boolean.FALSE);
+        return previous;
+    }
+
+    /**
+     * Restores the scope captured by {@link #suspendKnockoutScope}.
+     */
+    static void restoreKnockoutScope(boolean previous) {
+        paintingKnockoutGroup.set(previous);
     }
 
     // guard so replaying the stack to build a backdrop doesn't recursively try
@@ -1150,11 +1292,20 @@ public class FormDrawCmd extends AbstractDrawCmd {
                 if (captureCmykInk) {
                     ImageUtility.beginCmykInkCapture(bufferWidth, bufferHeight);
                 }
+                // Elements of a knockout group composite against the group's
+                // initial backdrop, i.e. they replace earlier siblings rather than
+                // compose over them (§11.4.5.5).  Flag the scope so each nested
+                // group's draw-back (below) uses KnockoutComposite; the flag is
+                // set unconditionally, so a non-knockout group also clears it for
+                // its own children instead of inheriting an ancestor's.
+                boolean previousKnockout = paintingKnockoutGroup.get();
+                paintingKnockoutGroup.set(xForm.isKnockOut());
                 try {
                     // parent page and any sentinel fill override passed as call-local
                     // parameters, no shared-state mutation.
                     xFormShapes.paint(canvas, parentPage, nullShapeFill);
                 } finally {
+                    paintingKnockoutGroup.set(previousKnockout);
                     if (captureCmykInk) {
                         capturedInk = ImageUtility.endCmykInkCapture();
                     }

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/ShapesDrawCmd.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/graphics/commands/ShapesDrawCmd.java
@@ -55,7 +55,20 @@ public class ShapesDrawCmd extends AbstractDrawCmd {
             // set/paint/reset-to-null pattern raced (nulling parentPage mid-paint
             // of another thread dropped the form's content).  paint() builds its
             // own per-call OCG state and reads the global alpha option internally.
-            shapes.paint(g, parentPage);
+            // An inline (unbuffered) transparency group is ONE element of any
+            // enclosing knockout group, so its own contents must composite with
+            // each other normally -- not knock each other out.  Suspend the
+            // knockout scope for the nested shapes and restore it after, or the
+            // flag leaks down and every nested group replaces its siblings
+            // (opera-mask hair, shadding-2-3-6.pdf).  The group cannot itself be
+            // knocked out as a unit while it paints straight onto the parent
+            // surface; that needs a buffer (see FormDrawCmd.requiresOffscreenBuffer).
+            boolean previousKnockout = FormDrawCmd.suspendKnockoutScope();
+            try {
+                shapes.paint(g, parentPage);
+            } finally {
+                FormDrawCmd.restoreKnockoutScope(previousKnockout);
+            }
         }
         return currentShape;
     }

--- a/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/util/parser/content/AbstractContentParser.java
@@ -1828,12 +1828,8 @@ public abstract class AbstractContentParser {
                     commonOverPrintAlpha(graphicState.getStrokeAlpha(),
                             graphicState.getStrokeColorSpace()));
         }
-        // The knockout effect can only be achieved by changing the alpha
-        // composite to source.  I don't have a test case for this for stroke
-        // but what we do for stroke is usually what we do for fill...
-        else if (graphicState.isKnockOut()) {
-            setAlpha(shapes, graphicState, AlphaComposite.SRC, graphicState.getStrokeAlpha());
-        }
+        // Knockout is applied when the group is painted (see commonFill), not
+        // baked into a SRC composite here.
 
         // found a PatternColor
         if (graphicState.getStrokeColorSpace() instanceof PatternColor) {
@@ -1962,11 +1958,13 @@ public abstract class AbstractContentParser {
             }
             return;
         }
-        // The knockout effect can only be achieved by changing the alpha
-        // composite to source.
-        else if (graphicState.isKnockOut()) {
-            setAlpha(shapes, graphicState, AlphaComposite.SRC, graphicState.getFillAlpha());
-        } else if (graphicState.getExtGState() == null || graphicState.getExtGState().getBlendingMode() == null) {
+        // Knockout is applied when the group is painted, not baked in here: a
+        // SRC composite discards the destination's alpha as well as its colour,
+        // which flattened translucent fills in a knockout group to opaque and
+        // turned a ca=0 circle into a black disc (the PDF 32000-1 figure in
+        // transparent_groups.pdf).  The group is rasterised to its own buffer and
+        // its elements replace one another there -- see KnockoutComposite.
+        else if (graphicState.getExtGState() == null || graphicState.getExtGState().getBlendingMode() == null) {
             setAlpha(shapes, graphicState, graphicState.getAlphaRule(), graphicState.getFillAlpha());
         }
 

--- a/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/KnockoutCompositeTest.java
+++ b/core/core-awt/src/test/java/org/icepdf/core/pobjects/graphics/KnockoutCompositeTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2026 Patrick Corless
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an "AS
+ * IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package org.icepdf.core.pobjects.graphics;
+
+import org.junit.jupiter.api.Test;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.awt.image.WritableRaster;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the compositing rule for an element of a knockout transparency group
+ * (PDF 32000-1 §11.4.5.5, {@code /Group << /K true >>}): the element composites
+ * with the group's <i>initial</i> backdrop rather than with the elements before
+ * it, so where it has coverage it <i>replaces</i> them -- colour and alpha both.
+ * <p>
+ * The behaviour these tests exist to protect is the difference from SRC_OVER: a
+ * stack of semi-transparent siblings composited over one another accumulates as
+ * {@code 1 - prod(1 - a_i)} and saturates to opaque (Duke's nose rendering as a
+ * flat red disc instead of a shaded sphere, Java Magazine Sept/Oct 2016 p3).
+ */
+public class KnockoutCompositeTest {
+
+    /** Runs the composite over a single pixel and returns the resulting ARGB. */
+    private static int compose(KnockoutComposite composite, int srcArgb, int dstArgb) {
+        BufferedImage src = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        BufferedImage dst = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        src.setRGB(0, 0, srcArgb);
+        dst.setRGB(0, 0, dstArgb);
+        WritableRaster out = dst.getRaster().createCompatibleWritableRaster();
+        CompositeContext context = composite.createContext(src.getColorModel(), dst.getColorModel(), null);
+        context.compose(src.getRaster(), dst.getRaster(), out);
+        context.dispose();
+        BufferedImage result = new BufferedImage(dst.getColorModel(), out, false, null);
+        return result.getRGB(0, 0);
+    }
+
+    private static int argb(int a, int r, int g, int b) {
+        return (a & 0xFF) << 24 | (r & 0xFF) << 16 | (g & 0xFF) << 8 | (b & 0xFF);
+    }
+
+    private static int alpha(int argb) {
+        return (argb >>> 24) & 0xFF;
+    }
+
+    /**
+     * The whole point: a half-opaque element lands on an opaque sibling as its own
+     * half-opaque self.  Composited SRC_OVER the destination would stay opaque and
+     * the colours would mix; knocked out the sibling is simply gone.
+     */
+    @Test
+    public void semiTransparentElementReplacesTheSiblingBeneathIt() {
+        // source buffer already carries the element's ca (0.5), as a group buffer does.
+        int result = compose(new KnockoutComposite(0.5f, 1f),
+                argb(128, 0, 0, 255), argb(255, 255, 0, 0));
+
+        assertEquals(128, alpha(result), "alpha is the element's own, not an accumulation");
+        assertEquals(argb(128, 0, 0, 255), result, "the element replaces the sibling outright");
+    }
+
+    /**
+     * A fully transparent element ({@code ca 0}) still knocks out: it replaces what
+     * is underneath with nothing, punching a hole through to the group's backdrop.
+     * This is the case the old {@code AlphaComposite.SRC} approximation got wrong in
+     * the other direction, painting a black disc (transparent_groups.pdf).
+     */
+    @Test
+    public void fullyTransparentElementPunchesAHole() {
+        // a fill: the source raster carries coverage, the constant alpha is 0.
+        int result = compose(new KnockoutComposite(1f, 0f),
+                argb(255, 255, 255, 255), argb(255, 255, 0, 0));
+
+        assertEquals(0, alpha(result), "a ca=0 element knocks the sibling out to transparent");
+    }
+
+    /**
+     * Outside the element there is no coverage, so earlier siblings survive.
+     */
+    @Test
+    public void noCoverageLeavesTheDestinationAlone() {
+        int dst = argb(255, 255, 0, 0);
+        int result = compose(new KnockoutComposite(1f, 1f), argb(0, 0, 0, 255), dst);
+
+        assertEquals(dst, result, "a pixel the element does not cover is not knocked out");
+    }
+
+    /**
+     * An anti-aliased edge is partial coverage, not a partial constant alpha, so it
+     * feathers between the sibling and the replacing element instead of replacing
+     * outright -- otherwise every element's soft edge would cut a hard step into the
+     * one below it.
+     */
+    @Test
+    public void antiAliasedEdgeFeathersBetweenSiblingAndElement() {
+        // element alpha 1.0, source alpha 128 => half coverage.
+        int result = compose(new KnockoutComposite(1f, 1f),
+                argb(128, 0, 0, 0), argb(255, 255, 255, 255));
+
+        int red = (result >> 16) & 0xFF;
+        assertTrue(red > 100 && red < 155, "edge pixel should be about half way, got " + red);
+        assertTrue(alpha(result) > 150, "half coverage keeps most of the opaque sibling's alpha");
+    }
+
+    /**
+     * The constant alpha still applies to what is knocked out: with the element's
+     * alpha supplied separately (a path fill, whose raster carries only coverage),
+     * the result takes that alpha.
+     */
+    @Test
+    public void constantAlphaBecomesTheKnockedOutAlpha() {
+        int result = compose(new KnockoutComposite(1f, 0.25f),
+                argb(255, 0, 0, 255), argb(255, 255, 0, 0));
+
+        assertEquals(64, alpha(result), 1, "result carries the element's constant alpha");
+        assertEquals(255, result & 0xFF, "and the element's colour");
+    }
+}


### PR DESCRIPTION
In a knockout group every element composites with the group's INITIAL backdrop rather than with the elements before it (PDF 32000-1 §11.4.5.5), so a later element replaces its earlier siblings wherever it has coverage. icepdf composited them SRC_OVER against the accumulated result instead, so a stack of semi-transparent siblings piled up as 1 - prod(1 - ca_i) and saturated to opaque.  Duke's nose on Java Magazine Sept/Oct 2016 p3/p61 is ~200 nested ellipses whose constant alpha ramps 0.005 to 1.0 inside a knockout group: it rendered as a flat saturated red disc instead of a shaded sphere.

KnockoutComposite does the coverage-weighted replace, of colour and alpha both.  It takes the element's constant alpha and its coverage separately: the alpha already baked into a group buffer is divided back out to recover the anti-aliased edge coverage, which is also what lets a fully transparent (ca 0) element still knock out -- it replaces what is underneath with nothing, punching a hole, as the spec figure's ca=0 circle demonstrates.

Wiring:
 - requiresOffscreenBuffer gives a knockout group a surface of its own, but only when knockoutChangesResult finds an element that is not opaque. Knocking out opaque elements is the same as compositing them, and buffering a non-isolated group costs it the page backdrop its content blends against (it lightened the opera mask's hair in shadding-2-3-6). The decision is made before the ExtGState is consulted: these groups are placed by a bare `Do` with no `gs`, and the old extGState == null early return skipped them entirely.
 - a paintingKnockoutGroup scope, set while the group's shapes are painted into its buffer.  ShapesDrawCmd suspends it, since an inline nested group is one element and must not knock out internally.
 - nested groups knock out at their draw-back; AlphaDrawCmd converts a SRC_OVER constant alpha into a KnockoutComposite so direct path fills knock out too.

That replaces the legacy AlphaComposite.SRC approximation in commonFill / commonStroke, which discarded the destination's alpha along with its colour: translucent fills in a knockout group came out opaque and the ca=0 circle painted as a black disc.

Two faults surfaced once ExtGState-less groups could reach the buffered path, both fixed here: paintOperand dereferenced getExtGState() unguarded (the NPE aborted the rest of the page's shape list silently), and the draw-back inherited whatever composite the previously painted form left behind -- a form's inner `gs` is not restored at its end and the page's setAlpha de-dup never sees it, so a group following one that ended on ca 0 vanished completely.  A form with no ExtGState has no constant alpha of its own, so its buffer is now blitted straight.

Validated against Ghostscript 10.02.1; poppler ignores /K (its knockout and non-knockout panels are pixel-identical) and is not an oracle here.  On the PDF 32000-1 figure in transparent_groups.pdf the isolated-knockout panel goes from meanDelta 61.1 to 1.36 against gs, the non-isolated one from 70.3 to 10.6, and OverlappingTransparentOverlays' overlay geometry now matches. A/B over pdf-qa/graphics (414 docs) and all 50 corpus documents carrying a raw /K true shows only those, plus maxDelta <= 2 noise.

Still missing, both pre-existing and outside knockout: a non-isolated group renders into a transparent buffer rather than over its real backdrop, and the group colour space (DeviceCMYK here) is ignored.