### PR TITLE
GH-535 cache glyph outlines per font instance

### DIFF
--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/GlyphCache.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/GlyphCache.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2026 Patrick Corless
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.icepdf.core.pobjects.fonts.zfont.fontFiles;
+
+import org.icepdf.core.pobjects.fonts.FontFile;
+
+import java.awt.*;
+import java.awt.geom.GeneralPath;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A simple glyph outline cache.  Glyph outlines in ICEpdf are produced in raw font (glyph) units
+ * and are independent of the font's point size and text/graphics-state transform, which are applied
+ * separately at paint time.  This makes the outlines safe to cache and reuse for the lifetime of a
+ * (derived) font instance.
+ * <br>
+ * FontBox caches the char string of a Type1/CFF glyph but rebuilds a TrueType {@code glyf} outline
+ * from its contours on every call, so an outline that is painted once per repaint is re-rendered
+ * once per repaint.  Caching here removes that work from every repaint, zoom and scroll after the
+ * first.
+ *
+ * @author John Hewson
+ * <p>
+ * Derived from {@code org.apache.pdfbox.rendering.GlyphCache} of Apache PDFBox 3.0.6, used under
+ * the Apache License, Version 2.0.  Changes for ICEpdf:
+ * - keyed on the ICEpdf {@link ZSimpleFont} / {@link FontFile} model rather than PDFBox's
+ *   {@code PDVectorFont}, so lookups take a {@code char} code and yield a {@link Shape}
+ * - {@link java.util.concurrent.ConcurrentHashMap} rather than {@code HashMap}, as a font instance
+ *   is shared by the page-rendering threads
+ * - {@code java.util.logging} rather than commons-logging
+ * - dropped the {@code hasGlyph} diagnostics, the Type0 CID warning and the PDFBOX-4001 standard-14
+ *   line-feed special case, none of which apply here
+ * - {@code RuntimeException} is caught as well as {@code IOException}, and the empty fallback
+ *   outline is cached rather than returned uncached, so a bad glyph costs one throw and not one
+ *   per paint
+ * @see ZSimpleFont#getGlphyShape(char)
+ */
+final class GlyphCache {
+
+    private static final Logger logger =
+            Logger.getLogger(GlyphCache.class.getName());
+
+    private final ZSimpleFont font;
+    private final Map<Integer, Shape> cache = new ConcurrentHashMap<>();
+
+    GlyphCache(ZSimpleFont font) {
+        this.font = font;
+    }
+
+    /**
+     * Returns the glyph outline for the given character code, caching it by code.
+     *
+     * @param code character code in a PDF
+     * @return the glyph outline, or an empty path on error
+     */
+    Shape getPathForCharacterCode(char code) {
+        Shape path = cache.get((int) code);
+        if (path != null) {
+            return path;
+        }
+        try {
+            path = font.getGlphyShape(code);
+        } catch (IOException | RuntimeException e) {
+            // RuntimeException covers fontbox throwing for unsupported tables
+            // (e.g. "OTF fonts do not have a glyf table"); cache the empty outline so the
+            // throw isn't repeated for every paint of the glyph.
+            logger.log(Level.FINE, "Glyph rendering failed for code " + (int) code + " in font " + font.getName(),
+                    e);
+        }
+        if (path == null) {
+            path = new GeneralPath();
+        }
+        cache.put((int) code, path);
+        return path;
+    }
+}

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZFontType2.java
@@ -21,7 +21,6 @@ import org.apache.pdfbox.io.RandomAccessReadBuffer;
 import org.icepdf.core.pobjects.Stream;
 import org.icepdf.core.pobjects.fonts.Encoding;
 import org.icepdf.core.pobjects.fonts.FontFile;
-import org.icepdf.core.pobjects.graphics.TextState;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
@@ -123,42 +122,19 @@ public class ZFontType2 extends ZSimpleFont { //extends ZFontTrueType {
     }
 
     @Override
-    public void paint(Graphics2D g, char estr, float x, float y, long layout, int mode, Color strokeColor) {
-        try {
-            if (isSubstitutedNotdef(estr)) {
-                return;
-            }
-            AffineTransform af = g.getTransform();
-            int gid = getCharToGid(estr);
-            GlyphData glyphData = trueTypeFont.getGlyph() != null
-                    ? trueTypeFont.getGlyph().getGlyph(gid) : null;
-            Shape outline;
-            if (glyphData == null) {
-                outline = new GeneralPath();
-            } else {
-                // must be scaled by caller using FontMatrix
-                outline = glyphData.getPath();
-            }
-
-            // clean up,  not very efficient
-            g.translate(x, y);
-            g.transform(this.fontTransform);
-
-            if (TextState.MODE_FILL == mode || TextState.MODE_FILL_STROKE == mode ||
-                    TextState.MODE_FILL_ADD == mode || TextState.MODE_FILL_STROKE_ADD == mode) {
-                g.fill(outline);
-            }
-            if (TextState.MODE_STROKE == mode || TextState.MODE_FILL_STROKE == mode ||
-                    TextState.MODE_STROKE_ADD == mode || TextState.MODE_FILL_STROKE_ADD == mode) {
-                g.draw(outline);
-            }
-            g.setTransform(af);
-        } catch (IOException | RuntimeException e) {
-            // RuntimeException covers fontbox throwing for unsupported tables
-            // (e.g. "OTF fonts do not have a glyf table"); skip the glyph rather
-            // than abort the whole text run / page.
-            logger.log(Level.FINE, "Error painting FontType2 font", e);
+    public Shape getGlphyShape(char estr) throws IOException {
+        // CID glyphs are addressed directly by glyph id; the outline is in raw font units and is
+        // scaled by the 1/unitsPerEm fontMatrix at paint time.  Painting and outline geometry both
+        // route through here so they share the cached outline (see ZSimpleFont#getGlyphCache).
+        int gid = getCharToGid(estr);
+        // fontbox has no glyf table for OTF/CFF-backed fonts; treat as an empty outline rather
+        // than letting the exception abort the whole text run / page
+        GlyphData glyphData = trueTypeFont.getGlyph() != null
+                ? trueTypeFont.getGlyph().getGlyph(gid) : null;
+        if (glyphData == null) {
+            return new GeneralPath();
         }
+        return glyphData.getPath();
     }
 
     @Override

--- a/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
+++ b/core/core-awt/src/main/java/org/icepdf/core/pobjects/fonts/zfont/fontFiles/ZSimpleFont.java
@@ -47,6 +47,11 @@ public abstract class ZSimpleFont implements FontFile {
     // text layout map, very expensive to create, so we'll cache them.
     private HashMap<String, Point2D.Float> echarAdvanceCache;
 
+    // lazily created per-font outline cache, keyed by character code.  Not shared with derived
+    // fonts as their encoding/gid mappings may differ; a derived instance is however retained by
+    // the TextSprite that draws with it, so its cache lives as long as the page's shapes do.
+    private GlyphCache glyphCache;
+
     // copied over from font descriptor
     protected float missingWidth;
 
@@ -176,6 +181,19 @@ public abstract class ZSimpleFont implements FontFile {
         return outline;
     }
 
+    /**
+     * Returns the outline cache for this font, creating it lazily.
+     *
+     * @return this font's glyph outline cache.
+     */
+    protected GlyphCache getGlyphCache() {
+        // benign race: at worst two caches are created, the loser is discarded
+        if (glyphCache == null) {
+            glyphCache = new GlyphCache(this);
+        }
+        return glyphCache;
+    }
+
     @Override
     public void paint(Graphics2D g, char estr, float x, float y, long layout, int mode, Color strokeColor) {
         try {
@@ -183,7 +201,7 @@ public abstract class ZSimpleFont implements FontFile {
                 return;
             }
             AffineTransform af = g.getTransform();
-            Shape outline = getGlphyShape(estr);
+            Shape outline = getGlyphCache().getPathForCharacterCode(estr);
 
             g.translate(x, y);
             g.transform(this.fontTransform);
@@ -197,7 +215,7 @@ public abstract class ZSimpleFont implements FontFile {
                 g.draw(outline);
             }
             g.setTransform(af);
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
             logger.log(Level.FINE, "Error painting SimpleFont", e);
         }
     }
@@ -208,14 +226,14 @@ public abstract class ZSimpleFont implements FontFile {
             if (isSubstitutedNotdef(estr)) {
                 return new Area();
             }
-            Shape glyph = getGlphyShape(estr);
+            Shape glyph = getGlyphCache().getPathForCharacterCode(estr);
             Area outline = new Area(glyph);
             AffineTransform transform = new AffineTransform();
             transform.translate(x, y);
             transform.concatenate(fontTransform);
             outline = outline.createTransformedArea(transform);
             return outline;
-        } catch (IOException e) {
+        } catch (RuntimeException e) {
             logger.log(Level.FINE, "Error painting font outline", e);
         }
         return null;


### PR DESCRIPTION
FontBox memoizes the char string of a Type1/CFF glyph, but GlyphData.getPath() builds a new GlyphRenderer on every call, so a TrueType glyf outline is rebuilt from its contours on every glyph paint - and therefore on every repaint, zoom and scroll.  Outlines are in raw font units and are independent of point size and the text/graphics-state transform, both of which are applied at paint time, so they can be cached and reused.

Adds GlyphCache, a per-font-instance code -> Shape map, derived from Apache PDFBox's GlyphCache (attribution and the list of changes are in the class javadoc).  ZSimpleFont.paint() and getOutline() now resolve outlines through it. The cache is not shared with derived fonts, as their encoding/gid mappings may differ; a derived instance is however retained by the TextSprite that draws with it, so the cache lives as long as the page's shapes do and warms across repaints.

ZFontType2 trades its paint() override for a getGlphyShape() override so that it feeds the shared cache.  As a side effect its getOutline() now uses the same gid-addressed outline as paint() instead of falling through to the base name-based lookup, which was never correct for CID addressing.  QA confirmed the change is good.
